### PR TITLE
chore(ci): mark windows as a required check (live since v0.2.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,9 @@ jobs:
   # CLI smoke over the fixture (static-ffmpeg Windows build + whisper tiny +
   # OCR + idempotent re-run), plus a diarize smoke through the native
   # sherpa-onnx stack (the System32-onnxruntime DLL clash class breaks HERE,
-  # not at users'). Promotion to a required branch check happens with the
-  # repo owner after a green week on the release branch.
+  # not at users'). Required branch check since v0.2.2 (2026-07-18), together
+  # with linux and macos — its first day on duty it caught a real
+  # Windows-only path bug, which settled the promotion debate.
   windows:
     runs-on: windows-latest
     timeout-minutes: 30


### PR DESCRIPTION
Comment-only: the windows job's "promotion after a green week" note is superseded — required checks {linux, macos, windows} were enabled with the owner on 2026-07-18 (20 runs, zero flakes, one real Windows-only bug caught the same day). This PR also end-to-end validates the new protection: it must show all three checks green before the REST merge goes through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)