### PR TITLE
fix(diarize): reject non-positive threshold env values

### DIFF
--- a/src/talkthrough_mcp/core/diarize.py
+++ b/src/talkthrough_mcp/core/diarize.py
@@ -69,7 +69,7 @@ def clustering_threshold() -> float:
     if not raw:
         return DEFAULT_THRESHOLD
     try:
-        return float(raw)
+        value = float(raw)
     except ValueError:
         logger.warning(
             "ignoring invalid TALKTHROUGH_DIARIZATION_THRESHOLD=%r, using %s",
@@ -77,6 +77,16 @@ def clustering_threshold() -> float:
             DEFAULT_THRESHOLD,
         )
         return DEFAULT_THRESHOLD
+    if value <= 0:
+        # a non-positive distance threshold would go straight into the native
+        # clustering with undefined results — same treatment as unparseable
+        logger.warning(
+            "ignoring non-positive TALKTHROUGH_DIARIZATION_THRESHOLD=%s, using %s",
+            value,
+            DEFAULT_THRESHOLD,
+        )
+        return DEFAULT_THRESHOLD
+    return value
 
 
 def diarization_threads() -> int:

--- a/tests/unit/test_diarize.py
+++ b/tests/unit/test_diarize.py
@@ -211,8 +211,9 @@ def test_threshold_default_override_and_invalid(monkeypatch: pytest.MonkeyPatch)
     assert clustering_threshold() == DEFAULT_THRESHOLD
     monkeypatch.setenv("TALKTHROUGH_DIARIZATION_THRESHOLD", "0.72")
     assert clustering_threshold() == 0.72
-    monkeypatch.setenv("TALKTHROUGH_DIARIZATION_THRESHOLD", "not-a-float")
-    assert clustering_threshold() == DEFAULT_THRESHOLD
+    for junk in ("not-a-float", "0", "-1", "-0.5"):
+        monkeypatch.setenv("TALKTHROUGH_DIARIZATION_THRESHOLD", junk)
+        assert clustering_threshold() == DEFAULT_THRESHOLD
 
 
 def test_threads_default_override_and_invalid(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
E7 hostile finding: a parseable negative threshold went verbatim into the native clustering. Non-positive now warns + defaults, matching the unparseable-input path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)