### PR TITLE
fix(server): cap diarization rosters + threshold-mode honesty note

### DIFF
--- a/src/talkthrough_mcp/core/pipeline.py
+++ b/src/talkthrough_mcp/core/pipeline.py
@@ -508,20 +508,55 @@ def process_media(
     return ProcessResult(manifest=manifest, reused=False, elapsed_s=time.monotonic() - started)
 
 
+SUMMARY_ROSTER_CAP = 12
+SUBSTANTIAL_TALK_MS = 30_000
+
+
+def roster_payload(diarization: Diarization) -> tuple[list[dict[str, Any]], int]:
+    """Top speakers by talk time, capped for the token budget.
+
+    Threshold-mode clustering on real meetings produces dozens of sub-30 s
+    micro-clusters; serving all of them in every response both floods the
+    context and invites agents to read the cluster count as a headcount.
+    Returns ``(entries, hidden_count)`` — entries stay in label order.
+    """
+    ranked = sorted(diarization.speakers, key=lambda s: -s.talk_time_ms)[:SUMMARY_ROSTER_CAP]
+    kept = {stat.label for stat in ranked}
+    entries = [
+        {"label": stat.label, "talk_time_ms": stat.talk_time_ms, "turn_count": stat.turn_count}
+        for stat in diarization.speakers
+        if stat.label in kept
+    ]
+    return entries, len(diarization.speakers) - len(entries)
+
+
 def _summarize_diarization(diarization: Diarization) -> dict[str, Any]:
     """Compact summary block: roster without first/last timestamps."""
     if not diarization.available:
         return {"available": False, "reason": diarization.reason}
+    speakers, hidden = roster_payload(diarization)
     payload: dict[str, Any] = {
         "available": True,
         "detected_num_speakers": diarization.detected_num_speakers,
-        "speakers": [
-            {"label": stat.label, "talk_time_ms": stat.talk_time_ms, "turn_count": stat.turn_count}
-            for stat in diarization.speakers
-        ],
+        "speakers": speakers,
     }
+    if hidden:
+        payload["speakers_truncated"] = hidden
     if diarization.requested_num_speakers is not None:
         payload["requested_num_speakers"] = diarization.requested_num_speakers
+    else:
+        substantial = sum(
+            1 for s in diarization.speakers if s.talk_time_ms >= SUBSTANTIAL_TALK_MS
+        )
+        if substantial < (diarization.detected_num_speakers or 0):
+            # threshold-mode honesty: clusters != people; give agents the
+            # number worth reporting and the lever that fixes it
+            payload["speakers_with_30s_plus"] = substantial
+            payload["note"] = (
+                "threshold clustering over-detects on real meetings — treat "
+                "speakers_with_30s_plus as the likely headcount, or re-run "
+                "with num_speakers for an exact roster"
+            )
     return payload
 
 

--- a/src/talkthrough_mcp/guidance.py
+++ b/src/talkthrough_mcp/guidance.py
@@ -42,7 +42,7 @@ Examples:
 - error mentions [diarization] → the extra is missing: install via uvx "talkthrough-mcp[diarization]"
 - process_media(path="/rec/review.mov", vocabulary="OKR, PgBouncer, Kanban") — jargon survives STT
 - user: "analyze/summarize this meeting" → include diarize=true — speaker structure is not optional extra credit
-- user: "I just recorded my screen, it's on my Desktop" → process_media(path="/Users/<user>/Desktop/<file>.mov")
+- threshold mode counts VOICE CLUSTERS, not people — report speakers_with_30s_plus, or re-run with num_speakers
 - summary shows wall_clock=null → ask when recording started, re-call with recorded_at=... and force=true
 - transcript garbled or language_probability low → re-call with model="large-v3-turbo" (or language="ru") + force=true
 - after success, do NOT dump everything — continue with get_transcript / get_moment / search on the job_id
@@ -62,7 +62,7 @@ Examples:
 - get_transcript(job_id="a1b2c3d4e5f60718", start_ms=0, end_ms=120000) — just the first two minutes
 - get_transcript(job_id="...", format="text") — prose block for summarization
 - get_transcript(job_id="...", format="srt") — subtitle export the user asked for
-- diarized job: segments carry "speaker" and the header a roster — who dominated the meeting is one look away
+- diarized job: segments carry "speaker" + a roster header (top-12 by talk time; speakers_truncated counts the rest)
 - "what did S2 say?" → format="segments", collect entries with speaker=="S2" (labels are in order of first voice)
 - got truncated=true with next_start_ms=421500 → get_transcript(job_id="...", start_ms=421500)
 - user: "what was said between 5:00 and 6:30?" → start_ms=300000, end_ms=390000

--- a/src/talkthrough_mcp/server.py
+++ b/src/talkthrough_mcp/server.py
@@ -210,10 +210,9 @@ def get_transcript(
     diarization = manifest.transcript.diarization
     if diarization is not None and diarization.available:
         payload["diarized"] = True
-        payload["speakers"] = [
-            {"label": stat.label, "talk_time_ms": stat.talk_time_ms, "turn_count": stat.turn_count}
-            for stat in diarization.speakers
-        ]
+        payload["speakers"], hidden = pipeline.roster_payload(diarization)
+        if hidden:
+            payload["speakers_truncated"] = hidden
     if format == "segments":
         payload["segments"] = [
             {

--- a/tests/unit/test_pipeline_config.py
+++ b/tests/unit/test_pipeline_config.py
@@ -193,3 +193,51 @@ def test_whisper_loads_from_local_cache_first(monkeypatch: pytest.MonkeyPatch) -
     cache_miss[0] = True
     stt._load_model("small")
     assert calls == [True, None], "cache miss must fall back to a one-time download"
+
+
+# --- dusty-roster budget (threshold-mode honesty) ------------------------------
+
+
+def dusty_diarization(majors: int, dust: int) -> Diarization:
+    from talkthrough_mcp.core.diarize import SpeakerStat
+
+    speakers = [
+        SpeakerStat(label=f"S{i+1}", talk_time_ms=60_000 + i, turn_count=5,
+                    first_ms=0, last_ms=1000)
+        for i in range(majors)
+    ] + [
+        SpeakerStat(label=f"S{majors+i+1}", talk_time_ms=2_000, turn_count=1,
+                    first_ms=0, last_ms=1000)
+        for i in range(dust)
+    ]
+    return Diarization(
+        available=True, reason="", detected_num_speakers=majors + dust,
+        speakers=speakers,
+    )
+
+
+def test_roster_payload_caps_and_counts_hidden() -> None:
+    from talkthrough_mcp.core.pipeline import SUMMARY_ROSTER_CAP, roster_payload
+
+    entries, hidden = roster_payload(dusty_diarization(majors=5, dust=118))
+    assert len(entries) == SUMMARY_ROSTER_CAP
+    assert hidden == 5 + 118 - SUMMARY_ROSTER_CAP
+    # top-by-talk-time, but label order preserved in the output
+    assert [e["label"] for e in entries][:5] == ["S1", "S2", "S3", "S4", "S5"]
+
+    small_entries, small_hidden = roster_payload(dusty_diarization(majors=3, dust=0))
+    assert len(small_entries) == 3 and small_hidden == 0
+
+
+def test_summary_threshold_mode_flags_dust() -> None:
+    from talkthrough_mcp.core.pipeline import _summarize_diarization
+
+    block = _summarize_diarization(dusty_diarization(majors=5, dust=118))
+    assert block["speakers_with_30s_plus"] == 5
+    assert "threshold clustering" in block["note"]
+    assert block["speakers_truncated"] == 111
+
+    exact = dusty_diarization(majors=5, dust=0)
+    exact.requested_num_speakers = 5
+    block = _summarize_diarization(exact)
+    assert "note" not in block and "speakers_with_30s_plus" not in block


### PR DESCRIPTION
Battery findings: (1) 123-cluster threshold roster violated the token-budget rule in get_transcript/summary — now top-12 by talk time + `speakers_truncated`, manifest unchanged; (2) agents misread raw cluster counts as headcounts (haiku: '~28 participants') — threshold summaries now carry `speakers_with_30s_plus` + a note pointing at `num_speakers`, guidance teaches the rule. Verified: re-run of the failing naive scenario after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)