### PR TITLE
fix(ocr): declare the engine argument positional-only (unblocks #32)

### DIFF
--- a/src/talkthrough_mcp/core/ocr.py
+++ b/src/talkthrough_mcp/core/ocr.py
@@ -66,7 +66,11 @@ _V5_REC_PACKS = frozenset(
 
 
 class OcrEngine(Protocol):  # pragma: no cover - typing only
-    def __call__(self, content: str) -> Any: ...
+    # Positional-only (`/`): RapidOCR names the argument `img_content`, and a
+    # named protocol parameter would demand that exact keyword. rapidocr 3.9.2
+    # shipped `py.typed`, which is what first made the mismatch visible — the
+    # frame path has always been passed positionally.
+    def __call__(self, content: str, /) -> Any: ...
 
 
 def ocr_enabled() -> bool:

--- a/tests/unit/test_ocr_engine.py
+++ b/tests/unit/test_ocr_engine.py
@@ -1,0 +1,44 @@
+"""The engine call contract: the frame path reaches RapidOCR positionally.
+
+RapidOCR names its first parameter ``img_content``, so a keyword call would
+raise ``TypeError`` against the real engine — and ``ocr_image`` swallows
+exceptions, so the regression would surface as silently empty OCR text on
+every frame rather than as a crash. ``OcrEngine`` declares the argument
+positional-only to pin that down; rapidocr 3.9.2 shipping ``py.typed`` is
+what first made the mismatch visible to mypy.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from talkthrough_mcp.core.ocr import OcrEngine, ocr_image
+
+
+class _RapidOcrLike:
+    """Mirrors the real ``RapidOCR.__call__`` parameter name and defaults."""
+
+    def __init__(self, *texts: str) -> None:
+        self._texts = texts
+        self.seen: list[str] = []
+
+    def __call__(self, img_content: str, use_det: bool | None = None) -> Any:
+        self.seen.append(img_content)
+        return SimpleNamespace(txts=self._texts)
+
+
+def test_protocol_declares_the_frame_path_positional_only() -> None:
+    parameters = list(inspect.signature(OcrEngine.__call__).parameters.values())
+    assert parameters[1].kind is inspect.Parameter.POSITIONAL_ONLY
+
+
+def test_ocr_image_calls_an_img_content_engine_positionally(tmp_path: Path) -> None:
+    frame = tmp_path / "frame-000001.jpg"
+    frame.touch()
+    engine = _RapidOcrLike("  Build failed  ", "", "exit code 1")
+
+    assert ocr_image(engine, frame) == "Build failed exit code 1"
+    assert engine.seen == [str(frame)]


### PR DESCRIPTION
## Why

Dependabot #32 (`rapidocr` 3.9.1 → 3.9.2) fails the required `linux` check on `uv run mypy src`:

```
src/talkthrough_mcp/core/ocr.py:156: error: Incompatible types in assignment
(expression has type "RapidOCR", variable has type "OcrEngine")  [assignment]
```

**rapidocr 3.9.2 ships a `py.typed` marker** (3.9.1 does not — verified by unpacking both wheels). mypy therefore stops treating `RapidOCR` as `Any` and starts matching it against our protocol:

```python
# src/talkthrough_mcp/core/ocr.py
def __call__(self, content: str) -> Any: ...
# rapidocr 3.9.2, rapidocr/main.py:95
def __call__(self, img_content: Union[str, np.ndarray, bytes, Path], ...)
```

A *named* protocol parameter demands that exact keyword, and `content` ≠ `img_content`. So the protocol never matched RapidOCR — the untyped package just hid it. This is a real signal, not a false positive from the bump.

## What changes

One character in the protocol — the argument becomes positional-only:

```python
def __call__(self, content: str, /) -> Any: ...
```

That states the contract already in force: the only call site is `engine(str(path))` (`ocr.py:167`), positional. A keyword call would raise `TypeError` against the real engine — and `ocr_image` swallows exceptions, so it would have surfaced as silently empty OCR text on every frame, not as a crash. No runtime change.

## Tests

`tests/unit/test_ocr_engine.py` pins both halves: the protocol stays positional-only, and `ocr_image` drives a RapidOCR-shaped `img_content` engine positionally (the fake mirrors the real parameter name, so a keyword regression fails the test instead of silently emptying OCR).

## Verification

Reproduced and fixed against a real **rapidocr 3.9.2** install (isolated venv, mypy 2.3.0 — same version as the lock):

- before: the CI error reproduces byte-for-byte
- after: `Success: no issues found`

On the current 3.9.1 lock: `ruff check`, `mypy src` (19 files) and `pytest tests/unit` (205 → 207 passed) all clean. Both guards were mutation-checked: reverting `/` fails the first, switching the call site to `engine(content=...)` fails the second with the exact silent-degradation log (`OCR failed on frame-000001.jpg: ... unexpected keyword argument 'content'`).

## After this lands

#32 re-runs against the merge commit and goes green; no push into the dependabot branch is needed.
