### PR TITLE
v0.2.3: fail-fast amend, honesty-contour closure, zero-hit search notes, longest_turn_ms

### DIFF
--- a/.agents/skills/talkthrough/SKILL.md
+++ b/.agents/skills/talkthrough/SKILL.md
@@ -50,7 +50,9 @@ install it: `claude mcp add -s user talkthrough -- uvx talkthrough-mcp`
 ## Timestamps
 
 Every timestamped result carries `t_ms` (video-relative) and, when the
-recording start is known, `t_wall` (ISO 8601 real time). Use `t_wall` to
+recording start is known, `t_wall` (ISO 8601 real time). Copy `t_wall`
+VERBATIM from the payload — never compute it from `t_ms` yourself
+(hand-derived wall-clocks drift by whole hours). Use `t_wall` to
 correlate remarks with server/app logs (±30 s grep window). If
 `wall_clock` is null or low-confidence, ask the user when the recording
 started and re-anchor: `process_media(path, recorded_at="<ISO 8601>",
@@ -70,11 +72,15 @@ method: `triage-recording` (screencast → findings JSON per the contract in
   by design — that error is expected, not a failure.
 - Speaker labels are anonymous (`S1`/`S2`, ordered by first voice). Mapping
   them to names is YOUR job: self-introductions, vocatives, the attendees
-  list — and on video jobs the screen itself (meeting-app name plates, the
-  recording's title card, the active-speaker highlight at that label's
-  `t_ms`). State the mapping explicitly and mark unmapped labels
-  "unidentified". `diarize=true` needs the `[diarization]` extra — its
-  absence produces an actionable install-hint error.
+  list — and on video jobs the screen check is MANDATORY: for every label
+  you map, `get_frames(at_ms=<that label's longest_turn_ms from the
+  roster>)` and read the meeting-app name plates, the recording's title
+  card, the active-speaker highlight BEFORE asserting the mapping. STT
+  homophones lie about name spellings (spoken "profit" vs on-screen
+  "Prophet") — trust OCR/frames over the transcript for names. State the
+  mapping explicitly and mark unmapped labels "unidentified".
+  `diarize=true` needs the `[diarization]` extra — its absence produces an
+  actionable install-hint error.
 - Findings/quotes must cite the narrator's exact words + `t_ms` (+ `t_wall`
   when known) + the frame files you actually inspected.
 - Low STT/vision confidence → surface a question; never silently guess.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketplace for the talkthrough plugin: narrated screen recordings in, agent-ready evidence out.",
-    "version": "0.2.2"
+    "version": "0.2.3"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,78 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [SemVer](https://semver.org/).
 
+## [0.2.3] — 2026-07-18
+
+Fail-fast and honesty-contour fixes, sourced from the same-day external
+evaluation of 0.2.2 and from holes that release itself introduced. Fully
+additive patch: the `talkthrough-manifest/v1` schema gains no fields, no
+new tools, no new dependencies — every new field lives in server responses
+only, so existing processed jobs serve the new data with no migration.
+
+### Fixed
+
+- **A failed explicit re-diarize no longer erases stored labels.** With the
+  0.2.2 embedding-model gate, a mistyped `TALKTHROUGH_DIARIZATION_EMB_MODEL`
+  plus `diarize=true` on a job with WORKING labels reached the amend path,
+  failed to build the engine, and overwrote good labels with
+  `available: false` (the 0.2.2 evaluation's one design caveat). The amend
+  now constructs the diarizer BEFORE the WAV extract and before any store
+  write: construction failures (bad model env, dead model download) raise a
+  clean tool error and the stored job stays byte-identical. The boundary,
+  documented in TROUBLESHOOTING: a failure *inside* diarization after
+  successful construction still degrades to `available: false` with the
+  reason, and a fresh (non-amend) run keeps degrading as before — there are
+  no labels to lose there.
+
+### Added
+
+- **The threshold-escalation note now reaches transcript-first agents.**
+  The ask-the-user note (over-detected threshold roster) lived only in the
+  `process_media` summary — an agent starting from `list_jobs` →
+  `get_transcript` never saw it (a 0.2.2 evaluation run mis-mapped a
+  speaker exactly that way). `get_transcript` headers now carry the same
+  byte-identical text as `diarization_note` next to the roster; absent on
+  jobs with an explicit `num_speakers` or a clean roster.
+- **`list_jobs` stops implying a headcount.** A diarized entry's
+  `"speakers"` field serves the raw detected count — on threshold-mode
+  over-detection that read as "28 people attended". Such entries now carry
+  `"speakers_with_30s_plus"` alongside; `"speakers"` itself is unchanged
+  for compatibility.
+- **Zero-hit searches explain themselves** (payload honesty, both notes new):
+  - `speaker=` with a label outside a diarized job's roster returns
+    `hits: []` plus a note naming the label and the valid range
+    (`label 'S99' is not in this job's roster (S1-S7)`) — an empty result
+    stops being indistinguishable from "that voice never said it".
+  - A multi-word query with zero hits gets a note explaining per-segment
+    word-AND matching; when the words DO meet across two adjacent segments
+    (the "recurring invites" class from the 0.2.2 evaluation), the note
+    names the spot: `the words appear together around t_ms=X … read
+    get_transcript there`. A cheap adjacent-pair scan, transcript only —
+    the hit contract, single-word behavior, and non-empty payloads are
+    byte-identical to 0.2.2.
+- **`longest_turn_ms` in every roster entry** (summary and `get_transcript`,
+  computed at serve time): the start of that speaker's longest turn — the
+  exact instant to pull frames for name plates / the active-speaker
+  highlight when mapping labels to people
+  (`get_frames(at_ms=<longest_turn_ms>)`).
+
+### Docs
+
+- Guidance pack, one regen: minutes/spec prompts now order "copy `t_wall`
+  VERBATIM from the payload — never compute it" (a 0.2.2 evaluation run
+  hand-derived one and slipped an hour); the meeting-actions screen check
+  is MANDATORY on video jobs and anchored at each label's
+  `longest_turn_ms` (uptake of the optional wording was probabilistic);
+  meeting-actions and triage-recording carry the homophone rule ("profit"
+  vs on-screen "Prophet" — trust OCR/frames for name spellings); the MCP
+  server `instructions` string gains one canon-keys sentence — an
+  experiment aimed at clients that read neither tool descriptions nor MCP
+  prompts, measured by the release battery.
+- TROUBLESHOOTING: "updated the plugin but the server is old" (running
+  sessions keep the MCP process until restart); the reprocess-cost rule
+  (explicit model change = full re-run, up to half the recording's duration
+  on a laptop — measured 65 min → 28.5 min); the fail-fast boundary above.
+
 ## [0.2.2] — 2026-07-18
 
 Search ergonomics and honesty fixes, each sourced from the v0.2.1 release

--- a/docs/MODEL-NOTES.md
+++ b/docs/MODEL-NOTES.md
@@ -5,6 +5,48 @@ models drift, sample sizes are small (n in every cell), and the corpus
 is one team's real recordings. Read it as "what tier of agent reliably
 drives this MCP for which job".*
 
+## v0.2.3 addendum (targeted battery, 2026-07-18)
+
+An 18-run battery (16 cells + 2 adjudication re-runs) on the v0.2.3
+server — the same four runner configs (haiku / sonnet / gpt-5.5 medium /
+gpt-5.4-mini low) on the same real recordings as the earlier grids, plus a
+39.7-min EN 3-speaker meeting and a stored 28-cluster threshold copy of
+the 73-min RU meeting. Every mechanical zero was adjudicated by reading
+the raw output (one was a checker artifact — a hedged «2–3 человека» range
+the hedge regex missed; no agent failures). Results:
+
+- **The MCP `instructions` channel REACHES codex — findings-key canon went
+  4/4** (v0.2.2: 2/4, Claude tiers only). One canon-keys sentence added to
+  the server's `initialize.instructions` («Triage findings JSON uses
+  EXACTLY the documented keys…») and both codex tiers emitted exactly
+  `quote`/`frame_refs` — including gpt-5.4-mini low, the runner that
+  neither description prose nor MCP prompt templates ever reach
+  (transcript-proven in v0.2.2). Two universal text channels now exist:
+  tool payloads and server instructions. The 0.3 canon-via-payload design
+  drops from "required" to "optional hardening".
+- **Escalation-note delivery via `get_transcript`: 4/4 without
+  re-processing.** Runners got ONLY a job id of a stored 28-cluster
+  threshold job («сколько людей говорило?») — every tier hedged or ranged
+  the headcount against cluster noise, zero confident wrong counts, zero
+  `process_media` calls. In 0.2.2 this note lived only in the
+  `process_media` summary, invisible on exactly this transcript-first
+  path.
+- **Speaker-mapping regression (meeting minutes on the 3-speaker EN
+  meeting): 6/6 runs mapped S1 = the presenter correctly; the 0.2.2-eval
+  failure shape (mapping the vocative target as the speaker) did not
+  recur.** Honest boundary: no headless runner pulled frames for the
+  screen check — the hardened MANDATORY step lives in prompt/skill text,
+  which `claude -p` does not auto-fetch and codex never fetches; it
+  reaches interactive clients (plugin command / server prompt users). The
+  payload half (`longest_turn_ms` in every roster entry) is served to all
+  clients; transcript evidence alone sufficed for the mapping here.
+- **T2 point-lookup regression: 4/4** (S2 + exact timestamp).
+- Harness lesson (recorded): a user-installed talkthrough plugin leaks its
+  STALE previous-release skill into headless `claude -p` runs — first-pass
+  cells consumed 0.2.2 skill text while testing the 0.2.3 server;
+  re-measured with the Skill tool disabled (same outcomes). Guidance-text
+  experiments must pin or disable installed plugins.
+
 ## v0.2.2 addendum (targeted battery, 2026-07-18)
 
 A 20-run battery on the v0.2.2 server — four runner configs (haiku /

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -59,6 +59,17 @@ create the venv from a modern interpreter, e.g. `python3.12 -m venv`.
 - Healthy state: the client lists 7 tools, and `list_jobs()` returns `[]` on
   a fresh install.
 
+## Updated the plugin, but the server behaves like the old version
+
+A running session keeps its MCP server process alive: `claude plugin update
+talkthrough` (or editing the version in any client's config) updates the
+files immediately, but the already-spawned server keeps serving the OLD
+version until the session/client restarts. Restart the session (or the
+client) after updating; headless and CI runs pick up the new version on
+their next launch because they spawn a fresh server every time. To verify
+what is actually running, check `tool_versions` in any `process_media`
+summary or manifest.
+
 ## Processing a long recording times out my agent call
 
 Pre-process outside the session, then query instantly:
@@ -79,6 +90,11 @@ same file is an instant re-call, and `list_jobs()` finds the job.
   `model="large-v3-turbo"` and `force=true`.
 - Domain jargon getting mangled: pass `vocabulary="Name1, Name2"` — it biases
   the decoder.
+- Budget note: an explicit model change reprocesses the WHOLE job (STT +
+  frames + OCR + diarization), not just the transcript — plan for up to half
+  the recording's own duration on a laptop (measured: a 65-minute 1080p
+  meeting took 28.5 minutes). Only a diarization-only change amends in
+  seconds.
 
 ## OCR misses on-screen text
 
@@ -138,6 +154,16 @@ TALKTHROUGH_DIARIZATION_EMB_MODEL=/models/embedding.onnx
 ```
 
 Paths are used verbatim, no network is touched.
+
+## A failed re-diarize keeps the stored labels
+
+Since 0.2.3, an explicit `diarize=true` on a job that already has working
+labels fails FAST when the engine cannot even be constructed (a mistyped
+`TALKTHROUGH_DIARIZATION_*_MODEL`, a dead model download): the call returns
+an error and the stored job — labels included — stays byte-identical. The
+boundary: a failure *inside* diarization after the engine constructed still
+degrades to `available: false` with the reason (the transcript always
+survives), and one clean amend restores labels.
 
 ## `t_wall` is null or looks wrong
 

--- a/examples/prompts/meeting-actions.md
+++ b/examples/prompts/meeting-actions.md
@@ -17,11 +17,17 @@ them, and that is fine.
 4. When segments carry speaker labels, map each label to a person before
    writing minutes. Evidence: self-introductions ("hi, this is Vera"),
    vocatives ("thanks, Tom"), the attendees list above — and, on video
-   jobs, the SCREEN: meeting-app name plates, the recording's title card
-   (who started/organized it), and the active-speaker highlight during that
-   speaker's t_ms all name people (get_moment at the moment, read frames +
-   OCR). State the mapping first (e.g. `S1 = Vera, S2 = Tom,
-   S3 = unidentified`) — never guess beyond the evidence.
+   jobs, the SCREEN. The screen check is MANDATORY on video jobs, not
+   optional: for EVERY label you map, call get_frames(job_id="<job_id>",
+   at_ms=<that label's longest_turn_ms from the roster>) and read the
+   meeting-app name plates, the recording's title card (who
+   started/organized it), and the active-speaker highlight BEFORE asserting
+   the mapping — vocative evidence alone mis-attributes (a remark spoken TO
+   Tom is routinely tagged as Tom speaking). Name spellings: STT
+   homophones lie (spoken "profit" vs on-screen "Prophet") — trust
+   OCR/frames over the transcript for names. State the mapping first (e.g.
+   `S1 = Vera, S2 = Tom, S3 = unidentified`) — never guess beyond the
+   evidence.
 5. Collect: action items (who committed to what), decisions (what was agreed),
    open questions (raised but unresolved). Keep exact quotes and t_ms for each.
 6. search(job_id="<job_id>", query="<name or topic>") to trace scattered
@@ -42,5 +48,8 @@ is diarized):
 
 Owners and dates come ONLY from spoken words — a commitment voiced by a mapped
 speaker counts ("I'll send it" spoken by S2 = Tom → owner: Tom); never infer
-beyond that. When unclear, write "unassigned"/"unspecified". Write the minutes
-in the meeting's language; quotes stay verbatim.
+beyond that. When unclear, write "unassigned"/"unspecified". Copy `t_wall`
+values VERBATIM from the payload — never compute them from t_ms yourself
+(hand-derived wall-clocks drift by whole hours; the correct value is already
+in the segment you are quoting). Write the minutes in the meeting's language;
+quotes stay verbatim.

--- a/examples/prompts/spec-from-workshop.md
+++ b/examples/prompts/spec-from-workshop.md
@@ -27,4 +27,5 @@ A markdown spec with these sections:
 5. **Open questions** — everything ambiguous or contested, with the quote that
    raised it. Do not resolve ambiguity yourself — surface it.
 
-Write the spec in the workshop's language; quotes stay verbatim.
+Copy `t_wall` values VERBATIM from the payload — never compute them from t_ms
+yourself. Write the spec in the workshop's language; quotes stay verbatim.

--- a/examples/prompts/triage-recording.md
+++ b/examples/prompts/triage-recording.md
@@ -38,6 +38,7 @@ Key names above are the contract — use them EXACTLY as written (`quote`,
 
 Rules: low STT/vision confidence → route="question" with a concrete question —
 never a silent guess. Findings without frame evidence (audio-only jobs) must say
-so in `frame_refs: []`. Write `digest` in the narrator's language (the
-transcript language); keep every `quote` verbatim in the original language —
-never translate quotes.
+so in `frame_refs: []`. STT homophones lie about name spellings (spoken
+"profit" vs on-screen "Prophet") — trust OCR/frames over the transcript for
+names. Write `digest` in the narrator's language (the transcript language);
+keep every `quote` verbatim in the original language — never translate quotes.

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "talkthrough",
   "description": "Turn narrated screen recordings into filed bugs, specs, backlogs and meeting actions. Bundles the talkthrough MCP server, five workflow commands, a triage agent, and an agent skill.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": {
     "name": "korovin-aa97",
     "url": "https://github.com/korovin-aa97"

--- a/integrations/claude-code/commands/meeting-actions.md
+++ b/integrations/claude-code/commands/meeting-actions.md
@@ -23,11 +23,17 @@ them, and that is fine.
 4. When segments carry speaker labels, map each label to a person before
    writing minutes. Evidence: self-introductions ("hi, this is Vera"),
    vocatives ("thanks, Tom"), the attendees list above — and, on video
-   jobs, the SCREEN: meeting-app name plates, the recording's title card
-   (who started/organized it), and the active-speaker highlight during that
-   speaker's t_ms all name people (get_moment at the moment, read frames +
-   OCR). State the mapping first (e.g. `S1 = Vera, S2 = Tom,
-   S3 = unidentified`) — never guess beyond the evidence.
+   jobs, the SCREEN. The screen check is MANDATORY on video jobs, not
+   optional: for EVERY label you map, call get_frames(job_id="$ARGUMENTS",
+   at_ms=<that label's longest_turn_ms from the roster>) and read the
+   meeting-app name plates, the recording's title card (who
+   started/organized it), and the active-speaker highlight BEFORE asserting
+   the mapping — vocative evidence alone mis-attributes (a remark spoken TO
+   Tom is routinely tagged as Tom speaking). Name spellings: STT
+   homophones lie (spoken "profit" vs on-screen "Prophet") — trust
+   OCR/frames over the transcript for names. State the mapping first (e.g.
+   `S1 = Vera, S2 = Tom, S3 = unidentified`) — never guess beyond the
+   evidence.
 5. Collect: action items (who committed to what), decisions (what was agreed),
    open questions (raised but unresolved). Keep exact quotes and t_ms for each.
 6. search(job_id="$ARGUMENTS", query="<name or topic>") to trace scattered
@@ -48,5 +54,8 @@ is diarized):
 
 Owners and dates come ONLY from spoken words — a commitment voiced by a mapped
 speaker counts ("I'll send it" spoken by S2 = Tom → owner: Tom); never infer
-beyond that. When unclear, write "unassigned"/"unspecified". Write the minutes
-in the meeting's language; quotes stay verbatim.
+beyond that. When unclear, write "unassigned"/"unspecified". Copy `t_wall`
+values VERBATIM from the payload — never compute them from t_ms yourself
+(hand-derived wall-clocks drift by whole hours; the correct value is already
+in the segment you are quoting). Write the minutes in the meeting's language;
+quotes stay verbatim.

--- a/integrations/claude-code/commands/spec-from-workshop.md
+++ b/integrations/claude-code/commands/spec-from-workshop.md
@@ -33,4 +33,5 @@ A markdown spec with these sections:
 5. **Open questions** — everything ambiguous or contested, with the quote that
    raised it. Do not resolve ambiguity yourself — surface it.
 
-Write the spec in the workshop's language; quotes stay verbatim.
+Copy `t_wall` values VERBATIM from the payload — never compute them from t_ms
+yourself. Write the spec in the workshop's language; quotes stay verbatim.

--- a/integrations/claude-code/commands/triage-recording.md
+++ b/integrations/claude-code/commands/triage-recording.md
@@ -44,6 +44,7 @@ Key names above are the contract — use them EXACTLY as written (`quote`,
 
 Rules: low STT/vision confidence → route="question" with a concrete question —
 never a silent guess. Findings without frame evidence (audio-only jobs) must say
-so in `frame_refs: []`. Write `digest` in the narrator's language (the
-transcript language); keep every `quote` verbatim in the original language —
-never translate quotes.
+so in `frame_refs: []`. STT homophones lie about name spellings (spoken
+"profit" vs on-screen "Prophet") — trust OCR/frames over the transcript for
+names. Write `digest` in the narrator's language (the transcript language);
+keep every `quote` verbatim in the original language — never translate quotes.

--- a/integrations/claude-code/skills/talkthrough/SKILL.md
+++ b/integrations/claude-code/skills/talkthrough/SKILL.md
@@ -50,7 +50,9 @@ install it: `claude mcp add -s user talkthrough -- uvx talkthrough-mcp`
 ## Timestamps
 
 Every timestamped result carries `t_ms` (video-relative) and, when the
-recording start is known, `t_wall` (ISO 8601 real time). Use `t_wall` to
+recording start is known, `t_wall` (ISO 8601 real time). Copy `t_wall`
+VERBATIM from the payload — never compute it from `t_ms` yourself
+(hand-derived wall-clocks drift by whole hours). Use `t_wall` to
 correlate remarks with server/app logs (±30 s grep window). If
 `wall_clock` is null or low-confidence, ask the user when the recording
 started and re-anchor: `process_media(path, recorded_at="<ISO 8601>",
@@ -70,11 +72,15 @@ method: `triage-recording` (screencast → findings JSON per the contract in
   by design — that error is expected, not a failure.
 - Speaker labels are anonymous (`S1`/`S2`, ordered by first voice). Mapping
   them to names is YOUR job: self-introductions, vocatives, the attendees
-  list — and on video jobs the screen itself (meeting-app name plates, the
-  recording's title card, the active-speaker highlight at that label's
-  `t_ms`). State the mapping explicitly and mark unmapped labels
-  "unidentified". `diarize=true` needs the `[diarization]` extra — its
-  absence produces an actionable install-hint error.
+  list — and on video jobs the screen check is MANDATORY: for every label
+  you map, `get_frames(at_ms=<that label's longest_turn_ms from the
+  roster>)` and read the meeting-app name plates, the recording's title
+  card, the active-speaker highlight BEFORE asserting the mapping. STT
+  homophones lie about name spellings (spoken "profit" vs on-screen
+  "Prophet") — trust OCR/frames over the transcript for names. State the
+  mapping explicitly and mark unmapped labels "unidentified".
+  `diarize=true` needs the `[diarization]` extra — its absence produces an
+  actionable install-hint error.
 - Findings/quotes must cite the narrator's exact words + `t_ms` (+ `t_wall`
   when known) + the frame files you actually inspected.
 - Low STT/vision confidence → surface a question; never silently guess.

--- a/integrations/claude-desktop/manifest.json
+++ b/integrations/claude-desktop/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "talkthrough",
   "display_name": "Talkthrough — narrated recordings for your agent",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Turn narrated screen recordings into structured evidence: local Whisper transcript, scene keyframes, OCR, wall-clock anchoring. Record, talk — Claude files the bugs.",
   "author": {
     "name": "korovin-aa97",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "talkthrough-mcp"
-version = "0.2.2"
+version = "0.2.3"
 description = "Local-first MCP server that turns narrated screen recordings into agent-ready structured data: timestamped transcript, scene keyframes, OCR text, and wall-clock anchoring."
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/korovin-aa97/talkthrough-mcp",
     "source": "github"
   },
-  "version": "0.2.2",
+  "version": "0.2.3",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "talkthrough-mcp",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/talkthrough_mcp/core/manifest.py
+++ b/src/talkthrough_mcp/core/manifest.py
@@ -7,6 +7,7 @@ reads from here — the source media is only re-read by ``extract_frame``.
 
 from __future__ import annotations
 
+import itertools
 import json
 import unicodedata
 from dataclasses import asdict, dataclass, field
@@ -364,3 +365,31 @@ def search_manifest(
             )
     hits.sort(key=lambda hit: hit.t_ms)
     return hits
+
+
+def straddle_hint_t_ms(
+    manifest: Manifest, query: str, *, speaker: str | None = None
+) -> int | None:
+    """``t0_ms`` of the first ADJACENT segment pair whose combined text
+    matches every query token — the cheap cross-boundary check behind the
+    zero-hit search note.
+
+    Word-AND is per-segment BY CONTRACT (#16); a phrase split over a segment
+    boundary ("recurring | invites") legitimately misses, and the note should
+    say where the words do meet instead of leaving the miss indistinguishable
+    from "never said". Same normalization as the search itself. OCR text
+    stays out — frames are not contiguous prose. With ``speaker`` both
+    segments of the pair must be that speaker's, mirroring the filter the
+    zero-hit search ran under. Not a search mode: the hit contract is
+    untouched, this feeds one prose note.
+    """
+    tokens = _fold_for_search(query).split()
+    if len(tokens) < 2:
+        return None
+    for first, second in itertools.pairwise(manifest.transcript.segments):
+        if speaker is not None and (first.speaker != speaker or second.speaker != speaker):
+            continue
+        combined = _fold_for_search(first.text + " " + second.text)
+        if all(token in combined for token in tokens):
+            return first.t0_ms
+    return None

--- a/src/talkthrough_mcp/core/pipeline.py
+++ b/src/talkthrough_mcp/core/pipeline.py
@@ -223,16 +223,22 @@ def _run_diarization(
     transcript: Transcript,
     request: _DiarizeRequest,
     report: ProgressFn,
+    diarizer: diarize.Diarizer | None = None,
 ) -> None:
     """Diarize the WAV and attach turns/roster/speakers to the transcript.
 
     Any engine failure (model download, native error) degrades to
     ``diarization.available=false`` with the reason — the transcript always
     survives. Only the fail-fast in ``_resolve_diarize_request`` raises.
+    ``diarizer`` lets the amend path hand in an engine it already constructed
+    (its fail-fast contract needs construction errors raised BEFORE any store
+    write); fresh runs construct here and degrade on failure — there are no
+    stored labels to lose.
     """
     report(DIARIZE_STAGE, DIARIZE_PROGRESS_START)
     try:
-        diarizer = diarize.create_diarizer()
+        if diarizer is None:
+            diarizer = diarize.create_diarizer()
         if diarizer is None:
             transcript.diarization = Diarization(
                 available=False, reason=diarize.MISSING_EXTRA_REASON
@@ -302,14 +308,31 @@ def _amend_diarization(
 
     Whisper is not re-run; stored segments are re-attributed in place and the
     manifest is re-saved. ``created_at`` stays — the job identity is the same.
+
+    Fail-fast (v0.2.3): the engine is constructed BEFORE the WAV extract and
+    before any store write. An amend may target a job whose stored labels are
+    good, and an engine that cannot even construct (mistyped
+    ``TALKTHROUGH_DIARIZATION_*_MODEL``, dead model download) is the caller's
+    env/network problem — it must not overwrite those labels with
+    ``available:false``. The ``ValidationError``/``ToolFailureError``
+    propagates (server → clean tool error) and the store stays byte-identical.
+    A failure INSIDE diarization after successful construction still degrades
+    with a reason, like a fresh run — that boundary is documented in
+    TROUBLESHOOTING.
     """
+    report("loading diarization models", 0.05)
+    diarizer = diarize.create_diarizer()
+    if diarizer is None:
+        # unreachable through the tool layer (explicit requests without the
+        # extra fail in _resolve_diarize_request) — kept for direct callers
+        raise ValidationError(diarize.MISSING_EXTRA_REASON)
     directory = jobs.job_dir(manifest.job_id)
     tool_timeout = max(600, int(manifest.media.duration_s * 4) + 120)
     wav_path = directory / "audio.wav"
     report("extracting audio", 0.10)
     try:
         audio.extract_wav(media, wav_path, timeout=tool_timeout)
-        _run_diarization(wav_path, manifest.transcript, request, report)
+        _run_diarization(wav_path, manifest.transcript, request, report, diarizer=diarizer)
     finally:
         wav_path.unlink(missing_ok=True)
     report("writing manifest", 0.99)
@@ -538,6 +561,54 @@ SUMMARY_ROSTER_CAP = 12
 SUBSTANTIAL_TALK_MS = 30_000
 
 
+def substantial_speaker_count(diarization: Diarization) -> int:
+    """Speakers with >= 30 s of attributed talk time — one signal among
+    several, never a headcount claim (an external eval falsified the
+    "likely headcount" reading: it said 4 on a true-2 meeting)."""
+    return sum(1 for s in diarization.speakers if s.talk_time_ms >= SUBSTANTIAL_TALK_MS)
+
+
+def threshold_escalation_note(diarization: Diarization) -> str | None:
+    """The ask-the-user note for threshold-mode over-detection, or None.
+
+    Fires when threshold clustering (no ``requested_num_speakers``) detected
+    more clusters than have substantial talk time. ONE text, byte-identical
+    on every surface that serves it (``process_media`` summary,
+    ``get_transcript`` header) — an agent starting from either entry point
+    must meet the same escalation contract; a summary-only note never reaches
+    transcript-first agents.
+    """
+    if not diarization.available or diarization.requested_num_speakers is not None:
+        return None
+    if substantial_speaker_count(diarization) >= (diarization.detected_num_speakers or 0):
+        return None
+    return (
+        "threshold clustering over-detected on this recording — the cluster "
+        "count is unreliable and is NOT a headcount. ASK YOUR USER how many "
+        "people actually spoke (the talk_time_ms roster above shows which "
+        "voices dominate), then re-run process_media(diarize=true, "
+        "num_speakers=N) — the amend takes seconds, whisper is not re-run"
+    )
+
+
+def _longest_turn_starts(diarization: Diarization) -> dict[str, int]:
+    """label → ``t0_ms`` of that speaker's longest turn (ties → the earliest).
+
+    Serve-time only, computed from the stored turns — the manifest schema
+    stays untouched. This is the "where to LOOK" anchor for screen-evidence
+    speaker mapping: ``get_frames(at_ms=<longest_turn_ms>)`` lands
+    mid-monologue, where name plates and the active-speaker highlight are
+    most likely to show the person actually talking.
+    """
+    best: dict[str, tuple[int, int]] = {}
+    for turn in diarization.turns:
+        duration = turn.t1_ms - turn.t0_ms
+        current = best.get(turn.speaker)
+        if current is None or (duration, -turn.t0_ms) > (current[0], -current[1]):
+            best[turn.speaker] = (duration, turn.t0_ms)
+    return {label: t0_ms for label, (_, t0_ms) in best.items()}
+
+
 def roster_payload(diarization: Diarization) -> tuple[list[dict[str, Any]], int]:
     """Top speakers by talk time, capped for the token budget.
 
@@ -548,8 +619,16 @@ def roster_payload(diarization: Diarization) -> tuple[list[dict[str, Any]], int]
     """
     ranked = sorted(diarization.speakers, key=lambda s: -s.talk_time_ms)[:SUMMARY_ROSTER_CAP]
     kept = {stat.label for stat in ranked}
+    longest = _longest_turn_starts(diarization)
     entries = [
-        {"label": stat.label, "talk_time_ms": stat.talk_time_ms, "turn_count": stat.turn_count}
+        {
+            "label": stat.label,
+            "talk_time_ms": stat.talk_time_ms,
+            "turn_count": stat.turn_count,
+            **(
+                {"longest_turn_ms": longest[stat.label]} if stat.label in longest else {}
+            ),
+        }
         for stat in diarization.speakers
         if stat.label in kept
     ]
@@ -571,24 +650,13 @@ def _summarize_diarization(diarization: Diarization) -> dict[str, Any]:
     if diarization.requested_num_speakers is not None:
         payload["requested_num_speakers"] = diarization.requested_num_speakers
     else:
-        substantial = sum(
-            1 for s in diarization.speakers if s.talk_time_ms >= SUBSTANTIAL_TALK_MS
-        )
-        if substantial < (diarization.detected_num_speakers or 0):
-            # threshold-mode honesty (v0.2.2): the cluster count is NOT a
-            # headcount, and no server heuristic is trusted to guess one — an
-            # external eval falsified speakers_with_30s_plus as "likely
-            # headcount" (said 4, truth 2). The user always knows their own
-            # meeting: escalate to them, with the talk-time roster as the
-            # material for the question.
-            payload["speakers_with_30s_plus"] = substantial
-            payload["note"] = (
-                "threshold clustering over-detected on this recording — the cluster "
-                "count is unreliable and is NOT a headcount. ASK YOUR USER how many "
-                "people actually spoke (the talk_time_ms roster above shows which "
-                "voices dominate), then re-run process_media(diarize=true, "
-                "num_speakers=N) — the amend takes seconds, whisper is not re-run"
-            )
+        # threshold-mode honesty (v0.2.2): the cluster count is NOT a
+        # headcount, and no server heuristic is trusted to guess one — the
+        # note escalates to the user, who always knows their own meeting.
+        note = threshold_escalation_note(diarization)
+        if note is not None:
+            payload["speakers_with_30s_plus"] = substantial_speaker_count(diarization)
+            payload["note"] = note
     return payload
 
 

--- a/src/talkthrough_mcp/guidance.py
+++ b/src/talkthrough_mcp/guidance.py
@@ -268,9 +268,10 @@ Key names above are the contract — use them EXACTLY as written (`quote`,
 
 Rules: low STT/vision confidence → route="question" with a concrete question —
 never a silent guess. Findings without frame evidence (audio-only jobs) must say
-so in `frame_refs: []`. Write `digest` in the narrator's language (the
-transcript language); keep every `quote` verbatim in the original language —
-never translate quotes.
+so in `frame_refs: []`. STT homophones lie about name spellings (spoken
+"profit" vs on-screen "Prophet") — trust OCR/frames over the transcript for
+names. Write `digest` in the narrator's language (the transcript language);
+keep every `quote` verbatim in the original language — never translate quotes.
 """,
     "spec-from-workshop": """\
 You are a product engineer writing a spec from a recorded workshop / design
@@ -302,7 +303,8 @@ A markdown spec with these sections:
 5. **Open questions** — everything ambiguous or contested, with the quote that
    raised it. Do not resolve ambiguity yourself — surface it.
 
-Write the spec in the workshop's language; quotes stay verbatim.
+Copy `t_wall` values VERBATIM from the payload — never compute them from t_ms
+yourself. Write the spec in the workshop's language; quotes stay verbatim.
 """,
     "backlog-from-demo": """\
 You are a product owner turning a recorded product demo into a prioritized
@@ -351,11 +353,17 @@ them, and that is fine.
 4. When segments carry speaker labels, map each label to a person before
    writing minutes. Evidence: self-introductions ("hi, this is Vera"),
    vocatives ("thanks, Tom"), the attendees list above — and, on video
-   jobs, the SCREEN: meeting-app name plates, the recording's title card
-   (who started/organized it), and the active-speaker highlight during that
-   speaker's t_ms all name people (get_moment at the moment, read frames +
-   OCR). State the mapping first (e.g. `S1 = Vera, S2 = Tom,
-   S3 = unidentified`) — never guess beyond the evidence.
+   jobs, the SCREEN. The screen check is MANDATORY on video jobs, not
+   optional: for EVERY label you map, call get_frames(job_id="{job_id}",
+   at_ms=<that label's longest_turn_ms from the roster>) and read the
+   meeting-app name plates, the recording's title card (who
+   started/organized it), and the active-speaker highlight BEFORE asserting
+   the mapping — vocative evidence alone mis-attributes (a remark spoken TO
+   Tom is routinely tagged as Tom speaking). Name spellings: STT
+   homophones lie (spoken "profit" vs on-screen "Prophet") — trust
+   OCR/frames over the transcript for names. State the mapping first (e.g.
+   `S1 = Vera, S2 = Tom, S3 = unidentified`) — never guess beyond the
+   evidence.
 5. Collect: action items (who committed to what), decisions (what was agreed),
    open questions (raised but unresolved). Keep exact quotes and t_ms for each.
 6. search(job_id="{job_id}", query="<name or topic>") to trace scattered
@@ -376,8 +384,11 @@ is diarized):
 
 Owners and dates come ONLY from spoken words — a commitment voiced by a mapped
 speaker counts ("I'll send it" spoken by S2 = Tom → owner: Tom); never infer
-beyond that. When unclear, write "unassigned"/"unspecified". Write the minutes
-in the meeting's language; quotes stay verbatim.
+beyond that. When unclear, write "unassigned"/"unspecified". Copy `t_wall`
+values VERBATIM from the payload — never compute them from t_ms yourself
+(hand-derived wall-clocks drift by whole hours; the correct value is already
+in the segment you are quoting). Write the minutes in the meeting's language;
+quotes stay verbatim.
 """,
     "correlate-with-logs": """\
 You are debugging with two evidence streams: a narrated recording (talkthrough

--- a/src/talkthrough_mcp/server.py
+++ b/src/talkthrough_mcp/server.py
@@ -23,7 +23,7 @@ from mcp.types import ToolAnnotations
 
 from . import guidance
 from .core import jobs, pipeline
-from .core.diarize import speakers_in_range
+from .core.diarize import Diarization, speakers_in_range
 from .core.errors import AudioOnlyJobError, TalkthroughError
 from .core.frames import Frame, extract_exact_frame
 from .core.manifest import (
@@ -36,6 +36,7 @@ from .core.manifest import (
     representative_frame,
     search_manifest,
     slice_segments,
+    straddle_hint_t_ms,
 )
 
 GET_FRAMES_HARD_CAP = 6
@@ -72,7 +73,13 @@ mcp = FastMCP(
         "not wait to be asked who spoke (num_speakers=N whenever the headcount is "
         "known). Server prompts "
         "(triage-recording, spec-from-workshop, backlog-from-demo, meeting-actions, "
-        "correlate-with-logs) package the common workflows."
+        "correlate-with-logs) package the common workflows. "
+        # v0.2.3 EXPERIMENT: initialize.instructions is the one text channel
+        # not yet falsified for clients that read neither descriptions nor MCP
+        # prompts (codex) — the canon-keys sentence rides here, measured by
+        # the release battery; harmless for everyone else.
+        "Triage findings JSON uses EXACTLY the documented keys (quote, frame_refs, "
+        "t_ms, …) — no renames, no wrappers."
     ),
 )
 
@@ -223,6 +230,12 @@ def get_transcript(
         payload["speakers"], hidden = pipeline.roster_payload(diarization)
         if hidden:
             payload["speakers_truncated"] = hidden
+        escalation = pipeline.threshold_escalation_note(diarization)
+        if escalation is not None:
+            # additive (v0.2.3): the same byte-identical text the process
+            # summary carries — agents that start transcript-first (list_jobs
+            # → get_transcript) never see that summary
+            payload["diarization_note"] = escalation
     if format == "segments":
         payload["segments"] = [
             {
@@ -371,24 +384,58 @@ def search(job_id: str, query: str, speaker: str | None = None) -> dict[str, Any
                     "process_media(diarize=true) to add them (fast amend), then filter"
                 ),
             }
+        roster_labels = [stat.label for stat in diarization.speakers]
+        if roster_labels and speaker_label not in roster_labels:
+            # honesty again (v0.2.3): a label outside the roster would return
+            # a bare empty list indistinguishable from "this voice never said
+            # it" — name the mistake and the valid range instead
+            span = (
+                roster_labels[0]
+                if len(roster_labels) == 1
+                else f"{roster_labels[0]}-{roster_labels[-1]}"
+            )
+            return {
+                "job_id": job_id,
+                "query": query,
+                "speaker": speaker_label,
+                "hit_count": 0,
+                "truncated": False,
+                "hits": [],
+                "note": (
+                    f"label {speaker_label!r} is not in this job's roster ({span}) — "
+                    "0 hits here means the label does not exist, not that the words "
+                    "were never said; use a roster label"
+                ),
+            }
     hits = search_manifest(manifest, query, speaker=speaker_label)
     truncated = len(hits) > SEARCH_MAX_HITS
+    notes: list[str] = []
+    if speaker_label:
+        notes.append(
+            "ocr hits are excluded when filtering by speaker — on-screen text has no voice"
+        )
+    if not hits and len(query.split()) >= 2:
+        # v0.2.3: a zero-hit multi-word query stops being mute. Word-AND is
+        # per-segment; the cheap adjacent-pair scan tells apart "phrase
+        # straddles a segment boundary" from "words never co-occur".
+        straddle_ms = straddle_hint_t_ms(manifest, query, speaker=speaker_label)
+        if straddle_ms is not None:
+            notes.append(
+                f"the words appear together around t_ms={straddle_ms}, split across "
+                "adjacent segments (matching is per-segment) — read get_transcript there"
+            )
+        else:
+            notes.append(
+                "no single segment contains ALL the words (matching is per-segment, "
+                "any order) — drop a word or shorten the stems"
+            )
     return {
         "job_id": job_id,
         "query": query,
         **({"speaker": speaker_label} if speaker_label else {}),
         "hit_count": len(hits),
         "truncated": truncated,
-        **(
-            {
-                "note": (
-                    "ocr hits are excluded when filtering by speaker — "
-                    "on-screen text has no voice"
-                )
-            }
-            if speaker_label
-            else {}
-        ),
+        **({"note": "; ".join(notes)} if notes else {}),
         "hits": [
             {
                 "source": hit.source,
@@ -444,6 +491,17 @@ def extract_frame(
     return [_json_block(meta), Image(path=out_path)]
 
 
+def _job_speakers(diarization: Diarization) -> dict[str, Any]:
+    """The list_jobs speaker block: the raw detected count, plus the 30s+
+    signal when threshold mode over-detected — a bare ``"speakers": 28`` on
+    such jobs reads as a headcount, the exact claim the escalation note
+    exists to prevent (the count stays for compatibility)."""
+    payload: dict[str, Any] = {"speakers": diarization.detected_num_speakers}
+    if pipeline.threshold_escalation_note(diarization) is not None:
+        payload["speakers_with_30s_plus"] = pipeline.substantial_speaker_count(diarization)
+    return payload
+
+
 @mcp.tool(description=guidance.TOOL_DESCRIPTIONS["list_jobs"], annotations=READONLY_TOOL)
 def list_jobs() -> dict[str, Any]:
     manifests = jobs.list_jobs()
@@ -464,7 +522,7 @@ def list_jobs() -> dict[str, Any]:
                 "frames_unique": manifest.frames.unique_count,
                 "frames_total": manifest.frames.count,
                 **(
-                    {"speakers": manifest.transcript.diarization.detected_num_speakers}
+                    _job_speakers(manifest.transcript.diarization)
                     if manifest.transcript.diarization is not None
                     and manifest.transcript.diarization.available
                     else {}

--- a/tests/e2e/test_mcp_client.py
+++ b/tests/e2e/test_mcp_client.py
@@ -171,6 +171,16 @@ async def _run_session(home: Path) -> None:
         assert undiarized_filter["hits"] == []
         assert "not diarized" in undiarized_filter["note"]
 
+        # 5c. v0.2.3: a zero-hit multi-word query explains the per-segment
+        # matching instead of returning a mute empty list.
+        zero_multi = _payload(
+            await session.call_tool(
+                "search", {"job_id": job_id, "query": "login zzznonexistent"}
+            )
+        )
+        assert zero_multi["hit_count"] == 0
+        assert "no single segment contains ALL the words" in zero_multi["note"]
+
         # 6. SRT export is well-formed; v0.2.2: the payload names the media kind.
         srt_result = await session.call_tool(
             "get_transcript", {"job_id": job_id, "format": "srt"}
@@ -219,6 +229,11 @@ async def _run_session(home: Path) -> None:
             assert block["available"] is True
             assert block["detected_num_speakers"] == TWO_VOICE_NUM_SPEAKERS
             assert [speaker["label"] for speaker in block["speakers"]] == ["S1", "S2"]
+            # v0.2.3: the roster carries the screen-check anchor on the wire
+            assert all(
+                isinstance(speaker["longest_turn_ms"], int)
+                for speaker in block["speakers"]
+            )
             assert any(
                 segment.get("speaker")
                 for segment in diarized_summary["transcript"]["preview_segments"]
@@ -248,6 +263,21 @@ async def _run_session(home: Path) -> None:
             assert s1_hits["hits"], "S1 speaks first — 'the' must hit her turns"
             assert all(hit["speaker"] == "S1" for hit in s1_hits["hits"])
             assert "ocr hits are excluded" in s1_hits["note"]
+
+            # v0.2.3: a label outside the roster names the roster instead of
+            # returning a mute empty list
+            bogus_label = _payload(
+                await session.call_tool(
+                    "search",
+                    {
+                        "job_id": diarized_summary["job_id"],
+                        "query": "the",
+                        "speaker": "S99",
+                    },
+                )
+            )
+            assert bogus_label["hits"] == []
+            assert "not in this job's roster (S1-S2)" in bogus_label["note"]
         else:
             failed = await session.call_tool(
                 "process_media",

--- a/tests/integration/test_diarization_integration.py
+++ b/tests/integration/test_diarization_integration.py
@@ -29,6 +29,7 @@ from tests.integration.fixture_facts import (
 )
 
 from talkthrough_mcp.core import diarize, jobs, pipeline
+from talkthrough_mcp.core.errors import ValidationError
 from talkthrough_mcp.core.pipeline import ProcessResult
 
 pytestmark = [
@@ -151,7 +152,9 @@ def test_summary_carries_compact_diarization_block(two_voice: ProcessResult) -> 
     assert block["available"] is True
     assert block["detected_num_speakers"] == TWO_VOICE_NUM_SPEAKERS
     assert block["requested_num_speakers"] == TWO_VOICE_NUM_SPEAKERS
-    assert {"label", "talk_time_ms", "turn_count"} == set(block["speakers"][0])
+    assert {"label", "talk_time_ms", "turn_count", "longest_turn_ms"} == set(
+        block["speakers"][0]
+    )
     preview = summary["transcript"]["preview_segments"]
     assert any(entry.get("speaker") for entry in preview)
 
@@ -184,7 +187,17 @@ def test_get_transcript_serves_speakers_roster_and_prefixes(two_voice: ProcessRe
     payload = get_transcript(job_id)
     assert payload["diarized"] is True
     assert [entry["label"] for entry in payload["speakers"]] == ["S1", "S2"]
-    assert {"label", "talk_time_ms", "turn_count"} == set(payload["speakers"][0])
+    assert {"label", "talk_time_ms", "turn_count", "longest_turn_ms"} == set(
+        payload["speakers"][0]
+    )
+    # the anchor points INSIDE one of that speaker's stored turns
+    diarization = two_voice.manifest.transcript.diarization
+    assert diarization is not None
+    for entry in payload["speakers"]:
+        own_turns = [t for t in diarization.turns if t.speaker == entry["label"]]
+        assert any(t.t0_ms == entry["longest_turn_ms"] for t in own_turns)
+        longest = max(own_turns, key=lambda t: t.t1_ms - t.t0_ms)
+        assert entry["longest_turn_ms"] == longest.t0_ms
     speakers_seen = {entry.get("speaker") for entry in payload["segments"]}
     assert {"S1", "S2"} <= speakers_seen
 
@@ -332,3 +345,46 @@ def test_explicit_diarize_amends_on_embedding_model_change(
         str(TWO_VOICE_M4A), diarize_speakers=True, num_speakers=TWO_VOICE_NUM_SPEAKERS
     )
     assert settled.reused is True and settled.amended is False
+
+
+def test_failed_amend_construction_leaves_stored_labels_untouched(
+    two_voice: ProcessResult, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """v0.2.3 fail-fast — the 0.2.2-eval failure injection, end-to-end: a
+    fat-fingered TALKTHROUGH_DIARIZATION_EMB_MODEL + explicit diarize=true
+    on a job with WORKING labels errors out (store byte-identical) instead
+    of overwriting them with available:false; correcting the env amends
+    cleanly right after. Runs last: the recovery amend mutates the two-voice
+    job (back to the session's default embedding model)."""
+    good_emb = os.environ["TALKTHROUGH_DIARIZATION_EMB_MODEL"]
+    manifest_path = jobs.job_dir(two_voice.manifest.job_id) / "manifest.json"
+    stored = jobs.load_job(two_voice.manifest.job_id).transcript.diarization
+    assert stored is not None and stored.available
+    before = manifest_path.read_bytes()
+
+    monkeypatch.setenv("TALKTHROUGH_DIARIZATION_EMB_MODEL", "nemo_titanet_smal")
+
+    def boom(*args: object, **kwargs: object) -> None:
+        raise AssertionError("whisper must not re-run during a failed amend")
+
+    monkeypatch.setattr(pipeline.stt, "transcribe", boom)
+    with pytest.raises(ValidationError, match="nemo_titanet_smal"):
+        pipeline.process_media(
+            str(TWO_VOICE_M4A), diarize_speakers=True, num_speakers=TWO_VOICE_NUM_SPEAKERS
+        )
+    assert manifest_path.read_bytes() == before, "store must stay byte-identical"
+    survivor = jobs.load_job(two_voice.manifest.job_id).transcript.diarization
+    assert survivor is not None and survivor.available
+    assert [stat.label for stat in survivor.speakers] == ["S1", "S2"]
+
+    # recovery: fixed env (differs from the stored wespeaker labels) → the
+    # same call now amends and lands fresh labels
+    monkeypatch.setenv("TALKTHROUGH_DIARIZATION_EMB_MODEL", good_emb)
+    recovered = pipeline.process_media(
+        str(TWO_VOICE_M4A), diarize_speakers=True, num_speakers=TWO_VOICE_NUM_SPEAKERS
+    )
+    assert recovered.reused is True and recovered.amended is True
+    after = recovered.manifest.transcript.diarization
+    assert after is not None and after.available
+    assert after.embedding_model == good_emb
+    assert [stat.label for stat in after.speakers] == ["S1", "S2"]

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -28,6 +28,7 @@ from talkthrough_mcp.core.manifest import (
     save_manifest,
     search_manifest,
     slice_segments,
+    straddle_hint_t_ms,
 )
 from talkthrough_mcp.core.wallclock import WallClock
 
@@ -184,6 +185,40 @@ def test_speaker_filter_excludes_ocr_hits() -> None:
     assert "ocr" in {hit.source for hit in unfiltered}
     filtered = search_manifest(manifest, "dashboard", speaker="S1")
     assert filtered and all(hit.source == "transcript" for hit in filtered)
+
+
+# --- adjacent-pair straddle hint (v0.2.3 zero-hit note) -----------------------
+
+
+def test_straddle_hint_names_the_first_boundary_pair() -> None:
+    manifest = make_manifest()
+    # "dashboard settings" never lands in ONE segment but meets across 2|3
+    assert search_manifest(manifest, "dashboard settings") == []
+    assert straddle_hint_t_ms(manifest, "dashboard settings") == 2500
+    # same normalization as the search: case + ё/е fold
+    assert straddle_hint_t_ms(manifest, "DASHBOARD Settings") == 2500
+    # words that never meet even across adjacent segments
+    assert straddle_hint_t_ms(manifest, "login settings") is None
+    # single-word queries never produce the hint (behavior unchanged there)
+    assert straddle_hint_t_ms(manifest, "dashboard") is None
+
+
+def test_straddle_hint_ignores_ocr_text() -> None:
+    """Frames are not contiguous prose — OCR stays out of the pair scan."""
+    manifest = make_manifest()
+    # "scene settings" HITS ocr (one frame), so the note never fires for it —
+    # but even a zero-hit ocr-only combination must not produce a hint
+    assert straddle_hint_t_ms(manifest, "scene checkout") is None
+
+
+def test_straddle_hint_respects_the_speaker_filter() -> None:
+    manifest = _diarized_manifest()  # segments 1,2 → S1; segment 3 → S2
+    assert straddle_hint_t_ms(manifest, "login error") == 0  # pair 1|2, both S1
+    assert straddle_hint_t_ms(manifest, "login error", speaker="S1") == 0
+    assert straddle_hint_t_ms(manifest, "login error", speaker="S2") is None
+    # pair 2|3 spans two voices — not offered under either single-voice filter
+    assert straddle_hint_t_ms(manifest, "dashboard settings") == 2500
+    assert straddle_hint_t_ms(manifest, "dashboard settings", speaker="S1") is None
 
 
 def test_from_dict_tolerates_extra_free_form_versions(tmp_path: Path) -> None:

--- a/tests/unit/test_pipeline_config.py
+++ b/tests/unit/test_pipeline_config.py
@@ -9,7 +9,7 @@ from tests.conftest import make_manifest
 
 from talkthrough_mcp.core import diarize
 from talkthrough_mcp.core.diarize import Diarization
-from talkthrough_mcp.core.errors import ValidationError
+from talkthrough_mcp.core.errors import ToolFailureError, ValidationError
 from talkthrough_mcp.core.pipeline import (
     ALLOWED_WHISPER_MODELS,
     DEFAULT_WHISPER_MODEL,
@@ -275,9 +275,12 @@ def _run_amend(media, monkeypatch: pytest.MonkeyPatch, *, succeed: bool):
     from talkthrough_mcp.core.diarize import Diarization
 
     engine(monkeypatch, available=True)
+    # the amend path constructs the engine BEFORE touching anything (v0.2.3
+    # fail-fast) — stub it so unit runs never resolve real models
+    monkeypatch.setattr(diarize, "create_diarizer", lambda: object())
     monkeypatch.setattr(audio, "extract_wav", lambda *a, **k: None)
 
-    def fake_run(wav_path, transcript, request, report) -> None:
+    def fake_run(wav_path, transcript, request, report, diarizer=None) -> None:
         transcript.diarization = (
             Diarization(available=True, reason="", detected_num_speakers=1)
             if succeed
@@ -312,6 +315,109 @@ def test_successful_amend_still_reports_the_flag(
     result = _run_amend(media, monkeypatch, succeed=True)
     assert result.amended is True
     assert pipeline.summarize(result)["diarization_amended"] is True
+
+
+# --- fail-fast failed amend (v0.2.3): construction errors leave the store alone
+
+
+def _stored_diarized_job(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """A stored job with GOOD labels whose next explicit call must amend
+    (stored requested k=2, the test calls with k=3)."""
+    from talkthrough_mcp.core import jobs
+    from talkthrough_mcp.core.diarize import SpeakerStat, Turn
+    from talkthrough_mcp.core.manifest import save_manifest
+
+    monkeypatch.setenv("TALKTHROUGH_HOME", str(tmp_path / "home"))
+    media = tmp_path / "meeting.mp4"
+    media.write_bytes(b"two voices, only ever hashed")
+    job_id = jobs.compute_job_id(media)
+    manifest = make_manifest(job_id=job_id)
+    manifest.media = type(manifest.media)(
+        **{**manifest.media.__dict__, "path": str(media)}
+    )
+    turns = [Turn(0, 5000, "S1"), Turn(5000, 8000, "S2")]
+    manifest.transcript.diarization = Diarization(
+        available=True,
+        reason="",
+        requested_num_speakers=2,
+        detected_num_speakers=2,
+        speakers=[
+            SpeakerStat(label="S1", talk_time_ms=5000, turn_count=1, first_ms=0, last_ms=5000),
+            SpeakerStat(label="S2", talk_time_ms=3000, turn_count=1, first_ms=5000, last_ms=8000),
+        ],
+        turns=turns,
+    )
+    directory = jobs.job_dir(job_id)
+    directory.mkdir(parents=True)
+    save_manifest(manifest, directory)
+    return media, directory / "manifest.json"
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ValidationError(
+            "TALKTHROUGH_DIARIZATION_EMB_MODEL='nemo_titanet_smal' is neither a known "
+            "model name nor an existing .onnx file"
+        ),
+        ToolFailureError("sherpa-onnx rejected the diarization model config"),
+    ],
+)
+def test_amend_construction_failure_fails_fast_and_leaves_the_store_alone(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, exc: Exception
+) -> None:
+    """The 0.2.2-eval caveat: a failed explicit re-diarize must not clobber
+    good stored labels. An engine that cannot even CONSTRUCT (mistyped model
+    env, dead download) now raises before the WAV extract and before any
+    manifest write — the store stays byte-identical."""
+    from talkthrough_mcp.core import audio, jobs, pipeline
+
+    media, manifest_path = _stored_diarized_job(tmp_path, monkeypatch)
+    before = manifest_path.read_bytes()
+    engine(monkeypatch, available=True)
+
+    def refuse_construction():
+        raise exc
+
+    monkeypatch.setattr(diarize, "create_diarizer", refuse_construction)
+
+    def no_extract(*args: object, **kwargs: object) -> None:
+        raise AssertionError("fail-fast must fire BEFORE the WAV extract")
+
+    monkeypatch.setattr(audio, "extract_wav", no_extract)
+    with pytest.raises((ValidationError, ToolFailureError)) as caught:
+        pipeline.process_media(str(media), diarize_speakers=True, num_speakers=3)
+    assert str(caught.value) == str(exc)
+    assert manifest_path.read_bytes() == before, "manifest must stay byte-identical"
+    stored = jobs.load_job(jobs.compute_job_id(media)).transcript.diarization
+    assert stored is not None and stored.available
+    assert [stat.label for stat in stored.speakers] == ["S1", "S2"]
+
+
+def test_fresh_run_construction_failure_still_degrades(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fail-fast is amend-only: a fresh pipeline has no labels to lose,
+    so a construction failure keeps degrading to available:false + reason."""
+    from talkthrough_mcp.core.manifest import Transcript
+    from talkthrough_mcp.core.pipeline import _run_diarization
+
+    def refuse_construction():
+        raise ToolFailureError("could not download diarization model: network down")
+
+    monkeypatch.setattr(diarize, "create_diarizer", refuse_construction)
+    transcript = Transcript(
+        available=True, reason="", language="en", model="tiny", segments=[]
+    )
+    _run_diarization(
+        Path("/nonexistent.wav"),
+        transcript,
+        request_for(monkeypatch, True, None),
+        lambda stage, fraction: None,
+    )
+    assert transcript.diarization is not None
+    assert transcript.diarization.available is False
+    assert "network down" in transcript.diarization.reason
 
 
 def test_whisper_loads_from_local_cache_first(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -398,3 +504,70 @@ def test_summary_threshold_mode_escalates_to_the_user() -> None:
     exact.requested_num_speakers = 5
     block = _summarize_diarization(exact)
     assert "note" not in block and "speakers_with_30s_plus" not in block
+
+
+def test_threshold_escalation_note_is_one_text_on_every_surface() -> None:
+    """v0.2.3: the note is a helper both the summary and get_transcript
+    serve — byte-identical, and absent outside threshold over-detection."""
+    from talkthrough_mcp.core.pipeline import (
+        _summarize_diarization,
+        threshold_escalation_note,
+    )
+
+    dusty = dusty_diarization(majors=5, dust=118)
+    note = threshold_escalation_note(dusty)
+    assert note is not None
+    assert note == _summarize_diarization(dusty)["note"]
+
+    clean = dusty_diarization(majors=3, dust=0)
+    assert threshold_escalation_note(clean) is None
+
+    requested = dusty_diarization(majors=5, dust=118)
+    requested.requested_num_speakers = 5
+    assert threshold_escalation_note(requested) is None
+
+    failed = Diarization(available=False, reason="engine exploded")
+    assert threshold_escalation_note(failed) is None
+
+
+# --- longest_turn_ms roster anchor (v0.2.3) ------------------------------------
+
+
+def test_roster_payload_carries_longest_turn_anchor() -> None:
+    """label → t0_ms of the speaker's longest turn; equal durations resolve
+    to the EARLIEST turn — deterministic regardless of stored turn order."""
+    from talkthrough_mcp.core.diarize import Turn, speaker_roster
+    from talkthrough_mcp.core.pipeline import roster_payload
+
+    turns = [
+        Turn(0, 4000, "S1"),
+        Turn(4000, 5000, "S2"),
+        Turn(5000, 9000, "S1"),  # ties the first S1 turn at 4000 ms
+        Turn(9000, 20000, "S2"),
+    ]
+    diarization = Diarization(
+        available=True,
+        reason="",
+        detected_num_speakers=2,
+        speakers=speaker_roster(turns),
+        turns=turns,
+    )
+    entries, hidden = roster_payload(diarization)
+    assert hidden == 0
+    by_label = {entry["label"]: entry for entry in entries}
+    assert by_label["S1"]["longest_turn_ms"] == 0  # 4000ms tie → earliest t0
+    assert by_label["S2"]["longest_turn_ms"] == 9000  # 11000ms beats 1000ms
+
+    shuffled = Diarization(
+        available=True,
+        reason="",
+        detected_num_speakers=2,
+        speakers=speaker_roster(turns),
+        turns=list(reversed(turns)),
+    )
+    shuffled_entries, _ = roster_payload(shuffled)
+    assert shuffled_entries == entries, "tie-break must not depend on turn order"
+
+    no_turns = dusty_diarization(majors=2, dust=0)
+    bare_entries, _ = roster_payload(no_turns)
+    assert all("longest_turn_ms" not in entry for entry in bare_entries)

--- a/tests/unit/test_server_tools.py
+++ b/tests/unit/test_server_tools.py
@@ -89,3 +89,148 @@ def test_get_transcript_names_the_media_kind(isolated_home: Path) -> None:
 
     audio_job = _store(make_manifest(job_id="fedcba9876543210", kind="audio"))
     assert get_transcript(audio_job)["media_kind"] == "audio"
+
+
+# --- v0.2.3 honesty contour: the escalation note reaches every entry point ----
+
+
+def _dusty_threshold(manifest: Manifest) -> Manifest:
+    """A threshold-mode over-detected job: 2 substantial voices + 26 dust
+    clusters (the real A360 shape), no requested_num_speakers."""
+    from talkthrough_mcp.core.diarize import SpeakerStat, Turn
+
+    turns = [Turn(0, 40_000, "S1"), Turn(40_000, 75_000, "S2")]
+    dust = [
+        SpeakerStat(
+            label=f"S{i + 3}", talk_time_ms=1_500, turn_count=1,
+            first_ms=75_000, last_ms=76_500,
+        )
+        for i in range(26)
+    ]
+    manifest.transcript.segments = attribute_segments(manifest.transcript.segments, turns)
+    manifest.transcript.diarization = Diarization(
+        available=True,
+        reason="",
+        engine="sherpa-onnx",
+        detected_num_speakers=28,
+        threshold=0.5,
+        speakers=speaker_roster(turns) + dust,
+        turns=turns,
+    )
+    return manifest
+
+
+def test_get_transcript_serves_the_escalation_note_byte_identical(
+    isolated_home: Path,
+) -> None:
+    from talkthrough_mcp.core import pipeline
+    from talkthrough_mcp.server import get_transcript
+
+    job_id = _store(_dusty_threshold(make_manifest()))
+    payload = get_transcript(job_id)
+    manifest = _dusty_threshold(make_manifest())
+    diarization = manifest.transcript.diarization
+    assert diarization is not None
+    expected = pipeline.threshold_escalation_note(diarization)
+    assert expected is not None
+    assert payload["diarization_note"] == expected
+    assert payload["diarization_note"] == pipeline._summarize_diarization(diarization)["note"]
+
+
+def test_get_transcript_has_no_note_on_clean_or_k_jobs(isolated_home: Path) -> None:
+    from talkthrough_mcp.core.diarize import Turn
+    from talkthrough_mcp.server import get_transcript
+
+    # clean threshold job: every detected voice is substantial (>=30 s)
+    clean_manifest = make_manifest()
+    turns = [Turn(0, 40_000, "S1"), Turn(40_000, 75_000, "S2")]
+    clean_manifest.transcript.segments = attribute_segments(
+        clean_manifest.transcript.segments, turns
+    )
+    clean_manifest.transcript.diarization = Diarization(
+        available=True,
+        reason="",
+        engine="sherpa-onnx",
+        detected_num_speakers=2,
+        threshold=0.5,
+        speakers=speaker_roster(turns),
+        turns=turns,
+    )
+    clean_job = _store(clean_manifest)
+    assert "diarization_note" not in get_transcript(clean_job)
+
+    k_manifest = _dusty_threshold(make_manifest(job_id="fedcba9876543210"))
+    diarization = k_manifest.transcript.diarization
+    assert diarization is not None
+    diarization.requested_num_speakers = 28  # explicit k → the user already decided
+    k_job = _store(k_manifest)
+    assert "diarization_note" not in get_transcript(k_job)
+
+
+def test_list_jobs_carries_the_30s_signal_only_on_overdetected_jobs(
+    isolated_home: Path,
+) -> None:
+    from talkthrough_mcp.server import list_jobs
+
+    threshold_job = _store(_dusty_threshold(make_manifest()))
+    k_manifest = _diarize(make_manifest(job_id="fedcba9876543210"))
+    diarization = k_manifest.transcript.diarization
+    assert diarization is not None
+    diarization.requested_num_speakers = 2
+    k_job = _store(k_manifest)
+
+    entries = {entry["job_id"]: entry for entry in list_jobs()["jobs"]}
+    assert entries[threshold_job]["speakers"] == 28  # existing field, unchanged
+    assert entries[threshold_job]["speakers_with_30s_plus"] == 2
+    assert entries[k_job]["speakers"] == 2
+    assert "speakers_with_30s_plus" not in entries[k_job]
+
+
+# --- v0.2.3 search notes: unknown label + zero-hit multi-word ------------------
+
+
+def test_search_unknown_speaker_label_names_the_roster(isolated_home: Path) -> None:
+    from talkthrough_mcp.server import search
+
+    job_id = _store(_diarize(make_manifest()))
+    payload = search(job_id, "dashboard", speaker="s99")
+    assert payload["hits"] == [] and payload["hit_count"] == 0
+    assert payload["speaker"] == "S99"
+    assert "not in this job's roster (S1-S2)" in payload["note"]
+    assert "'S99'" in payload["note"]
+
+
+def test_search_zero_hit_multiword_notes_explain_the_miss(isolated_home: Path) -> None:
+    from talkthrough_mcp.server import search
+
+    job_id = _store(make_manifest())
+    # "dashboard settings" straddles segments 2|3 → the note names the spot
+    straddle = search(job_id, "dashboard settings")
+    assert straddle["hit_count"] == 0
+    assert "t_ms=2500" in straddle["note"]
+    assert "get_transcript" in straddle["note"]
+    # "login settings" never meets even across adjacent segments → generic note
+    generic = search(job_id, "login settings")
+    assert generic["hit_count"] == 0
+    assert "no single segment contains ALL the words" in generic["note"]
+    # single-word zero hit: behavior unchanged — no note at all
+    single = search(job_id, "flurble")
+    assert single["hit_count"] == 0 and "note" not in single
+    # non-zero-hit payloads stay note-free
+    hit = search(job_id, "dashboard error")
+    assert hit["hit_count"] >= 1 and "note" not in hit
+
+
+def test_search_zero_hit_multiword_respects_the_speaker_filter(
+    isolated_home: Path,
+) -> None:
+    """The straddle scan mirrors the filter: a pair split across two voices
+    must not be offered to a single-voice query."""
+    from talkthrough_mcp.server import search
+
+    job_id = _store(_diarize(make_manifest()))
+    payload = search(job_id, "dashboard settings", speaker="S1")
+    assert payload["hit_count"] == 0
+    assert "ocr hits are excluded" in payload["note"]  # 0.2.2 note survives, joined
+    assert "no single segment contains ALL the words" in payload["note"]
+    assert "t_ms=" not in payload["note"]  # segments 2|3 are S1|S2 — not S1's pair

--- a/uv.lock
+++ b/uv.lock
@@ -1634,7 +1634,7 @@ wheels = [
 
 [[package]]
 name = "talkthrough-mcp"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "faster-whisper" },


### PR DESCRIPTION
Patch release per the owner-fixed 2026-07-18 plan. Fully additive: **zero manifest-schema changes, no new tools, no new dependencies** — every new field lives in server responses only; existing jobs serve everything with no migration.

## What ships

1. **Fail-fast failed amends** (the 0.2.2 external evaluation's one design caveat). An explicit `diarize=true` on a job with working labels used to overwrite them with `available:false` when the engine couldn't even construct (mistyped `TALKTHROUGH_DIARIZATION_*_MODEL`, dead download). The amend now constructs the diarizer BEFORE the WAV extract and any store write; construction errors raise a clean tool error and the store stays **byte-identical** (sha256-checked in tests). Post-construction runtime failures still degrade with a reason; fresh runs unchanged.
2. **Escalation note reaches transcript-first agents**: `get_transcript` headers on over-detected threshold jobs carry `diarization_note` — byte-identical to the summary note (one helper feeds both surfaces).
3. **`list_jobs` stops implying headcounts**: over-detected entries add `speakers_with_30s_plus` next to the untouched `speakers` field.
4. **Zero-hit search notes**: unknown `speaker=` label names the roster range (`'S99' is not in this job's roster (S1-S5)`); zero-hit multi-word queries explain per-segment matching, and when the words meet across adjacent segments the note names the exact `t_ms` (cheap pair scan; hit contract, single-word behavior and non-empty payloads byte-stable).
5. **`longest_turn_ms`** in every roster entry (summary + `get_transcript`, serve-time) — the anchor for screen-evidence speaker mapping.
6. **Guidance pack** (one regen): `t_wall` VERBATIM rule; MANDATORY screen check anchored at `longest_turn_ms`; homophone rule (trust OCR for name spellings); canon-keys sentence in server `instructions` — the instructions-channel experiment.
7. **TROUBLESHOOTING**: plugin update vs live sessions; explicit-model-change reprocess cost (65 min → 28.5 min measured); the fail-fast boundary.

## Evidence

- **Suite 235 passed** (3-OS CI pending on this PR); ruff/mypy strict clean; drift + guidance gates green; zero-network gate 0 connect attempts; hostile extended 13/13; real `~/.talkthrough` mtime-verified untouched.
- **Real-data probes 19/19** on scratch clones: А360 threshold copy (28 raw clusters) serves the note + both list_jobs fields; k=5 copy serves neither; S99 note names S1-S5; real straddle on a 39.7-min EN meeting («repository called» → note names t_ms=620420); fail-fast injection leaves the manifest sha256-identical with labels alive.
- **Mini-battery 18 runs** (haiku / sonnet / gpt-5.5 medium / gpt-5.4-mini low), every zero adjudicated:
  - **T6 findings canon 4/4 — the instructions channel REACHES codex** (v0.2.2 baseline: 2/4, Claude only; both codex tiers invented schemas). gpt-5.4-mini emitted exactly `quote`/`frame_refs`.
  - **T-note 4/4**: stored 28-cluster job, transcript-first entry — every tier hedged/asked, zero re-processing (the note now arrives via `get_transcript`).
  - **T-map 6/6**: S1 = presenter mapped correctly on the 3-speaker EN meeting; the 0.2.2-eval mis-mapping shape did not recur. Honest boundary in MODEL-NOTES: headless runners don't fetch prompt/skill text, so the MANDATORY screen-check step reaches interactive clients only; `longest_turn_ms` (payload) is served to everyone.
  - **T2 regression 4/4.**

Sources: the two external evaluation reports of 0.2.1/0.2.2 (repo-root working copies, untracked) and the v0.2.2 release battery. Plan deviations are listed in the owner report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)