### PR TITLE
fix(guidance): naive 'analyze this meeting' must trigger diarization

### DIFF
--- a/.agents/skills/talkthrough/SKILL.md
+++ b/.agents/skills/talkthrough/SKILL.md
@@ -28,7 +28,8 @@ install it: `claude mcp add -s user talkthrough -- uvx talkthrough-mcp`
    re-calls on the same file return instantly. Long videos take minutes and
    stream progress. The summary gives you `job_id`, counts, wall-clock, and
    a transcript preview — do NOT dump anything else eagerly. Multi-person
-   recording (meeting/interview)? Add `diarize=true` and — whenever the
+   recording (meeting/interview)? Add `diarize=true` — even when the ask is
+   just "summarize", speaker structure is part of meeting analysis — and — whenever the
    headcount is known — `num_speakers=N` (the main accuracy lever): segments
    get `S1`/`S2`/… labels and the summary a talk-time roster. On an
    already-processed job this amends in seconds without re-transcribing.

--- a/integrations/claude-code/skills/talkthrough/SKILL.md
+++ b/integrations/claude-code/skills/talkthrough/SKILL.md
@@ -28,7 +28,8 @@ install it: `claude mcp add -s user talkthrough -- uvx talkthrough-mcp`
    re-calls on the same file return instantly. Long videos take minutes and
    stream progress. The summary gives you `job_id`, counts, wall-clock, and
    a transcript preview — do NOT dump anything else eagerly. Multi-person
-   recording (meeting/interview)? Add `diarize=true` and — whenever the
+   recording (meeting/interview)? Add `diarize=true` — even when the ask is
+   just "summarize", speaker structure is part of meeting analysis — and — whenever the
    headcount is known — `num_speakers=N` (the main accuracy lever): segments
    get `S1`/`S2`/… labels and the summary a talk-time roster. On an
    already-processed job this amends in seconds without re-transcribing.

--- a/src/talkthrough_mcp/guidance.py
+++ b/src/talkthrough_mcp/guidance.py
@@ -29,7 +29,7 @@ speech locally (whisper), extracts scene-change keyframes, OCRs on-screen text, 
 the wall-clock start time, and (opt-in) labels who said what via local speaker diarization. \
 Returns a compact summary (job_id, media info, wall_clock, transcript preview, speaker \
 roster when diarized) — full data stays on disk and is served lazily by the other tools. \
-Idempotent by content hash: re-calling on an already-processed file returns instantly.
+Idempotent by content hash: re-calling on an already-processed file returns instantly. For MULTI-PERSON recordings (meetings, interviews, calls) diarize=true is part of a proper analysis — pass it even when the user only asks for a summary.
 When NOT to use: to re-fetch data you already processed (use the retrieval tools), or for \
 URLs — local file paths only.
 Examples:
@@ -41,7 +41,7 @@ Examples:
 - job already processed + diarize=true → speakers are added in place, whisper does NOT re-run (fast amend)
 - error mentions [diarization] → the extra is missing: install via uvx "talkthrough-mcp[diarization]"
 - process_media(path="/rec/review.mov", vocabulary="OKR, PgBouncer, Kanban") — jargon survives STT
-- process_media(path="/rec/demo.mov", recorded_at="2026-07-10T12:03:00+02:00") — exact wall-clock anchor
+- user: "analyze/summarize this meeting" → include diarize=true — speaker structure is not optional extra credit
 - user: "I just recorded my screen, it's on my Desktop" → process_media(path="/Users/<user>/Desktop/<file>.mov")
 - summary shows wall_clock=null → ask when recording started, re-call with recorded_at=... and force=true
 - transcript garbled or language_probability low → re-call with model="large-v3-turbo" (or language="ru") + force=true

--- a/src/talkthrough_mcp/server.py
+++ b/src/talkthrough_mcp/server.py
@@ -66,7 +66,10 @@ mcp = FastMCP(
         "processed). Timestamps: t_ms is video-relative; t_wall is real wall-clock time "
         "when the recording start could be resolved. Speaker diarization (optional "
         "[diarization] extra): process_media(diarize=true, num_speakers=N when known) "
-        "labels who said what as S1/S2/… across the transcript tools. Server prompts "
+        "labels who said what as S1/S2/… across the transcript tools; for any "
+        "multi-person recording pass diarize=true as part of normal analysis — do "
+        "not wait to be asked who spoke (num_speakers=N whenever the headcount is "
+        "known). Server prompts "
         "(triage-recording, spec-from-workshop, backlog-from-demo, meeting-actions, "
         "correlate-with-logs) package the common workflows."
     ),


### PR DESCRIPTION
T0 battery data (naive prompt, zero hints, 6 runners): 1/6 volunteered diarization; the examples tied it to explicit who-said-what intent. The rule is now unconditional across guidance prose + example, server instructions, and the Agent Skill. Delta re-run lands in the release test report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)