### PR TITLE
fix(frames): spread the keyframe budget across long recordings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,14 @@ gain fields when diarization actually ran.
 - `tool_versions["talkthrough-mcp"]` in manifests recorded a stale hardcoded
   `0.1.0` on every release; `__version__` now derives from the installed
   package metadata.
+- Long recordings no longer lose their tail frames: the fixed 1 s keyframe
+  selection floor meant the 600-frame budget covered only the first ~10
+  minutes of a meeting (a 73-minute real meeting surfaced it — slides shown
+  after minute 10 were invisible to `get_frames`/OCR search). The floor now
+  adapts to `max(1 s, duration / max_frames)`, spreading the same budget
+  across the entire recording; scene changes still capture at any instant.
+  Videos short enough for the budget at 1 fps are extracted byte-identically
+  to before.
 
 ## [0.1.3] — 2026-07-12
 

--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ model downloads once. Spoken-language support is unaffected either way.
 | `TALKTHROUGH_DIARIZATION_EMB_MODEL` | `nemo_en_titanet_small` | embedding model: allowlist name (see [Speakers](#speakers-optional-diarization)) or a local `.onnx` path |
 | `TALKTHROUGH_DIARIZATION_THREADS` | `min(4, cpus)` | ONNX threads for both diarization models |
 | `TALKTHROUGH_MAX_SECONDS` | `7200` | max media duration |
-| `TALKTHROUGH_MAX_FRAMES` | `600` | keyframe cap per job |
+| `TALKTHROUGH_MAX_FRAMES` | `600` | keyframe budget per job, spread across the whole duration (the 1 s selection floor auto-grows to `duration/budget` on long recordings) |
 | `TALKTHROUGH_HOME` | `~/.talkthrough` | job store root |
 
 ## CLI

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -20,7 +20,9 @@ exact instants.
    │ 4 ffmpeg → 16 kHz mono WAV → faster-whisper segments      │
    │ 4b (opt-in) sherpa-onnx diarization on the same WAV       │
    │     → S1/S2 turns → segment attribution by max overlap    │
-   │ 5 ffmpeg ONE pass: select(scene>0.10 ∨ Δt≥1s)             │
+   │ 5 ffmpeg ONE pass: select(scene>0.10 ∨ Δt≥floor);         │
+   │     floor = max(1s, duration/max_frames) — the frame      │
+   │     budget covers the WHOLE recording, head never wins    │
    │     + scale ≤1568px + showinfo pts → t<ms>.jpg            │
    │ 6 dHash dedup (consecutive, Hamming ≤4 → duplicate_of)    │
    │ 7 RapidOCR over unique frames → ocr_text                  │

--- a/src/talkthrough_mcp/core/frames.py
+++ b/src/talkthrough_mcp/core/frames.py
@@ -1,9 +1,16 @@
-"""Keyframe extraction: ONE decode pass, scene-change OR 1 fps floor.
+"""Keyframe extraction: ONE decode pass, scene-change OR time floor.
 
 The select expression keeps a frame when any of these holds:
 - it is the first frame (``isnan(prev_selected_t)``),
 - the scene-change score exceeds the threshold,
-- at least 1 s passed since the last selected frame (floor for static scenes).
+- the adaptive time floor passed since the last selected frame.
+
+The floor is 1 s for short videos and grows to ``duration / max_frames``
+for long ones, so the frame budget covers the WHOLE recording instead of
+truncating at the head (600 frames at a fixed 1 fps floor used to mean
+"the first 10 minutes of a meeting"). Scene changes still fire at any
+instant; ``-frames:v`` stays as the hard backstop, so a scene-dense video
+can still hit the cap early — ``cap_hit`` reports it.
 
 Frames are scaled to <=1568 px wide in the SAME filter chain (vision-model
 sweet spot; the source video is never re-read for normal frame serving) and
@@ -48,6 +55,18 @@ def frame_filename(ms: int) -> str:
     return f"t{ms:08d}.jpg"
 
 
+def frame_floor_s(duration_s: float | None, max_frames: int) -> float:
+    """Seconds that must pass between selected frames (absent a scene change).
+
+    ``max(1, duration / max_frames)``: videos short enough for the budget
+    keep the historical 1 s floor byte-for-byte; longer ones stretch the
+    same budget across their entire duration.
+    """
+    if not duration_s or duration_s <= 0 or max_frames <= 0:
+        return 1.0
+    return max(1.0, duration_s / max_frames)
+
+
 def extract_keyframes(
     media: Path,
     frames_dir: Path,
@@ -55,10 +74,15 @@ def extract_keyframes(
     scene_threshold: float = DEFAULT_SCENE_THRESHOLD,
     max_frames: int,
     timeout: int,
+    duration_s: float | None = None,
 ) -> tuple[list[Frame], bool]:
-    """One-pass scene-change + 1 fps floor extraction, renamed to video-ms."""
+    """One-pass scene-change + adaptive-floor extraction, renamed to video-ms."""
     frames_dir.mkdir(parents=True, exist_ok=True)
-    select_expr = f"isnan(prev_selected_t)+gt(scene\\,{scene_threshold})+gte(t-prev_selected_t\\,1)"
+    floor_s = frame_floor_s(duration_s, max_frames)
+    select_expr = (
+        f"isnan(prev_selected_t)+gt(scene\\,{scene_threshold})"
+        f"+gte(t-prev_selected_t\\,{floor_s:.3f})"
+    )
     vf = f"select='{select_expr}',scale='min({MAX_FRAME_WIDTH},iw)':-2,showinfo"
     try:
         proc = subprocess.run(

--- a/src/talkthrough_mcp/core/pipeline.py
+++ b/src/talkthrough_mcp/core/pipeline.py
@@ -452,6 +452,7 @@ def process_media(
                 frames_directory,
                 max_frames=max_frames_cap(),
                 timeout=tool_timeout,
+                duration_s=info.duration_s,
             )
             report("deduplicating frames", 0.82)
             dedup.mark_duplicates(extracted, frames_directory)

--- a/tests/integration/test_pipeline_integration.py
+++ b/tests/integration/test_pipeline_integration.py
@@ -119,6 +119,30 @@ def test_idempotent_rerun_is_instant(demo: ProcessResult) -> None:
     assert rerun.manifest == demo.manifest
 
 
+def test_frame_budget_spreads_across_the_whole_video(tmp_path: Path) -> None:
+    """A budget smaller than duration x 1 fps must cover the WHOLE video, not
+    its head. With max_frames=4 on the ~18.5 s demo the old fixed 1 s floor
+    grabbed the first 4 seconds and stopped; the adaptive floor (~4.6 s)
+    reaches the last scene."""
+    from talkthrough_mcp.core import frames as frames_mod
+    from talkthrough_mcp.core.probe import probe_media
+
+    duration_s = probe_media(Path(DEMO_MP4)).duration_s
+    extracted, _cap_hit = frames_mod.extract_keyframes(
+        Path(DEMO_MP4),
+        tmp_path / "frames",
+        max_frames=4,
+        timeout=120,
+        duration_s=duration_s,
+    )
+    assert len(extracted) <= 4
+    last_ms = extracted[-1].ms
+    assert last_ms >= duration_s * 1000 * 0.6, (
+        f"budgeted frames stop at {last_ms}ms of {duration_s * 1000:.0f}ms — "
+        f"head-truncation regressed: {[f.ms for f in extracted]}"
+    )
+
+
 # --- server tool layer on the processed job ---------------------------------
 
 

--- a/tests/unit/test_frames.py
+++ b/tests/unit/test_frames.py
@@ -1,8 +1,8 @@
-"""showinfo pts parsing and frame naming."""
+"""showinfo pts parsing, frame naming, and the adaptive selection floor."""
 
 from __future__ import annotations
 
-from talkthrough_mcp.core.frames import frame_filename, parse_showinfo_pts_ms
+from talkthrough_mcp.core.frames import frame_filename, frame_floor_s, parse_showinfo_pts_ms
 
 # Shape captured from real ffmpeg stderr: showinfo lines interleaved with
 # encoder chatter and deprecation warnings.
@@ -35,3 +35,25 @@ def test_frame_filename_is_eight_digit_ms() -> None:
     assert frame_filename(0) == "t00000000.jpg"
     assert frame_filename(12345) == "t00012345.jpg"
     assert frame_filename(7_199_999) == "t07199999.jpg"
+
+
+def test_frame_floor_stays_one_second_for_short_videos() -> None:
+    """Every video that fits the budget at 1 fps keeps the historical floor —
+    short-video extraction stays byte-identical to 0.1.x."""
+    assert frame_floor_s(18.55, 600) == 1.0
+    assert frame_floor_s(599.9, 600) == 1.0
+    assert frame_floor_s(600.0, 600) == 1.0
+
+
+def test_frame_floor_spreads_budget_over_long_videos() -> None:
+    # 73-minute meeting at the default cap: one frame every ~7.3 s covers it all
+    assert abs(frame_floor_s(4375.6, 600) - 7.2927) < 0.001
+    assert frame_floor_s(7200.0, 600) == 12.0
+    assert frame_floor_s(1200.0, 600) == 2.0
+
+
+def test_frame_floor_degrades_to_one_second_without_duration() -> None:
+    assert frame_floor_s(None, 600) == 1.0
+    assert frame_floor_s(0.0, 600) == 1.0
+    assert frame_floor_s(-5.0, 600) == 1.0
+    assert frame_floor_s(100.0, 0) == 1.0


### PR DESCRIPTION
The fixed 1 s selection floor meant `TALKTHROUGH_MAX_FRAMES=600` covered only the first ~10 minutes of a long recording — found on a real 73-minute meeting where slides shown after minute 10 never reached the frame index or OCR search. The floor now adapts to `max(1 s, duration / max_frames)`: the same budget spreads across the entire recording, scene changes still fire at any instant, and `-frames:v` remains the backstop (`cap_hit` reports it).

Short videos (fits-the-budget-at-1fps, i.e. ≤10 min at defaults) extract **identically** to 0.1.x — locked by unit tests; integration proves the spread with `max_frames=4` on the committed demo fixture.

Rides the untagged v0.2.0 (CHANGELOG updated in place). Real-recording validation on the 73-min meeting attached in a comment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)