### PR TITLE
docs: link the narrated video demo from README + example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Also works for meetings, workshops, product demos, and production incidents.
 keyframes · OCR · wall-clock), the evidence checkpoint is assembled, and the
 bug lands in the tracker with the screenshot attached.*
 
+**[▶ Watch the demo with sound (1:18)](https://youtu.be/nHfGfEiVdE8)** — a
+real, unedited session: a narrated recording goes in, a ready-to-file
+`bug-report.md` comes out.
+
 ## Quickstart
 
 One command, no system dependencies: ffmpeg falls back to a bundled build,

--- a/examples/bug-from-silent-recording/README.md
+++ b/examples/bug-from-silent-recording/README.md
@@ -5,6 +5,10 @@ checkout bug (no narration — like Windows Game Bar clips, which don't capture
 the microphone by default) goes in; an evidence-backed GitHub issue draft
 comes out.
 
+**[▶ Video: the same scenario, narrated (1:18)](https://youtu.be/nHfGfEiVdE8)**
+— the same demo app processed live in Claude Code, this time with the user
+talking over the recording; the spoken words end up quoted in the report.
+
 **Transparent labeling: this is a scripted reproduction of a demo-app bug.**
 The app is a single self-contained page (`checkout-demo.html`, a fake shop —
 not a real store), the reproduction is driven by Playwright


### PR DESCRIPTION
Adds the published demo video (https://youtu.be/nHfGfEiVdE8, 1:18, real unedited session) as a '▶ Watch the demo with sound' link under the hero GIF, and as a cross-link in examples/bug-from-silent-recording/ (same demo app, narrated variant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)