### PR TITLE
v0.2.2: word-level search (#16), speaker= filter, ask-user escalation, echo trim, amend honesty

### DIFF
--- a/.agents/skills/talkthrough/SKILL.md
+++ b/.agents/skills/talkthrough/SKILL.md
@@ -70,7 +70,9 @@ method: `triage-recording` (screencast → findings JSON per the contract in
   by design — that error is expected, not a failure.
 - Speaker labels are anonymous (`S1`/`S2`, ordered by first voice). Mapping
   them to names is YOUR job: self-introductions, vocatives, the attendees
-  list. State the mapping explicitly and mark unmapped labels
+  list — and on video jobs the screen itself (meeting-app name plates, the
+  recording's title card, the active-speaker highlight at that label's
+  `t_ms`). State the mapping explicitly and mark unmapped labels
   "unidentified". `diarize=true` needs the `[diarization]` extra — its
   absence produces an actionable install-hint error.
 - Findings/quotes must cite the narrator's exact words + `t_ms` (+ `t_wall`

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketplace for the talkthrough plugin: narrated screen recordings in, agent-ready evidence out.",
-    "version": "0.2.1"
+    "version": "0.2.2"
   },
   "plugins": [
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,12 @@ jobs:
       - run: uv run ruff check
       - run: uv run pytest tests/unit -q
 
-  # Best-effort (issue #1): not a required check, but keeps the Windows path
-  # honest — imports, unit suite, and a real CLI smoke over the fixture
-  # (static-ffmpeg Windows build + whisper tiny + OCR + idempotent re-run),
-  # plus a diarize smoke through the native sherpa-onnx stack (the
-  # System32-onnxruntime DLL clash class breaks HERE, not at users').
+  # Keeps the Windows path honest (issue #1): imports, unit suite, and a real
+  # CLI smoke over the fixture (static-ffmpeg Windows build + whisper tiny +
+  # OCR + idempotent re-run), plus a diarize smoke through the native
+  # sherpa-onnx stack (the System32-onnxruntime DLL clash class breaks HERE,
+  # not at users'). Promotion to a required branch check happens with the
+  # repo owner after a green week on the release branch.
   windows:
     runs-on: windows-latest
     timeout-minutes: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,97 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [SemVer](https://semver.org/).
 
+## [0.2.2] — 2026-07-18
+
+Search ergonomics and honesty fixes, each sourced from the v0.2.1 release
+battery or the external evaluation of 0.2.1 on a real corporate meeting.
+Fully additive patch: the `talkthrough-manifest/v1` schema gains no fields
+at all, no new tools, no new dependencies — every new field below lives in
+server responses only, so existing processed jobs serve the new data with
+no migration.
+
+### Added
+
+- **Word-level search** (#16) — a multi-word `search` query now hits when
+  EVERY whitespace-separated word matches as a substring, in any order at
+  any distance; both sides are normalized with casefold + ё→е + NFC. A
+  single-word query behaves exactly as before, and the stem trick from the
+  guidance now closes Russian case endings: «кнопк отправк» finds both
+  «Кнопка отправки» and «кнопку отправки» (no stemming — deliberately).
+  Hit payloads are unchanged. Verified on a real RU screencast: «карточк
+  справ» lands on «…увидеть карточку справа…», «заявк» reaches both the
+  spoken phrase and the on-screen bot reply via OCR.
+- **`search(…, speaker="S2")`** — filter transcript hits to one diarized
+  voice (label case-insensitive). OCR hits are excluded when the filter is
+  active — on-screen text has no voice — and the payload says so. On an
+  undiarized job the response is honestly empty with a note naming the fix
+  (`diarize=true`, fast amend) instead of an error. `query` stays required:
+  "everything S2 said" is `get_transcript`'s job.
+- **`media_kind` in `get_transcript`** — `"video"` or `"audio"` next to
+  `language`, so minutes writers can't mislabel a video job "audio-only"
+  (an Opus slip observed by the external evaluation) —
+  payload-over-description, again.
+- **Vocabulary-echo trim** — whisper replays `initial_prompt` (the
+  `vocabulary`) over quiet opening seconds; on a real 73-minute meeting
+  the echo swallowed the actual first words. Segments inside the first
+  ~90 s that are ≥80% vocabulary tokens AND (a token repeated 3+ times OR
+  a near-verbatim vocabulary prefix) are dropped, logged, and counted in
+  the summary as `transcript.vocabulary_echo_trimmed` (present only when
+  > 0). A live roll-call («на встрече присутствуют Анастасия, Диана и
+  Влад») has connecting words, fails the 80% bar, and survives — guarded
+  by a dedicated unit test.
+
+### Changed
+
+- **Threshold-mode over-detection now escalates to the user.** The 0.2.1
+  note called `speakers_with_30s_plus` "the likely headcount" — the
+  external evaluation falsified that (it said 4 on a true-2 meeting), so
+  the server no longer guesses headcounts at all. The note now instructs
+  the agent to ASK THE USER how many people spoke (the talk-time roster
+  right above is the material for that question) and to re-run with
+  `num_speakers=N` — the amend takes seconds, whisper is not re-run.
+  `speakers_with_30s_plus` stays in the payload as one signal among
+  several, without the claim.
+- **Explicit `diarize=true` re-diarizes when the embedding model changed.**
+  A job diarized under one `TALKTHROUGH_DIARIZATION_EMB_MODEL` used to
+  serve its old labels forever; now an explicit request on a job whose
+  stored `diarization.embedding_model` differs from the currently resolved
+  one re-runs just the diarization stage (whisper untouched) — the mirror
+  of the explicit-whisper-model reuse rule. An env change without explicit
+  intent still never invalidates the store.
+
+### Fixed
+
+- **`diarization_amended` reflects the outcome.** A failed amend (e.g. a
+  model download dying on corporate TLS) used to return top-level
+  `diarization_amended: true` right above `diarization.available: false`.
+  The flag is now set only when the amend actually landed labels; failures
+  keep the transcript and report `available: false` with the reason.
+
+### Docs
+
+- Tool guidance: search examples teach word-AND semantics and the
+  `speaker=` filter; `process_media` gains the meeting recipe
+  (`large-v3-turbo` + attendee `vocabulary` + `num_speakers` — turbo's
+  extra cost is trivial next to frames+OCR) and the ask-the-user line for
+  noisy threshold rosters.
+- `meeting-actions` prompt (and the Agent Skill): speaker-mapping evidence
+  now includes on-screen sources — meeting-app name plates, the
+  recording's title card, the active-speaker highlight — the exact
+  evidence a freeform evaluation run used to name speakers while the
+  command-constrained run left them "unidentified".
+- `triage-recording` prompt: the findings keys are declared EXACTLY
+  (`quote`, `frame_refs`, …, no `quotes[]`/`evidence[]` wrappers) — aimed
+  at the one runner that kept drifting from the canon.
+- TROUBLESHOOTING: a "Corporate networks" section (`HF_HUB_DISABLE_XET=1`
+  for stalled whisper downloads, `SSL_CERT_FILE` for TLS-inspected
+  diarization downloads). MODEL-NOTES: EN homophone names resist
+  `vocabulary` at every config ("prophet" → "profit") — the multi-modal
+  OCR redundancy is the compensation.
+- Windows wording: the CI job is no longer labeled "best-effort" —
+  promotion to a required branch check is planned right after this
+  release's green week.
+
 ## [0.2.1] — 2026-07-18
 
 Quality quick-wins, each grown out of a concrete v0.2.0 release-battery

--- a/README.md
+++ b/README.md
@@ -531,14 +531,15 @@ processes in ~40 s) — and instant re-runs on the same file. Progress streams
 as MCP progress notifications, and the CLI prints stage lines. More:
 [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md).
 
-## Windows (best-effort)
+## Windows
 
-CI runs lint, the unit suite, and a full CLI smoke on `windows-latest`
-(static-ffmpeg Windows build, whisper `tiny` transcription, OCR, and the
-instant idempotent re-run). Notes: the per-job lock is POSIX `fcntl` and
+CI runs lint, the unit suite, a full CLI smoke, and a diarize smoke on
+`windows-latest` (static-ffmpeg Windows build, whisper `tiny` transcription,
+OCR, the instant idempotent re-run, and a speaker-roster assert through the
+native sherpa-onnx stack). Notes: the per-job lock is POSIX `fcntl` and
 degrades to a no-op on Windows — fine for a single-user machine; quote paths
 with spaces (`uv run talkthrough-mcp process "C:\Videos\Screen Recording.mp4"`).
-Windows is not a release gate — if something breaks, please open an issue.
+If something breaks, please open an issue.
 
 ## Supported inputs
 
@@ -571,7 +572,8 @@ Honest edges, so you can decide fast:
 - **OCR reads crisp UI text well;** tiny or low-contrast print is best-effort.
 - **Wall-clock confidence depends on recorder metadata** — worst case pass
   `recorded_at=` (see the ladder above).
-- **Windows is best-effort** (see above).
+- **Windows caveats** — POSIX lock degrades to a no-op; see the Windows
+  section above.
 
 ## How it compares
 

--- a/docs/MODEL-NOTES.md
+++ b/docs/MODEL-NOTES.md
@@ -5,6 +5,53 @@ models drift, sample sizes are small (n in every cell), and the corpus
 is one team's real recordings. Read it as "what tier of agent reliably
 drives this MCP for which job".*
 
+## v0.2.2 addendum (targeted battery, 2026-07-18)
+
+A 20-run battery on the v0.2.2 server — four runner configs (haiku /
+sonnet / gpt-5.5 medium / gpt-5.4-mini low) × the surfaces this release
+touches, on the same real recordings as the earlier grids. Every
+mechanical zero was adjudicated by reading the raw output (three were
+checker-shape artifacts, none were agent failures). Results:
+
+- **Two-word stem search (#16): 8/8.** «карточк отправ»-class queries —
+  «карточк справ» on the 2-min RU screencast, «обратн связ» on the 73-min
+  RU meeting — returned the ground-truth moment at every tier (10–27 s
+  wall). On 0.2.1 these exact queries returned zero hits (exact-substring
+  semantics); agents needed lucky single-word fallbacks.
+- **Ask-the-user escalation: 4/4 refused to trust the cluster count**
+  on an UNDIARIZED copy of the 73-min meeting («сколько людей говорило и
+  кто что сказал?», no headcount given). Sonnet asked outright
+  («Подскажите, сколько человек реально участвовало? … пересчитаю с
+  num_speakers=N — это быстро»); gpt-5.4-mini — the runner that
+  description prose famously never reaches — ALSO asked («напишите число,
+  тогда доразмечу с num_speakers=N»), driven purely by the payload note;
+  haiku and gpt-5.5 hedged the number against cluster noise instead of
+  asserting it. Zero confident wrong headcounts (the v0.2.1 external
+  eval's failure mode).
+- **T6 findings JSON: 4/4 evidence-complete** (verbatim quotes
+  string-matched, cited frame files exist). Canonical key names: both
+  Claude tiers exact; both codex tiers still invent schemas
+  (`evidence_frames`/nested `evidence{}`) — and the transcript shows WHY:
+  `codex exec` never fetches MCP prompt templates, so the new canon
+  paragraph in `triage-recording` physically cannot reach codex runners.
+  The description-vs-payload lesson extends to prompts: contracts that
+  must reach every client belong in tool RESPONSES, not prompt text.
+- **T2 point-lookup regression: 4/4** (S2 + exact timestamp).
+- **Vocabulary-echo trim** (engine-level): on the 73-min meeting
+  re-transcription (small + six-name vocabulary) the opening
+  initial_prompt echo is now dropped — `vocabulary_echo_trimmed: 1` in
+  the summary, transcript opens with real speech, reference-point names
+  intact («влад дим дайте какую-то обратную…», «александр коровин»).
+  The echo's shape VARIES between decodes (repeat runs vs. a single
+  vocabulary-order pass — whisper's fallback sampling is nondeterministic
+  in quiet windows), which is why the detector matches vocabulary ORDER,
+  not a verbatim prefix. Boundary, honestly: trimming cannot resurrect
+  words whisper never emitted — on this recording the opening «Евгений
+  мне сообщил…» is decoded fine WITHOUT the vocabulary prompt but
+  swallowed WITH it; restoring such openings needs a prompt-free
+  re-decode of the trimmed window (a 0.3 candidate, evidence in the
+  v0.2.2 release notes).
+
 ## v0.2.1 addendum (feature-grid battery, 2026-07-18)
 
 A 36-run feature grid re-ran on the v0.2.1 server — all six v0.2.0 runner

--- a/docs/MODEL-NOTES.md
+++ b/docs/MODEL-NOTES.md
@@ -51,6 +51,12 @@ failures). Results:
   into the first ~60 s of quiet opening chatter (a known `initial_prompt`
   trait, present since 0.1.0). If you pass `vocabulary`, treat the opening
   seconds of the transcript with suspicion before quoting them.
+  The note is RU-derived; an external EN evaluation adds the boundary:
+  `vocabulary` does not rescue English homophone names — a name that IS a
+  common word ("Prophet" → "profit") stays wrong in every config, and its
+  count can even shift slightly — while the pipeline's multi-modal
+  redundancy compensates: OCR reads the correct spellings off slides/UI,
+  and Sonnet-tier agents reconcile the two streams in their output.
 
 ## Method
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -16,6 +16,33 @@ After that, expect roughly 3× faster than real time on an Apple-Silicon CPU
 with the default `small` model, OCR included (a 2-minute clip ≈ 40 s).
 Re-processing the same file returns instantly from the job store.
 
+## Corporate networks: model downloads stall or fail TLS
+
+Two env vars fix the one-time downloads on locked-down networks (warm runs
+are offline and unaffected):
+
+- **Whisper download hangs / stalls at 0%** — some proxies break Hugging
+  Face's Xet transfer protocol. Disable it; downloads fall back to plain
+  HTTPS:
+
+  ```bash
+  HF_HUB_DISABLE_XET=1
+  ```
+
+- **Diarization model download fails with a certificate error** — TLS
+  inspection re-signs traffic with a corporate CA that Python's bundled
+  certificate store doesn't trust. Point Python at the system store that
+  includes your CA (macOS: `/etc/ssl/cert.pem`; Linux distros commonly use
+  `/etc/ssl/certs/ca-certificates.crt`):
+
+  ```bash
+  SSL_CERT_FILE=/etc/ssl/cert.pem
+  ```
+
+Set both in the MCP server config (`"env": {...}`) or the shell that runs
+the first `process_media`. Once the models are cached, neither is needed —
+processing is zero-network by design.
+
 ## `pip install` says "No matching distribution found"
 
 Your Python is older than 3.11 (macOS ships 3.9 as `/usr/bin/python3`), so
@@ -136,9 +163,9 @@ Nothing is written anywhere else, and there is no telemetry to opt out of.
 
 ## Windows
 
-Best-effort but CI-smoked (lint + unit + a real CLI run). Quote paths with
-spaces; the per-job lock degrades to a no-op — fine on a single-user machine.
-Details: README → Windows.
+CI-smoked on every push (lint + unit + a real CLI run + a diarize smoke).
+Quote paths with spaces; the per-job lock degrades to a no-op — fine on a
+single-user machine. Details: README → Windows.
 
 Diarization caveat: sherpa-onnx vendors its own ONNX Runtime, but a stray
 `onnxruntime.dll` in `C:\Windows\System32` (left there by some installers)

--- a/examples/prompts/meeting-actions.md
+++ b/examples/prompts/meeting-actions.md
@@ -15,10 +15,13 @@ them, and that is fine.
    in that call — names survive transcription instead of degrading into
    look-alike words, and owner attribution depends on them.
 4. When segments carry speaker labels, map each label to a person before
-   writing minutes: self-introductions ("hi, this is Vera"), vocatives
-   ("thanks, Tom"), and the attendees list above are the evidence. State the
-   mapping first (e.g. `S1 = Vera, S2 = Tom, S3 = unidentified`) — never
-   guess beyond the evidence.
+   writing minutes. Evidence: self-introductions ("hi, this is Vera"),
+   vocatives ("thanks, Tom"), the attendees list above — and, on video
+   jobs, the SCREEN: meeting-app name plates, the recording's title card
+   (who started/organized it), and the active-speaker highlight during that
+   speaker's t_ms all name people (get_moment at the moment, read frames +
+   OCR). State the mapping first (e.g. `S1 = Vera, S2 = Tom,
+   S3 = unidentified`) — never guess beyond the evidence.
 5. Collect: action items (who committed to what), decisions (what was agreed),
    open questions (raised but unresolved). Keep exact quotes and t_ms for each.
 6. search(job_id="<job_id>", query="<name or topic>") to trace scattered

--- a/examples/prompts/triage-recording.md
+++ b/examples/prompts/triage-recording.md
@@ -32,6 +32,10 @@ Return ONE fenced JSON object, no other prose:
   answer with "1,3-4".
 - `key_frames`: 2-3 frame refs that best show the problems.
 
+Key names above are the contract — use them EXACTLY as written (`quote`,
+`frame_refs`, `t_ms`, …): no renames, no wrappers, no `quotes[]` or
+`evidence[]` arrays. Downstream tooling reads these keys mechanically.
+
 Rules: low STT/vision confidence → route="question" with a concrete question —
 never a silent guess. Findings without frame evidence (audio-only jobs) must say
 so in `frame_refs: []`. Write `digest` in the narrator's language (the

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "talkthrough",
   "description": "Turn narrated screen recordings into filed bugs, specs, backlogs and meeting actions. Bundles the talkthrough MCP server, five workflow commands, a triage agent, and an agent skill.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "korovin-aa97",
     "url": "https://github.com/korovin-aa97"

--- a/integrations/claude-code/commands/meeting-actions.md
+++ b/integrations/claude-code/commands/meeting-actions.md
@@ -21,10 +21,13 @@ them, and that is fine.
    in that call — names survive transcription instead of degrading into
    look-alike words, and owner attribution depends on them.
 4. When segments carry speaker labels, map each label to a person before
-   writing minutes: self-introductions ("hi, this is Vera"), vocatives
-   ("thanks, Tom"), and the attendees list above are the evidence. State the
-   mapping first (e.g. `S1 = Vera, S2 = Tom, S3 = unidentified`) — never
-   guess beyond the evidence.
+   writing minutes. Evidence: self-introductions ("hi, this is Vera"),
+   vocatives ("thanks, Tom"), the attendees list above — and, on video
+   jobs, the SCREEN: meeting-app name plates, the recording's title card
+   (who started/organized it), and the active-speaker highlight during that
+   speaker's t_ms all name people (get_moment at the moment, read frames +
+   OCR). State the mapping first (e.g. `S1 = Vera, S2 = Tom,
+   S3 = unidentified`) — never guess beyond the evidence.
 5. Collect: action items (who committed to what), decisions (what was agreed),
    open questions (raised but unresolved). Keep exact quotes and t_ms for each.
 6. search(job_id="$ARGUMENTS", query="<name or topic>") to trace scattered

--- a/integrations/claude-code/commands/triage-recording.md
+++ b/integrations/claude-code/commands/triage-recording.md
@@ -38,6 +38,10 @@ Return ONE fenced JSON object, no other prose:
   answer with "1,3-4".
 - `key_frames`: 2-3 frame refs that best show the problems.
 
+Key names above are the contract — use them EXACTLY as written (`quote`,
+`frame_refs`, `t_ms`, …): no renames, no wrappers, no `quotes[]` or
+`evidence[]` arrays. Downstream tooling reads these keys mechanically.
+
 Rules: low STT/vision confidence → route="question" with a concrete question —
 never a silent guess. Findings without frame evidence (audio-only jobs) must say
 so in `frame_refs: []`. Write `digest` in the narrator's language (the

--- a/integrations/claude-code/skills/talkthrough/SKILL.md
+++ b/integrations/claude-code/skills/talkthrough/SKILL.md
@@ -70,7 +70,9 @@ method: `triage-recording` (screencast → findings JSON per the contract in
   by design — that error is expected, not a failure.
 - Speaker labels are anonymous (`S1`/`S2`, ordered by first voice). Mapping
   them to names is YOUR job: self-introductions, vocatives, the attendees
-  list. State the mapping explicitly and mark unmapped labels
+  list — and on video jobs the screen itself (meeting-app name plates, the
+  recording's title card, the active-speaker highlight at that label's
+  `t_ms`). State the mapping explicitly and mark unmapped labels
   "unidentified". `diarize=true` needs the `[diarization]` extra — its
   absence produces an actionable install-hint error.
 - Findings/quotes must cite the narrator's exact words + `t_ms` (+ `t_wall`

--- a/integrations/claude-desktop/manifest.json
+++ b/integrations/claude-desktop/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "talkthrough",
   "display_name": "Talkthrough — narrated recordings for your agent",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Turn narrated screen recordings into structured evidence: local Whisper transcript, scene keyframes, OCR, wall-clock anchoring. Record, talk — Claude files the bugs.",
   "author": {
     "name": "korovin-aa97",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "talkthrough-mcp"
-version = "0.2.1"
+version = "0.2.2"
 description = "Local-first MCP server that turns narrated screen recordings into agent-ready structured data: timestamped transcript, scene keyframes, OCR text, and wall-clock anchoring."
 readme = "README.md"
 authors = [
@@ -83,10 +83,19 @@ select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]
 # captured ffmpeg stderr sample lines are long by nature
 "tests/unit/test_frames.py" = ["E501"]
 # tool-description example one-liners are allowed up to 120 chars by the
-# guidance contract (enforced in tests/unit/test_guidance.py)
-"src/talkthrough_mcp/guidance.py" = ["E501"]
+# guidance contract (enforced in tests/unit/test_guidance.py); Cyrillic
+# ё/е examples are the point of the search guidance
+"src/talkthrough_mcp/guidance.py" = ["E501", "RUF001"]
 # generator templates carry one-line skill descriptions and markdown tables
 "scripts/gen_integrations.py" = ["E501"]
+# Cyrillic ё→е folding literals and RU sample strings are the FEATURE here
+# (#16 search normalization + vocabulary-echo trimming), not lookalike typos
+"src/talkthrough_mcp/core/manifest.py" = ["RUF001", "RUF002"]
+"src/talkthrough_mcp/core/stt.py" = ["RUF001", "RUF002"]
+"tests/unit/test_manifest.py" = ["RUF001", "RUF003"]
+"tests/unit/test_stt_echo.py" = ["RUF001", "RUF002"]
+"tests/integration/fixture_facts.py" = ["RUF003"]
+"tests/integration/test_pipeline_integration.py" = ["RUF001", "RUF002"]
 
 [tool.mypy]
 # 3.12 (the pinned dev/CI interpreter): transitive numpy stubs use py3.12

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/korovin-aa97/talkthrough-mcp",
     "source": "github"
   },
-  "version": "0.2.1",
+  "version": "0.2.2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "talkthrough-mcp",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/talkthrough_mcp/core/diarize.py
+++ b/src/talkthrough_mcp/core/diarize.py
@@ -451,6 +451,22 @@ def ensure_model_file(spec: ModelSpec) -> Path:
     return target
 
 
+def resolved_embedding_label() -> str:
+    """The label ``create_diarizer`` would record for the embedding model —
+    WITHOUT touching the network or the disk cache.
+
+    Mirrors ``resolve_model``'s labeling: allowlist name (or the default),
+    else the env value read as a local path, verbatim. Used by the amend
+    gate to compare against ``diarization.embedding_model`` in a stored
+    manifest; an invalid env value simply compares unequal and the engine
+    reports the real error when the amend actually runs.
+    """
+    raw = os.environ.get("TALKTHROUGH_DIARIZATION_EMB_MODEL", "").strip()
+    if not raw or raw in EMBEDDING_MODELS:
+        return raw or DEFAULT_EMBEDDING_MODEL
+    return str(Path(raw).expanduser())
+
+
 def resolve_model(
     env_var: str, models: Mapping[str, ModelSpec], default_name: str
 ) -> tuple[str, Path]:

--- a/src/talkthrough_mcp/core/manifest.py
+++ b/src/talkthrough_mcp/core/manifest.py
@@ -8,6 +8,7 @@ reads from here — the source media is only re-read by ``extract_frame``.
 from __future__ import annotations
 
 import json
+import unicodedata
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
@@ -298,14 +299,41 @@ class SearchHit:
     speaker: str | None = None  # transcript hits on diarized jobs
 
 
-def search_manifest(manifest: Manifest, query: str) -> list[SearchHit]:
-    """Case-insensitive substring match over transcript segments AND frame OCR text."""
-    needle = query.strip().lower()
+def _fold_for_search(text: str) -> str:
+    """Match-time normalization applied to BOTH query and indexed text (#16).
+
+    NFC first (so a decomposed ``е`` + combining diaeresis becomes ``ё``
+    before folding), then casefold, then ё→е — Russian writes the same word
+    both ways and neither side should have to guess which one the recording
+    used.
+    """
+    return unicodedata.normalize("NFC", text).casefold().replace("ё", "е")
+
+
+def search_manifest(
+    manifest: Manifest, query: str, *, speaker: str | None = None
+) -> list[SearchHit]:
+    """Word-level match over transcript segments AND frame OCR text.
+
+    The query is tokenized on whitespace; a text hits when EVERY token
+    matches as a substring — any order, any distance (#16). A single-word
+    query therefore behaves exactly like the old exact-substring match.
+    ``speaker`` filters transcript hits to one diarized label; OCR hits are
+    excluded then (on-screen text has no voice).
+    """
+    tokens = _fold_for_search(query).split()
     hits: list[SearchHit] = []
-    if not needle:
+    if not tokens:
         return hits
+
+    def matches(text: str) -> bool:
+        folded = _fold_for_search(text)
+        return all(token in folded for token in tokens)
+
     for segment in manifest.transcript.segments:
-        if needle in segment.text.lower():
+        if speaker is not None and segment.speaker != speaker:
+            continue
+        if matches(segment.text):
             hits.append(
                 SearchHit(
                     source="transcript",
@@ -318,8 +346,11 @@ def search_manifest(manifest: Manifest, query: str) -> list[SearchHit]:
                     speaker=segment.speaker,
                 )
             )
+    if speaker is not None:
+        hits.sort(key=lambda hit: hit.t_ms)
+        return hits
     for frame in manifest.frames.items:
-        if frame.ocr_text and needle in frame.ocr_text.lower():
+        if frame.ocr_text and matches(frame.ocr_text):
             hits.append(
                 SearchHit(
                     source="ocr",

--- a/src/talkthrough_mcp/core/pipeline.py
+++ b/src/talkthrough_mcp/core/pipeline.py
@@ -87,7 +87,11 @@ class ProcessResult:
     manifest: Manifest
     reused: bool
     elapsed_s: float
-    amended: bool = False  # diarization added to an existing job, whisper untouched
+    # True only when an amend RAN AND landed labels (whisper untouched); a
+    # failed amend must not claim success — diarization.available carries
+    # the outcome either way.
+    amended: bool = False
+    vocabulary_echo_trimmed: int = 0  # opening initial_prompt echoes dropped
 
 
 def _env_int(name: str, default: int) -> int:
@@ -267,14 +271,23 @@ def _needs_diarize_amend(manifest: Manifest, request: _DiarizeRequest) -> bool:
 
     A stored job without (working) diarization + an explicit request → run
     just the diarization stage. An explicit ``num_speakers`` differing from
-    the stored one re-diarizes the same way. The env default deliberately
-    never invalidates the store, and a diarized job served to a non-diarize
-    call is a harmless superset.
+    the stored one re-diarizes the same way, and so does a stored
+    ``embedding_model`` that no longer matches the currently resolved one —
+    silently serving old-model labels to a caller who switched
+    ``TALKTHROUGH_DIARIZATION_EMB_MODEL`` would betray the same intent the
+    whisper-model rule protects. The env default (and an env change without
+    an explicit ``diarize=true``) deliberately never invalidates the store,
+    and a diarized job served to a non-diarize call is a harmless superset.
     """
     if not (request.run and request.explicit and manifest.media.has_audio):
         return False
     stored = manifest.transcript.diarization
     if stored is None or not stored.available:
+        return True
+    if (
+        stored.embedding_model is not None
+        and stored.embedding_model != diarize.resolved_embedding_label()
+    ):
         return True
     return (
         request.num_speakers is not None
@@ -373,11 +386,15 @@ def process_media(
                     "job %s exists — amending diarization only, whisper is not re-run", job_id
                 )
                 amended = _amend_diarization(media, manifest_hit, diarize_request, report)
+                diarization = amended.transcript.diarization
                 return ProcessResult(
                     manifest=amended,
                     reused=True,
                     elapsed_s=time.monotonic() - started,
-                    amended=True,
+                    # the flag reflects the OUTCOME: a failed amend keeps the
+                    # transcript, records available=false + reason, and must
+                    # not be reported as an applied amend
+                    amended=diarization is not None and diarization.available,
                 )
             return ProcessResult(
                 manifest=manifest_hit, reused=True, elapsed_s=time.monotonic() - started
@@ -405,6 +422,7 @@ def process_media(
         transcript = Transcript(
             available=False, reason="no audio stream in recording", language=None, model=None
         )
+        echo_trimmed = 0
         if info.has_audio:
             report("extracting audio", 0.10)
             wav_path = directory / "audio.wav"
@@ -433,6 +451,7 @@ def process_media(
                     language_probability=stt_result.language_probability,
                     segments=list(stt_result.segments),
                 )
+                echo_trimmed = stt_result.vocabulary_echo_trimmed
                 if diarize_request.run:
                     # The stage eats the same WAV — it must run before unlink.
                     _run_diarization(wav_path, transcript, diarize_request, report)
@@ -507,7 +526,12 @@ def process_media(
         save_manifest(manifest, directory)
 
     report("done", 1.0)
-    return ProcessResult(manifest=manifest, reused=False, elapsed_s=time.monotonic() - started)
+    return ProcessResult(
+        manifest=manifest,
+        reused=False,
+        elapsed_s=time.monotonic() - started,
+        vocabulary_echo_trimmed=echo_trimmed,
+    )
 
 
 SUMMARY_ROSTER_CAP = 12
@@ -551,13 +575,19 @@ def _summarize_diarization(diarization: Diarization) -> dict[str, Any]:
             1 for s in diarization.speakers if s.talk_time_ms >= SUBSTANTIAL_TALK_MS
         )
         if substantial < (diarization.detected_num_speakers or 0):
-            # threshold-mode honesty: clusters != people; give agents the
-            # number worth reporting and the lever that fixes it
+            # threshold-mode honesty (v0.2.2): the cluster count is NOT a
+            # headcount, and no server heuristic is trusted to guess one — an
+            # external eval falsified speakers_with_30s_plus as "likely
+            # headcount" (said 4, truth 2). The user always knows their own
+            # meeting: escalate to them, with the talk-time roster as the
+            # material for the question.
             payload["speakers_with_30s_plus"] = substantial
             payload["note"] = (
-                "threshold clustering over-detects on real meetings — treat "
-                "speakers_with_30s_plus as the likely headcount, or re-run "
-                "with num_speakers for an exact roster"
+                "threshold clustering over-detected on this recording — the cluster "
+                "count is unreliable and is NOT a headcount. ASK YOUR USER how many "
+                "people actually spoke (the talk_time_ms roster above shows which "
+                "voices dominate), then re-run process_media(diarize=true, "
+                "num_speakers=N) — the amend takes seconds, whisper is not re-run"
             )
     return payload
 
@@ -624,6 +654,13 @@ def summarize(result: ProcessResult) -> dict[str, Any]:
             "language_probability": manifest.transcript.language_probability,
             "model": manifest.transcript.model,
             "segment_count": len(segments),
+            # serve-time fact, not manifest schema: opening initial_prompt
+            # echoes whisper hallucinated over quiet seconds were dropped
+            **(
+                {"vocabulary_echo_trimmed": result.vocabulary_echo_trimmed}
+                if result.vocabulary_echo_trimmed
+                else {}
+            ),
             "preview_segments": preview,
             "preview_truncated": len(segments) > len(preview),
         },

--- a/src/talkthrough_mcp/core/stt.py
+++ b/src/talkthrough_mcp/core/stt.py
@@ -9,8 +9,9 @@ local cache; there is no cloud STT path in this codebase.
 from __future__ import annotations
 
 import logging
+import re
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
@@ -34,9 +35,71 @@ class SttResult:
     segments: tuple[SttSegment, ...]
     latency_ms: int
     language_probability: float | None = None
+    vocabulary_echo_trimmed: int = 0  # opening initial_prompt echoes dropped
 
     def full_text(self) -> str:
         return " ".join(segment.text for segment in self.segments if segment.text).strip()
+
+
+# --- vocabulary echo (initial_prompt replayed over quiet openings) -----------
+
+VOCAB_ECHO_WINDOW_MS = 90_000
+VOCAB_ECHO_MIN_VOCAB_FRACTION = 0.8
+VOCAB_ECHO_MIN_REPEATS = 3
+VOCAB_ECHO_MIN_PREFIX_TOKENS = 3
+
+
+def _echo_tokens(text: str) -> list[str]:
+    """Fold to comparison tokens: casefold + ё→е, punctuation-split."""
+    return [t for t in re.split(r"[\W_]+", text.casefold().replace("ё", "е")) if t]
+
+
+def trim_vocabulary_echo(
+    segments: Sequence[SttSegment], vocabulary: str
+) -> tuple[list[SttSegment], list[SttSegment]]:
+    """Drop opening segments that are the ``initial_prompt`` echoed back.
+
+    Whisper replays the vocabulary over quiet opening seconds (a known
+    ``initial_prompt`` trait, documented in MODEL-NOTES since v0.2.1) — on a
+    real meeting the echo swallowed the actual opening words. A segment
+    inside the first ~90 s is treated as echo when (a) at least ~80% of its
+    tokens come from the vocabulary AND (b) one token repeats 3+ times OR
+    the text is a near-verbatim prefix of the vocabulary itself. A live
+    roll-call ("на встрече присутствуют Анастасия, Диана и Влад") carries
+    verbs/prepositions, fails (a), and survives.
+
+    Returns ``(kept, trimmed)``; timing of kept segments is untouched.
+    """
+    vocab_tokens = _echo_tokens(vocabulary)
+    if not vocab_tokens:
+        return list(segments), []
+    vocab_set = set(vocab_tokens)
+    kept: list[SttSegment] = []
+    trimmed: list[SttSegment] = []
+    for segment in segments:
+        if segment.t0_ms >= VOCAB_ECHO_WINDOW_MS:
+            kept.append(segment)
+            continue
+        tokens = _echo_tokens(segment.text)
+        if not tokens:
+            kept.append(segment)
+            continue
+        vocab_fraction = sum(1 for t in tokens if t in vocab_set) / len(tokens)
+        if vocab_fraction < VOCAB_ECHO_MIN_VOCAB_FRACTION:
+            kept.append(segment)
+            continue
+        max_repeat = max(tokens.count(t) for t in set(tokens))
+        prefix = vocab_tokens[: len(tokens)]
+        near_verbatim_prefix = (
+            len(tokens) >= VOCAB_ECHO_MIN_PREFIX_TOKENS
+            and len(tokens) == len(prefix)
+            and sum(1 for got, want in zip(tokens, prefix, strict=True) if got != want) <= 1
+        )
+        if max_repeat >= VOCAB_ECHO_MIN_REPEATS or near_verbatim_prefix:
+            trimmed.append(segment)
+        else:
+            kept.append(segment)
+    return kept, trimmed
 
 
 def _load_model(model_name: str) -> Any:
@@ -101,6 +164,18 @@ def transcribe(
         if on_segment is not None:
             on_segment(t1_ms)
 
+    echo_trimmed = 0
+    if vocabulary:
+        segments, trimmed = trim_vocabulary_echo(segments, vocabulary)
+        echo_trimmed = len(trimmed)
+        for segment in trimmed:
+            logger.info(
+                "dropped vocabulary-echo segment [%d-%d ms]: %r",
+                segment.t0_ms,
+                segment.t1_ms,
+                segment.text,
+            )
+
     probability = getattr(info, "language_probability", None)
     return SttResult(
         language=getattr(info, "language", None),
@@ -108,4 +183,5 @@ def transcribe(
         segments=tuple(_renumber(segments)),
         latency_ms=int((time.monotonic() - started) * 1000),
         language_probability=round(float(probability), 3) if probability is not None else None,
+        vocabulary_echo_trimmed=echo_trimmed,
     )

--- a/src/talkthrough_mcp/core/stt.py
+++ b/src/talkthrough_mcp/core/stt.py
@@ -54,6 +54,14 @@ def _echo_tokens(text: str) -> list[str]:
     return [t for t in re.split(r"[\W_]+", text.casefold().replace("ё", "е")) if t]
 
 
+def _ordered_vocab_run(tokens: list[str], vocab_tokens: list[str], vocab_set: set[str]) -> int:
+    """Longest count of the segment's vocabulary tokens that appear in
+    vocabulary ORDER (subsequence; non-vocab tokens are skipped)."""
+    in_vocab = [t for t in tokens if t in vocab_set]
+    iterator = iter(vocab_tokens)
+    return sum(1 for token in in_vocab if token in iterator)
+
+
 def trim_vocabulary_echo(
     segments: Sequence[SttSegment], vocabulary: str
 ) -> tuple[list[SttSegment], list[SttSegment]]:
@@ -61,12 +69,16 @@ def trim_vocabulary_echo(
 
     Whisper replays the vocabulary over quiet opening seconds (a known
     ``initial_prompt`` trait, documented in MODEL-NOTES since v0.2.1) — on a
-    real meeting the echo swallowed the actual opening words. A segment
-    inside the first ~90 s is treated as echo when (a) at least ~80% of its
-    tokens come from the vocabulary AND (b) one token repeats 3+ times OR
-    the text is a near-verbatim prefix of the vocabulary itself. A live
-    roll-call ("на встрече присутствуют Анастасия, Диана и Влад") carries
-    verbs/prepositions, fails (a), and survives.
+    real meeting the echo swallowed the actual opening words. The echo's
+    shape varies between decodes: verbatim repeats of the list, or a single
+    pass with names dropped — but it always keeps the VOCABULARY ORDER,
+    which real speech has no reason to follow. A segment inside the first
+    ~90 s is treated as echo when (a) at least ~80% of its tokens come from
+    the vocabulary AND (b) one token repeats 3+ times OR 3+ of its tokens
+    follow the vocabulary's own order (an ordered subsequence — a verbatim
+    prefix is the special case). A live roll-call ("на встрече присутствуют
+    Анастасия, Диана и Влад") carries verbs/prepositions, fails (a), and
+    survives.
 
     Returns ``(kept, trimmed)``; timing of kept segments is untouched.
     """
@@ -89,13 +101,8 @@ def trim_vocabulary_echo(
             kept.append(segment)
             continue
         max_repeat = max(tokens.count(t) for t in set(tokens))
-        prefix = vocab_tokens[: len(tokens)]
-        near_verbatim_prefix = (
-            len(tokens) >= VOCAB_ECHO_MIN_PREFIX_TOKENS
-            and len(tokens) == len(prefix)
-            and sum(1 for got, want in zip(tokens, prefix, strict=True) if got != want) <= 1
-        )
-        if max_repeat >= VOCAB_ECHO_MIN_REPEATS or near_verbatim_prefix:
+        ordered_run = _ordered_vocab_run(tokens, vocab_tokens, vocab_set)
+        if max_repeat >= VOCAB_ECHO_MIN_REPEATS or ordered_run >= VOCAB_ECHO_MIN_PREFIX_TOKENS:
             trimmed.append(segment)
         else:
             kept.append(segment)

--- a/src/talkthrough_mcp/guidance.py
+++ b/src/talkthrough_mcp/guidance.py
@@ -34,14 +34,14 @@ When NOT to use: to re-fetch data you already processed (use the retrieval tools
 URLs — local file paths only.
 Examples:
 - process_media(path="/Users/sam/Desktop/bug-repro.mov") — narrated screencast, defaults are right
-- process_media(path="/rec/interview.mov", model="large-v3-turbo") — best multilingual quality (1.5 GB, one-time)
+- meetings: model="large-v3-turbo" + vocabulary=<attendees, terms> + num_speakers=N — turbo's extra cost is trivial
 - process_media(path="/tmp/standup.m4a") — audio-only: transcript tools work, frame tools will error
 - process_media(path="/rec/panel.mov", diarize=true, num_speakers=4) — headcount known? ALWAYS pass it: best accuracy
 - job already processed + diarize=true → speakers are added in place, whisper does NOT re-run (fast amend)
 - error mentions [diarization] → the extra is missing: install via uvx "talkthrough-mcp[diarization]"
 - know the attendees? process_media(path=..., vocabulary="Anastasia, Evgenii, OKR") — names+jargon survive STT
 - user: "analyze/summarize this meeting" → include diarize=true — speaker structure is not optional extra credit
-- threshold mode counts VOICE CLUSTERS, not people — report speakers_with_30s_plus, or re-run with num_speakers
+- noisy threshold roster (clusters ≫ people)? ASK your user for the real headcount, then re-run with num_speakers=N
 - cap_hit or sampling_interval_s in summary → for slide hunts raise TALKTHROUGH_MAX_FRAMES or use extract_frame
 - summary shows wall_clock=null → ask when recording started, re-call with recorded_at=... and force=true
 - transcript garbled or language_probability low → re-call with model="large-v3-turbo" (or language="ru") + force=true
@@ -118,26 +118,30 @@ Examples:
 - keep ranges under ~30 s; a 5-min "moment" dilutes the bundle and wastes tokens
 """,
     "search": """\
-Case-insensitive substring search across BOTH transcript segments and frame OCR text. Hits \
-carry source (transcript|ocr), t_ms, t_wall when known, the matched text, and the nearest \
-frame position — everything needed to jump straight to evidence. Exact substring only, no \
+Case-insensitive word search across BOTH transcript segments and frame OCR text: a text \
+hits when EVERY word of the query matches it as a substring — any order, any distance \
+(ё and е are interchangeable). Hits carry source (transcript|ocr), t_ms, t_wall when \
+known, the matched text, and the nearest frame position — everything needed to jump \
+straight to evidence. Optional speaker="S2" narrows to one voice's transcript hits. No \
 embeddings.
 When NOT to use: fuzzy/semantic questions ("anything about performance?") — page \
 get_transcript and read; regex is not supported.
 Examples:
 - search(job_id="...", query="login") — every spoken or on-screen mention of login
 - user: "what did I say about the login button?" → search(job_id, "login button") → get_moment at hits
-- search(job_id, "error") — catches the SPOKEN word and the on-screen error text (OCR) in one call
-- search(job_id, "TypeError") — stack traces on screen are OCR-indexed; great for bug repros
+- search(job_id, "TypeError") — on-screen stack traces and error text are OCR-indexed; great for bug repros
 - search(job_id, "€49") — prices, IDs, and literals on screen are findable via OCR
 - take hit.t_wall and grep your server logs ±30 s around it to pair remark ↔ log line
 - no hits? shorten the stem: "notif" matches notification / notifications / notify
-- prefer one distinctive word ("checkout") over a whole sentence — substrings must match exactly
+- multi-word = ALL words as substrings, any order: "first phase" hits "the first real phase"
+- stems beat inflected phrases: "кнопк отправк" finds «Кнопка отправки» and «кнопку отправки»
 - every hit has nearest_frame_ms → get_frames(job_id, at_ms=<that>) shows the moment
 - diarized job: transcript hits carry "speaker" — "who mentioned the deadline?" is answered by the hit itself
+- search(job_id, "deadline", speaker="S2") — only S2's mentions; OCR hits are excluded (screens have no voice)
 - audio-only job → transcript hits only (there is no OCR index)
 - anti-example: "summarize the pricing discussion" → get_transcript(format="text") and read it
 - anti-example: finding an icon or layout glitch with no text → get_frames over the range; OCR sees text only
+- anti-example: "everything S2 said" → get_transcript and collect speaker=="S2" — search always needs a query
 """,
     "extract_frame": """\
 Re-extract ONE frame at an exact timestamp from the ORIGINAL source video at native \
@@ -258,6 +262,10 @@ Return ONE fenced JSON object, no other prose:
   answer with "1,3-4".
 - `key_frames`: 2-3 frame refs that best show the problems.
 
+Key names above are the contract — use them EXACTLY as written (`quote`,
+`frame_refs`, `t_ms`, …): no renames, no wrappers, no `quotes[]` or
+`evidence[]` arrays. Downstream tooling reads these keys mechanically.
+
 Rules: low STT/vision confidence → route="question" with a concrete question —
 never a silent guess. Findings without frame evidence (audio-only jobs) must say
 so in `frame_refs: []`. Write `digest` in the narrator's language (the
@@ -341,10 +349,13 @@ them, and that is fine.
    in that call — names survive transcription instead of degrading into
    look-alike words, and owner attribution depends on them.
 4. When segments carry speaker labels, map each label to a person before
-   writing minutes: self-introductions ("hi, this is Vera"), vocatives
-   ("thanks, Tom"), and the attendees list above are the evidence. State the
-   mapping first (e.g. `S1 = Vera, S2 = Tom, S3 = unidentified`) — never
-   guess beyond the evidence.
+   writing minutes. Evidence: self-introductions ("hi, this is Vera"),
+   vocatives ("thanks, Tom"), the attendees list above — and, on video
+   jobs, the SCREEN: meeting-app name plates, the recording's title card
+   (who started/organized it), and the active-speaker highlight during that
+   speaker's t_ms all name people (get_moment at the moment, read frames +
+   OCR). State the mapping first (e.g. `S1 = Vera, S2 = Tom,
+   S3 = unidentified`) — never guess beyond the evidence.
 5. Collect: action items (who committed to what), decisions (what was agreed),
    open questions (raised but unresolved). Keep exact quotes and t_ms for each.
 6. search(job_id="{job_id}", query="<name or topic>") to trace scattered

--- a/src/talkthrough_mcp/server.py
+++ b/src/talkthrough_mcp/server.py
@@ -208,6 +208,9 @@ def get_transcript(
         "job_id": job_id,
         "format": format,
         "language": manifest.transcript.language,
+        # payload-over-description: an agent writing minutes must not have to
+        # remember the media kind — "audio-only" slips on video jobs happen
+        "media_kind": manifest.media.kind,
         "segment_count_total": len(manifest.transcript.segments),
         "segments_returned": len(served),
         "range": {"start_ms": start_ms, "end_ms": end_ms},
@@ -347,17 +350,45 @@ def get_moment(job_id: str, start_ms: int, end_ms: int) -> list[str | Image]:
 
 
 @mcp.tool(description=guidance.TOOL_DESCRIPTIONS["search"], annotations=READONLY_TOOL)
-def search(job_id: str, query: str) -> dict[str, Any]:
+def search(job_id: str, query: str, speaker: str | None = None) -> dict[str, Any]:
     manifest = _load(job_id)
     if not query.strip():
         raise ToolError("query is empty — pass a distinctive word or phrase")
-    hits = search_manifest(manifest, query)
+    speaker_label = speaker.strip().upper() if speaker and speaker.strip() else None
+    if speaker_label is not None:
+        diarization = manifest.transcript.diarization
+        if diarization is None or not diarization.available:
+            # honesty, not an error: the labels the filter needs don't exist yet
+            return {
+                "job_id": job_id,
+                "query": query,
+                "speaker": speaker_label,
+                "hit_count": 0,
+                "truncated": False,
+                "hits": [],
+                "note": (
+                    "job is not diarized — speaker labels don't exist here; re-run "
+                    "process_media(diarize=true) to add them (fast amend), then filter"
+                ),
+            }
+    hits = search_manifest(manifest, query, speaker=speaker_label)
     truncated = len(hits) > SEARCH_MAX_HITS
     return {
         "job_id": job_id,
         "query": query,
+        **({"speaker": speaker_label} if speaker_label else {}),
         "hit_count": len(hits),
         "truncated": truncated,
+        **(
+            {
+                "note": (
+                    "ocr hits are excluded when filtering by speaker — "
+                    "on-screen text has no voice"
+                )
+            }
+            if speaker_label
+            else {}
+        ),
         "hits": [
             {
                 "source": hit.source,

--- a/tests/e2e/test_mcp_client.py
+++ b/tests/e2e/test_mcp_client.py
@@ -155,7 +155,23 @@ async def _run_session(home: Path) -> None:
             "search hits must carry t_wall when the wall clock is known"
         )
 
-        # 6. SRT export is well-formed.
+        # 5b. v0.2.2: multi-word AND-search on the wire; speaker= on an
+        # undiarized job answers honestly instead of erroring.
+        multiword = _payload(
+            await session.call_tool(
+                "search", {"job_id": job_id, "query": "page login"}
+            )
+        )
+        assert multiword["hit_count"] >= 1, "order-free multi-word query must hit"
+        undiarized_filter = _payload(
+            await session.call_tool(
+                "search", {"job_id": job_id, "query": "login", "speaker": "S1"}
+            )
+        )
+        assert undiarized_filter["hits"] == []
+        assert "not diarized" in undiarized_filter["note"]
+
+        # 6. SRT export is well-formed; v0.2.2: the payload names the media kind.
         srt_result = await session.call_tool(
             "get_transcript", {"job_id": job_id, "format": "srt"}
         )
@@ -163,6 +179,7 @@ async def _run_session(home: Path) -> None:
         srt = srt_payload["srt"]
         assert srt.startswith("1\n00:00:0")
         assert " --> " in srt
+        assert srt_payload["media_kind"] == "video"
 
         # 7. list_jobs sees the processed job.
         jobs_result = await session.call_tool("list_jobs", {})
@@ -213,6 +230,24 @@ async def _run_session(home: Path) -> None:
                 )
             )
             assert "S1: " in srt_diarized["srt"]
+            assert srt_diarized["media_kind"] == "audio"
+
+            # v0.2.2: speaker= filter on the wire — one voice, case-normalized,
+            # with the ocr-exclusion note in the payload.
+            s1_hits = _payload(
+                await session.call_tool(
+                    "search",
+                    {
+                        "job_id": diarized_summary["job_id"],
+                        "query": "the",
+                        "speaker": "s1",
+                    },
+                )
+            )
+            assert s1_hits["speaker"] == "S1"
+            assert s1_hits["hits"], "S1 speaks first — 'the' must hit her turns"
+            assert all(hit["speaker"] == "S1" for hit in s1_hits["hits"])
+            assert "ocr hits are excluded" in s1_hits["note"]
         else:
             failed = await session.call_tool(
                 "process_media",

--- a/tests/integration/fixture_facts.py
+++ b/tests/integration/fixture_facts.py
@@ -33,6 +33,14 @@ MEETING_KEYWORDS = ("action", "report", "team")
 RU_M4A = FIXTURES_DIR / "multilang-ru-demo.m4a"
 RU_LANGUAGE = "ru"
 
+# v0.2.2 word-search facts (#16): the narration says «Кнопка отправки не
+# работает…» and «Ещё я хочу…»; `tiny` renders "кнопка отправки" verbatim
+# and writes "еще" WITHOUT the ё — exactly the two real-world cases the
+# search normalization must close (multi-word stems; ё-query over е-text).
+RU_STEM_QUERY = "кнопк отправк"
+RU_YO_QUERY = "ещё"
+RU_STEM_TARGET = "кнопка отправки"
+
 # Japanese narrated screencast (Kyoko voice) — the auto-OCR-pack fixture.
 # The on-screen heading is katakana-heavy on purpose: the default
 # Latin+Chinese recognition model cannot read kana, so an OCR hit on the

--- a/tests/integration/test_diarization_integration.py
+++ b/tests/integration/test_diarization_integration.py
@@ -274,3 +274,61 @@ def test_amend_again_on_explicit_num_speakers_mismatch(
     settled = pipeline.process_media(str(MEETING_M4A), diarize_speakers=True, num_speakers=2)
     assert settled.reused is True
     assert settled.amended is False
+
+
+def test_explicit_diarize_amends_on_embedding_model_change(
+    two_voice: ProcessResult, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """v0.2.2: explicit diarize=true + a different resolved embedding model
+    re-runs ONLY diarization — labels re-land, engine fields update, whisper
+    stays untouched. MUTATES the two-voice job: keep this test LAST."""
+    stored = two_voice.manifest.transcript.diarization
+    assert stored is not None and stored.available
+
+    saved_home = os.environ["TALKTHROUGH_HOME"]
+    os.environ["TALKTHROUGH_HOME"] = str(_models_cache())
+    try:
+        wespeaker = diarize.ensure_model_file(
+            diarize.EMBEDDING_MODELS["wespeaker_en_voxceleb_resnet34_LM"]
+        )
+    finally:
+        os.environ["TALKTHROUGH_HOME"] = saved_home
+    monkeypatch.setenv("TALKTHROUGH_DIARIZATION_EMB_MODEL", str(wespeaker))
+    assert stored.embedding_model != str(wespeaker)
+
+    # an env change WITHOUT explicit intent must not invalidate the store
+    untouched = pipeline.process_media(str(TWO_VOICE_M4A))
+    assert untouched.reused is True and untouched.amended is False
+    untouched_diarization = untouched.manifest.transcript.diarization
+    assert untouched_diarization is not None
+    assert untouched_diarization.embedding_model == stored.embedding_model
+
+    def boom(*args: object, **kwargs: object) -> None:
+        raise AssertionError("whisper must not re-run during an emb-change amend")
+
+    monkeypatch.setattr(pipeline.stt, "transcribe", boom)
+    amended = pipeline.process_media(
+        str(TWO_VOICE_M4A), diarize_speakers=True, num_speakers=TWO_VOICE_NUM_SPEAKERS
+    )
+    assert amended.reused is True and amended.amended is True
+    assert amended.manifest.created_at == two_voice.manifest.created_at
+    after = amended.manifest.transcript.diarization
+    assert after is not None and after.available
+    assert after.embedding_model == str(wespeaker)
+    assert after.detected_num_speakers == TWO_VOICE_NUM_SPEAKERS
+    assert [stat.label for stat in after.speakers] == ["S1", "S2"]
+
+    # labels re-landed correctly under the new model
+    scored = [
+        (segment.speaker, _expected_label(segment.t0_ms, segment.t1_ms))
+        for segment in amended.manifest.transcript.segments
+    ]
+    comparable = [(got, want) for got, want in scored if want is not None]
+    matches = sum(1 for got, want in comparable if got == want)
+    assert matches / len(comparable) >= 0.8, f"re-attribution disagrees: {scored}"
+
+    # a repeat call with the SAME resolved model settles back to plain reuse
+    settled = pipeline.process_media(
+        str(TWO_VOICE_M4A), diarize_speakers=True, num_speakers=TWO_VOICE_NUM_SPEAKERS
+    )
+    assert settled.reused is True and settled.amended is False

--- a/tests/integration/test_pipeline_integration.py
+++ b/tests/integration/test_pipeline_integration.py
@@ -292,6 +292,32 @@ def test_russian_narration_detected_and_reported(integration_home: Path) -> None
     assert ocr.engine_params(transcript.language)["Rec.lang_type"] == "eslav"
 
 
+def test_word_search_stems_and_yo_on_the_russian_fixture(integration_home: Path) -> None:
+    """#16 acceptance on a real transcript: multi-word stems hit the
+    «кнопка отправки» segment (closing Russian case endings without any
+    stemmer), and a ё-spelled query finds the е-spelled transcript text."""
+    from tests.integration.fixture_facts import (
+        RU_M4A,
+        RU_STEM_QUERY,
+        RU_STEM_TARGET,
+        RU_YO_QUERY,
+    )
+
+    result = pipeline.process_media(str(RU_M4A))
+    stem_hits = search_manifest(result.manifest, RU_STEM_QUERY)
+    assert stem_hits, "multi-word stem query must hit the «кнопка отправки» segment"
+    assert all(hit.source == "transcript" for hit in stem_hits)
+    assert any(RU_STEM_TARGET in hit.text.lower() for hit in stem_hits)
+    yo_hits = search_manifest(result.manifest, RU_YO_QUERY)
+    assert yo_hits, "«ещё» must match the transcript's «еще» via ё→е folding"
+
+
+def test_multiword_search_reaches_ocr_text(demo: ProcessResult) -> None:
+    """#16 over the OCR index: both words live only on-screen together."""
+    hits = search_manifest(demo.manifest, "scene dashboard")
+    assert any(hit.source == "ocr" for hit in hits), hits
+
+
 def test_japanese_narration_autoselects_the_japan_ocr_pack(integration_home: Path) -> None:
     """The full v0.2.1 auto-OCR chain on a non-Cyrillic script: speech
     detected as ja → japan recognition pack engaged → the katakana heading

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -110,6 +110,82 @@ def test_search_empty_query_returns_nothing() -> None:
     assert search_manifest(make_manifest(), "   ") == []
 
 
+# --- word-level search + ё/е normalization (#16) -----------------------------
+
+
+def test_multiword_query_matches_all_words_in_any_order() -> None:
+    manifest = make_manifest()
+    # "The dashboard shows an error message." — words far apart, reversed order
+    hits = search_manifest(manifest, "error dashboard")
+    assert [hit.seq for hit in hits if hit.source == "transcript"] == [2]
+    # same tokens, original order, extra whitespace
+    assert search_manifest(manifest, "  dashboard   error ") == hits
+
+
+def test_multiword_query_requires_every_word() -> None:
+    manifest = make_manifest()
+    assert search_manifest(manifest, "dashboard checkout") == []
+
+
+def test_multiword_matches_ocr_text_too() -> None:
+    manifest = make_manifest()
+    hits = search_manifest(manifest, "scene settings")
+    assert [hit.source for hit in hits] == ["ocr"]
+    assert hits[0].frame_ms == 12012
+
+
+def test_single_word_behaves_like_the_old_exact_substring() -> None:
+    manifest = make_manifest()
+    for query in ("dashboard", "DASHBOARD", "  dashboard  ", "dashboa"):
+        hits = search_manifest(manifest, query)
+        assert [hit.source for hit in hits] == ["transcript", "ocr"], query
+    assert search_manifest(manifest, "dashboard error message") != []
+    assert search_manifest(manifest, "nonexistent") == []
+
+
+def test_yo_normalization_matches_both_ways() -> None:
+    manifest = make_manifest()
+    manifest.transcript.segments = [
+        type(manifest.transcript.segments[0])(
+            seq=1, t0_ms=0, t1_ms=2000, text="Нажмём на кнопку отправки."
+        ),
+        type(manifest.transcript.segments[0])(
+            seq=2, t0_ms=2500, t1_ms=4000, text="Ошибка все еще видна."
+        ),
+    ]
+    # ё in the text, е in the query — and the reverse
+    assert [h.seq for h in search_manifest(manifest, "нажмем")] == [1]
+    assert [h.seq for h in search_manifest(manifest, "ещё")] == [2]
+    # multi-word stems close Russian case endings («кнопк отправк» class)
+    assert [h.seq for h in search_manifest(manifest, "кнопк отправк")] == [1]
+
+
+def test_whitespace_only_tokens_return_nothing() -> None:
+    manifest = make_manifest()
+    assert search_manifest(manifest, " \t\n ") == []
+
+
+# --- search(speaker=) --------------------------------------------------------
+
+
+def test_speaker_filter_restricts_transcript_hits() -> None:
+    manifest = _diarized_manifest()  # S1: login + dashboard segs, S2: settings
+    all_hits = search_manifest(manifest, "the")
+    assert {hit.source for hit in all_hits} == {"transcript"}
+    s1_hits = search_manifest(manifest, "the", speaker="S1")
+    assert [hit.seq for hit in s1_hits] == [1, 2]
+    assert all(hit.speaker == "S1" for hit in s1_hits)
+    assert search_manifest(manifest, "login", speaker="S2") == []
+
+
+def test_speaker_filter_excludes_ocr_hits() -> None:
+    manifest = _diarized_manifest()
+    unfiltered = search_manifest(manifest, "dashboard")
+    assert "ocr" in {hit.source for hit in unfiltered}
+    filtered = search_manifest(manifest, "dashboard", speaker="S1")
+    assert filtered and all(hit.source == "transcript" for hit in filtered)
+
+
 def test_from_dict_tolerates_extra_free_form_versions(tmp_path: Path) -> None:
     manifest = make_manifest()
     payload = manifest.to_dict()

--- a/tests/unit/test_pipeline_config.py
+++ b/tests/unit/test_pipeline_config.py
@@ -165,6 +165,152 @@ def test_no_audio_job_never_amends(monkeypatch: pytest.MonkeyPatch) -> None:
     assert _needs_diarize_amend(manifest, request_for(monkeypatch, True, None)) is False
 
 
+# --- re-diarize on embedding-model change (v0.2.2) ----------------------------
+
+
+def emb_diarized(embedding_model: str | None) -> Diarization:
+    return Diarization(available=True, reason="", embedding_model=embedding_model)
+
+
+def test_explicit_diarize_amends_when_emb_model_changed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "TALKTHROUGH_DIARIZATION_EMB_MODEL", "wespeaker_en_voxceleb_resnet34_LM"
+    )
+    manifest = make_manifest()
+    manifest.transcript.diarization = emb_diarized(diarize.DEFAULT_EMBEDDING_MODEL)
+    assert _needs_diarize_amend(manifest, request_for(monkeypatch, True, None)) is True
+
+
+def test_matching_emb_model_reuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = make_manifest()
+    manifest.transcript.diarization = emb_diarized(diarize.DEFAULT_EMBEDDING_MODEL)
+    monkeypatch.delenv("TALKTHROUGH_DIARIZATION_EMB_MODEL", raising=False)
+    assert _needs_diarize_amend(manifest, request_for(monkeypatch, True, None)) is False
+    monkeypatch.setenv("TALKTHROUGH_DIARIZATION_EMB_MODEL", diarize.DEFAULT_EMBEDDING_MODEL)
+    assert _needs_diarize_amend(manifest, request_for(monkeypatch, True, None)) is False
+
+
+def test_emb_env_change_without_explicit_diarize_never_invalidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mirror of the whisper-model rule: only explicit intent re-runs."""
+    monkeypatch.setenv("TALKTHROUGH_DIARIZE", "on")
+    monkeypatch.setenv(
+        "TALKTHROUGH_DIARIZATION_EMB_MODEL", "wespeaker_en_voxceleb_resnet34_LM"
+    )
+    manifest = make_manifest()
+    manifest.transcript.diarization = emb_diarized(diarize.DEFAULT_EMBEDDING_MODEL)
+    assert _needs_diarize_amend(manifest, request_for(monkeypatch, None, None)) is False
+
+
+def test_local_onnx_path_env_counts_as_a_model_change(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    onnx = tmp_path / "custom.onnx"
+    onnx.write_bytes(b"onnx")
+    monkeypatch.setenv("TALKTHROUGH_DIARIZATION_EMB_MODEL", str(onnx))
+    manifest = make_manifest()
+    manifest.transcript.diarization = emb_diarized(diarize.DEFAULT_EMBEDDING_MODEL)
+    assert _needs_diarize_amend(manifest, request_for(monkeypatch, True, None)) is True
+    # a job stored FROM that path matches it on the next explicit call
+    manifest.transcript.diarization = emb_diarized(str(onnx))
+    assert _needs_diarize_amend(manifest, request_for(monkeypatch, True, None)) is False
+
+
+def test_manifest_without_emb_label_skips_the_emb_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "TALKTHROUGH_DIARIZATION_EMB_MODEL", "wespeaker_en_voxceleb_resnet34_LM"
+    )
+    manifest = make_manifest()
+    manifest.transcript.diarization = emb_diarized(None)
+    assert _needs_diarize_amend(manifest, request_for(monkeypatch, True, None)) is False
+
+
+def test_resolved_embedding_label_never_touches_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        diarize, "ensure_model_file", lambda spec: (_ for _ in ()).throw(AssertionError)
+    )
+    monkeypatch.delenv("TALKTHROUGH_DIARIZATION_EMB_MODEL", raising=False)
+    assert diarize.resolved_embedding_label() == diarize.DEFAULT_EMBEDDING_MODEL
+    monkeypatch.setenv("TALKTHROUGH_DIARIZATION_EMB_MODEL", "nemo_en_titanet_small")
+    assert diarize.resolved_embedding_label() == "nemo_en_titanet_small"
+    monkeypatch.setenv("TALKTHROUGH_DIARIZATION_EMB_MODEL", "~/models/x.onnx")
+    assert diarize.resolved_embedding_label().endswith("/models/x.onnx")
+    assert "~" not in diarize.resolved_embedding_label()
+
+
+# --- diarization_amended reflects the OUTCOME (v0.2.2 honesty fix) -------------
+
+
+def _stored_job(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """A real store entry whose job_id matches a real (tiny) media file."""
+    from talkthrough_mcp.core import jobs
+    from talkthrough_mcp.core.manifest import save_manifest
+
+    monkeypatch.setenv("TALKTHROUGH_HOME", str(tmp_path / "home"))
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"not really a video, only hashed")
+    job_id = jobs.compute_job_id(media)
+    manifest = make_manifest(job_id=job_id)
+    manifest.media = type(manifest.media)(
+        **{**manifest.media.__dict__, "path": str(media)}
+    )
+    directory = jobs.job_dir(job_id)
+    directory.mkdir(parents=True)
+    save_manifest(manifest, directory)
+    return media
+
+
+def _run_amend(media, monkeypatch: pytest.MonkeyPatch, *, succeed: bool):
+    from talkthrough_mcp.core import audio, pipeline
+    from talkthrough_mcp.core.diarize import Diarization
+
+    engine(monkeypatch, available=True)
+    monkeypatch.setattr(audio, "extract_wav", lambda *a, **k: None)
+
+    def fake_run(wav_path, transcript, request, report) -> None:
+        transcript.diarization = (
+            Diarization(available=True, reason="", detected_num_speakers=1)
+            if succeed
+            else Diarization(available=False, reason="model download failed: TLS")
+        )
+
+    monkeypatch.setattr(pipeline, "_run_diarization", fake_run)
+    return pipeline.process_media(str(media), diarize_speakers=True)
+
+
+def test_failed_amend_does_not_claim_diarization_amended(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from talkthrough_mcp.core import pipeline
+
+    media = _stored_job(tmp_path, monkeypatch)
+    result = _run_amend(media, monkeypatch, succeed=False)
+    assert result.reused is True
+    assert result.amended is False, "a failed amend must not be reported as applied"
+    summary = pipeline.summarize(result)
+    assert "diarization_amended" not in summary
+    assert summary["diarization"]["available"] is False
+    assert "TLS" in summary["diarization"]["reason"]
+
+
+def test_successful_amend_still_reports_the_flag(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from talkthrough_mcp.core import pipeline
+
+    media = _stored_job(tmp_path, monkeypatch)
+    result = _run_amend(media, monkeypatch, succeed=True)
+    assert result.amended is True
+    assert pipeline.summarize(result)["diarization_amended"] is True
+
+
 def test_whisper_loads_from_local_cache_first(monkeypatch: pytest.MonkeyPatch) -> None:
     """Warm loads must be zero-network: try local_files_only=True, download on miss.
 
@@ -229,12 +375,20 @@ def test_roster_payload_caps_and_counts_hidden() -> None:
     assert len(small_entries) == 3 and small_hidden == 0
 
 
-def test_summary_threshold_mode_flags_dust() -> None:
+def test_summary_threshold_mode_escalates_to_the_user() -> None:
+    """v0.2.2: over-detection no longer claims a 'likely headcount' (an
+    external eval falsified that: said 4, truth 2) — the note instructs the
+    agent to ASK THE USER and names the fast num_speakers amend."""
     from talkthrough_mcp.core.pipeline import _summarize_diarization
 
     block = _summarize_diarization(dusty_diarization(majors=5, dust=118))
-    assert block["speakers_with_30s_plus"] == 5
-    assert "threshold clustering" in block["note"]
+    assert block["speakers_with_30s_plus"] == 5  # still served — one signal of several
+    note = block["note"]
+    assert "NOT a headcount" in note
+    assert "ASK YOUR USER" in note
+    assert "num_speakers=N" in note
+    assert "whisper is not re-run" in note
+    assert "likely headcount" not in note  # the falsified claim is gone
     assert block["speakers_truncated"] == 111
 
     exact = dusty_diarization(majors=5, dust=0)

--- a/tests/unit/test_pipeline_config.py
+++ b/tests/unit/test_pipeline_config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from tests.conftest import make_manifest
 
@@ -241,8 +243,9 @@ def test_resolved_embedding_label_never_touches_network(
     monkeypatch.setenv("TALKTHROUGH_DIARIZATION_EMB_MODEL", "nemo_en_titanet_small")
     assert diarize.resolved_embedding_label() == "nemo_en_titanet_small"
     monkeypatch.setenv("TALKTHROUGH_DIARIZATION_EMB_MODEL", "~/models/x.onnx")
-    assert diarize.resolved_embedding_label().endswith("/models/x.onnx")
-    assert "~" not in diarize.resolved_embedding_label()
+    label = diarize.resolved_embedding_label()
+    assert label == str(Path("~/models/x.onnx").expanduser())  # platform-native
+    assert "~" not in label
 
 
 # --- diarization_amended reflects the OUTCOME (v0.2.2 honesty fix) -------------

--- a/tests/unit/test_server_tools.py
+++ b/tests/unit/test_server_tools.py
@@ -1,0 +1,91 @@
+"""Server-layer payload contracts: search(speaker=) honesty + media_kind.
+
+These drive the real tool functions against a manifest saved into an
+isolated store — the payload exactly as a client receives it, no MCP
+transport needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.conftest import make_manifest
+
+from talkthrough_mcp.core.diarize import Diarization, Turn, attribute_segments, speaker_roster
+from talkthrough_mcp.core.jobs import job_dir
+from talkthrough_mcp.core.manifest import Manifest, save_manifest
+
+
+def _store(manifest: Manifest) -> str:
+    directory = job_dir(manifest.job_id)
+    directory.mkdir(parents=True, exist_ok=True)
+    save_manifest(manifest, directory)
+    return manifest.job_id
+
+
+def _diarize(manifest: Manifest) -> Manifest:
+    turns = [Turn(0, 5000, "S1"), Turn(5000, 8000, "S2")]
+    manifest.transcript.segments = attribute_segments(manifest.transcript.segments, turns)
+    manifest.transcript.diarization = Diarization(
+        available=True,
+        reason="",
+        engine="sherpa-onnx",
+        detected_num_speakers=2,
+        speakers=speaker_roster(turns),
+        turns=turns,
+    )
+    return manifest
+
+
+# --- search(speaker=) on the wire --------------------------------------------
+
+
+def test_search_speaker_filters_and_notes_ocr_exclusion(isolated_home: Path) -> None:
+    from talkthrough_mcp.server import search
+
+    job_id = _store(_diarize(make_manifest()))
+    payload = search(job_id, "dashboard", speaker="s1")  # lowercase label normalized
+    assert payload["speaker"] == "S1"
+    assert payload["hit_count"] == 1
+    assert [hit["source"] for hit in payload["hits"]] == ["transcript"]
+    assert all(hit["speaker"] == "S1" for hit in payload["hits"])
+    assert "ocr hits are excluded" in payload["note"]
+
+    unfiltered = search(job_id, "dashboard")
+    assert "note" not in unfiltered
+    assert "speaker" not in {k for k in unfiltered if k != "hits"}
+    assert {hit["source"] for hit in unfiltered["hits"]} == {"transcript", "ocr"}
+
+
+def test_search_speaker_on_undiarized_job_is_honest_not_an_error(isolated_home: Path) -> None:
+    from talkthrough_mcp.server import search
+
+    job_id = _store(make_manifest())
+    payload = search(job_id, "dashboard", speaker="S2")
+    assert payload["hits"] == []
+    assert payload["hit_count"] == 0
+    assert payload["speaker"] == "S2"
+    assert "not diarized" in payload["note"]
+    assert "diarize=true" in payload["note"]
+
+
+def test_search_blank_speaker_means_no_filter(isolated_home: Path) -> None:
+    from talkthrough_mcp.server import search
+
+    job_id = _store(make_manifest())
+    payload = search(job_id, "dashboard", speaker="  ")
+    assert payload["hit_count"] == 2
+    assert "note" not in payload
+
+
+# --- media_kind in get_transcript --------------------------------------------
+
+
+def test_get_transcript_names_the_media_kind(isolated_home: Path) -> None:
+    from talkthrough_mcp.server import get_transcript
+
+    video_job = _store(make_manifest())
+    assert get_transcript(video_job)["media_kind"] == "video"
+
+    audio_job = _store(make_manifest(job_id="fedcba9876543210", kind="audio"))
+    assert get_transcript(audio_job)["media_kind"] == "audio"

--- a/tests/unit/test_stt_echo.py
+++ b/tests/unit/test_stt_echo.py
@@ -1,0 +1,83 @@
+"""trim_vocabulary_echo: drop initial_prompt echoes, never live speech.
+
+The real case (73-min RU meeting, v0.2.1 battery): whisper replayed the
+attendee vocabulary over the quiet opening seconds — two segments of
+nothing but name repeats swallowed the actual first words. The guard the
+plan demands: a live roll-call that HAPPENS to list the same names must
+survive, because real speech carries verbs and prepositions.
+"""
+
+from __future__ import annotations
+
+from talkthrough_mcp.core.stt import (
+    VOCAB_ECHO_WINDOW_MS,
+    SttSegment,
+    trim_vocabulary_echo,
+)
+
+VOCABULARY = "Анастасия, Диана, Влад, Евгений, Александр"
+
+
+def seg(seq: int, t0_ms: int, text: str, t1_ms: int | None = None) -> SttSegment:
+    return SttSegment(seq=seq, t0_ms=t0_ms, t1_ms=t1_ms or (t0_ms + 2000), text=text)
+
+
+def test_repeated_name_echo_is_trimmed() -> None:
+    segments = [
+        seg(1, 0, "Анастасия, Диана, Анастасия, Диана, Анастасия, Диана."),
+        seg(2, 3000, "Евгений мне сообщил, что вроде как Клод вы получили доступ."),
+    ]
+    kept, trimmed = trim_vocabulary_echo(segments, VOCABULARY)
+    assert [s.seq for s in kept] == [2]
+    assert [s.seq for s in trimmed] == [1]
+
+
+def test_verbatim_vocabulary_prefix_is_trimmed() -> None:
+    segments = [
+        seg(1, 500, "Анастасия, Диана, Влад, Евгений."),
+        seg(2, 4000, "Начинаем встречу."),
+    ]
+    kept, trimmed = trim_vocabulary_echo(segments, VOCABULARY)
+    assert [s.seq for s in kept] == [2]
+    assert len(trimmed) == 1
+
+
+def test_live_roll_call_with_connecting_words_survives() -> None:
+    """The mandatory guard: real speech listing the same names is NOT echo —
+    verbs/prepositions push the vocabulary fraction under the bar."""
+    segments = [
+        seg(1, 1000, "На встрече присутствуют Анастасия, Диана и Влад."),
+        seg(2, 5000, "Переходим к повестке."),
+    ]
+    kept, trimmed = trim_vocabulary_echo(segments, VOCABULARY)
+    assert [s.seq for s in kept] == [1, 2]
+    assert trimmed == []
+
+
+def test_echo_shaped_segment_after_the_window_survives() -> None:
+    late = VOCAB_ECHO_WINDOW_MS + 5000
+    segments = [seg(1, late, "Анастасия, Диана, Анастасия, Диана, Анастасия.")]
+    kept, trimmed = trim_vocabulary_echo(segments, VOCABULARY)
+    assert kept == segments
+    assert trimmed == []
+
+
+def test_short_pure_name_mention_survives() -> None:
+    # One or two vocabulary tokens with no repeats: a real vocative
+    # («Анастасия?»), not an echo — below the prefix minimum.
+    segments = [seg(1, 2000, "Анастасия?"), seg(2, 6000, "Анастасия, Диана?")]
+    kept, trimmed = trim_vocabulary_echo(segments, VOCABULARY)
+    assert [s.seq for s in kept] == [1, 2]
+    assert trimmed == []
+
+
+def test_empty_vocabulary_trims_nothing() -> None:
+    segments = [seg(1, 0, "Анастасия, Диана, Анастасия, Диана, Анастасия.")]
+    assert trim_vocabulary_echo(segments, "  ,  ") == (segments, [])
+
+
+def test_yo_normalization_applies_to_vocabulary_matching() -> None:
+    segments = [seg(1, 0, "Артем, Семен, Артем, Семен, Артем, Семен.")]
+    kept, trimmed = trim_vocabulary_echo(segments, "Артём, Семён")
+    assert kept == []
+    assert len(trimmed) == 1

--- a/tests/unit/test_stt_echo.py
+++ b/tests/unit/test_stt_echo.py
@@ -42,6 +42,29 @@ def test_verbatim_vocabulary_prefix_is_trimmed() -> None:
     assert len(trimmed) == 1
 
 
+def test_vocab_order_subsequence_echo_is_trimmed() -> None:
+    """The REAL echo shape observed on the 73-min meeting re-run: one pass
+    over the list with names dropped — no repeats, not a strict prefix, but
+    the vocabulary's own order, which live speech has no reason to follow."""
+    vocabulary = "Анастасия, Евгений, Владислав, Дмитрий, Алексей, Диана"
+    segments = [
+        seg(1, 1680, "Анастасия, Дмитрий, Алексей, Диана"),
+        seg(2, 61680, "Дальше про строительные блоки."),
+    ]
+    kept, trimmed = trim_vocabulary_echo(segments, vocabulary)
+    assert [s.seq for s in kept] == [2]
+    assert [s.seq for s in trimmed] == [1]
+
+
+def test_names_out_of_vocabulary_order_survive() -> None:
+    # Live addressing lists people in the speaker's order, not the list's —
+    # a reversed-order trio must NOT look like an echo.
+    segments = [seg(1, 2000, "Влад, Диана, Анастасия?")]
+    kept, trimmed = trim_vocabulary_echo(segments, VOCABULARY)
+    assert kept == segments
+    assert trimmed == []
+
+
 def test_live_roll_call_with_connecting_words_survives() -> None:
     """The mandatory guard: real speech listing the same names is NOT echo —
     verbs/prepositions push the vocabulary fraction under the bar."""

--- a/tests/unit/test_summarize.py
+++ b/tests/unit/test_summarize.py
@@ -32,3 +32,15 @@ def test_audio_only_summary_never_carries_the_frame_note() -> None:
     frames = _summary(duration_s=4380.0, kind="audio")["frames"]
     assert "sampling_interval_s" not in frames
     assert "note" not in frames
+
+
+def test_vocabulary_echo_count_appears_only_when_segments_were_dropped() -> None:
+    manifest = make_manifest()
+    plain = summarize(ProcessResult(manifest=manifest, reused=False, elapsed_s=1.0))
+    assert "vocabulary_echo_trimmed" not in plain["transcript"]
+    trimmed = summarize(
+        ProcessResult(
+            manifest=manifest, reused=False, elapsed_s=1.0, vocabulary_echo_trimmed=2
+        )
+    )
+    assert trimmed["transcript"]["vocabulary_echo_trimmed"] == 2

--- a/uv.lock
+++ b/uv.lock
@@ -1634,7 +1634,7 @@ wheels = [
 
 [[package]]
 name = "talkthrough-mcp"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "faster-whisper" },


### PR DESCRIPTION
Patch release per the fixed v0.2.2 plan: search ergonomics + honesty fixes, every item sourced from the v0.2.1 release battery or the external evaluation on a real corporate meeting. **Fully additive**: zero new manifest fields (schema `talkthrough-manifest/v1` untouched), no new tools, no new dependencies — new fields live in server responses only.

## What's in

1. **#16 — word-level search + ё/е normalization.** Multi-word queries AND-match every token as a substring (any order/distance); casefold + ё→е + NFC on both sides. Single-word behavior byte-stable. Real-data: «карточк справ» → «…увидеть карточку справа…» (transcript), «заявк» → spoken + on-screen bot reply (OCR).
2. **`search(speaker=)`** — transcript hits filtered to one voice (case-normalized); OCR hits excluded with a payload note; undiarized job → honest empty + actionable note. Real-data: «агент» on a 73-min RU meeting: 93 hits → 86 with `speaker="S3"` (exactly the S3 subset).
3. **Ask-user escalation on noisy clustering.** The falsified «likely headcount» claim (external eval: said 4, truth 2) is gone; threshold over-detection now serves an explicit instruction: *ask your user for the headcount, re-run with `num_speakers=N`, the amend is seconds*. Real-data cycle: 28-cluster job → note fires; after `num_speakers=5` amend → note gone.
4. **Vocabulary-echo trim** (0.2.1 finding): `initial_prompt` echoes in the opening ~90 s are dropped (≥80% vocab tokens AND repeat≥3 or near-verbatim prefix); live roll-call guard-tested. Summary reports `vocabulary_echo_trimmed`.
5. **Re-diarize on embedding-model change** — explicit `diarize=true` + changed `TALKTHROUGH_DIARIZATION_EMB_MODEL` re-runs diarization only (mirror of the whisper-model reuse rule); env change alone never invalidates.
6. **`diarization_amended` honesty** — the flag now reflects the outcome; a failed amend reports `available: false` + reason, no flag.
7. **`media_kind` in `get_transcript`** — closes the "audio-only" slip on video jobs (payload-over-description).
8. **Guidance pack** — findings-key canon in `triage-recording` (targets gpt-5.4-mini's `quotes[]`/`evidence[]` drift), on-screen speaker-mapping evidence (name plates / title card / active-speaker highlight) in `meeting-actions` + Agent Skill, meeting recipe (`large-v3-turbo` + `vocabulary` + `num_speakers`) in `process_media`.
9. **Windows wording** — "best-effort" label dropped from the CI job comment and docs; required-check promotion planned with the owner after a green week.
10. **Docs** — corporate-network env vars (`HF_HUB_DISABLE_XET=1`, `SSL_CERT_FILE`) in TROUBLESHOOTING; EN-homophone honesty sentence in MODEL-NOTES.

## Verification

- Full suite: **218 passed** (unit 179 + integration + e2e over real MCP stdio), ruff + mypy strict clean, generated-artifact drift gate green.
- Real-data on scratch copies of the production store (store itself read-only, mtime-verified): all six plan scenarios pass — details in the session report.
- Zero-network gate: 3 warm pipelines, 0 connect attempts. Hostile extended: 13/13.
- Mini-battery (sonnet/haiku/gpt-5.5-medium/gpt-5.4-mini × T6/T-search/T1-ask/T2): results land in this PR thread after the run completes.

Release notes: `CHANGELOG.md [0.2.2]`. Version bumped; `uv.lock` + generated integrations regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)