### PR TITLE
fix(deps): pin mcp<2 — 0.2.5 emergency release (server cannot start on fresh installs)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketplace for the talkthrough plugin: narrated screen recordings in, agent-ready evidence out.",
-    "version": "0.2.4"
+    "version": "0.2.5"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [SemVer](https://semver.org/).
 
+## [0.2.5] — 2026-07-31
+
+An emergency one-line release: a dependency bound, no code or behavior
+changes. Every step of the diagnosis below comes from an external incident
+report — reproduced verbatim before fixing.
+
+### Fixed
+
+- **Server could not start in any freshly resolved environment since
+  2026-07-28.** The MCP Python SDK released 2.0.0 on 2026-07-28, removing
+  the `mcp.server.fastmcp` module this server imports; talkthrough-mcp
+  declared `mcp>=1.28.1` with no upper bound, so every fresh resolve —
+  `uvx` first installs, plugin installs, cache refreshes — picked the
+  incompatible SDK and died at import with `ModuleNotFoundError: No module
+  named 'mcp.server.fastmcp'` (Claude Code surfaces it as `Failed to
+  reconnect … -32000`). Warm pre-2.0 uv caches kept working until their
+  next re-resolve, which made the breakage look intermittent and
+  machine-specific. The dependency is now bounded: `mcp>=1.28.1,<2`.
+  Porting to SDK 2.x is a separate, unhurried task — the bound stays until
+  it lands. Environments already broken heal on their next resolve; force
+  it with `uvx --refresh "talkthrough-mcp[diarization]"`. The interim
+  `--with 'mcp<2'` workaround is compatible and can be dropped.
+
 ## [0.2.4] — 2026-07-27
 
 A growth-and-honesty micro-release: one new workflow prompt, a hygiene fix

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -59,6 +59,27 @@ create the venv from a modern interpreter, e.g. `python3.12 -m venv`.
 - Healthy state: the client lists 7 tools, and `list_jobs()` returns `[]` on
   a fresh install.
 
+## Claude Code says `Failed to reconnect … -32000` / `No module named 'mcp.server.fastmcp'`
+
+The server process died on import before the MCP handshake. On any
+talkthrough-mcp **≤ 0.2.4** resolved after 2026-07-28 the cause is the MCP
+Python SDK: its 2.0.0 release removed the `mcp.server.fastmcp` module the
+server imports, and those talkthrough versions declared `mcp>=1.28.1` with no
+upper bound, so a fresh resolve picked the incompatible SDK. Machines with a
+warm pre-2.0 uv cache kept working until uv re-resolved — which made the
+breakage look intermittent and machine-specific. It is neither.
+
+Fixed in **0.2.5** (`mcp>=1.28.1,<2`). Unpinned `uvx` setups — the plugin
+included — pick 0.2.5 up on their next resolve; to force it now:
+
+```bash
+uvx --refresh "talkthrough-mcp[diarization]" --help
+```
+
+then reconnect (`/mcp`). If you applied the interim workaround of adding
+`"--with", "mcp<2"` to the server args, it is compatible with 0.2.5 and can
+be dropped at your leisure.
+
 ## Updated the plugin, but the server behaves like the old version
 
 A running session keeps its MCP server process alive: `claude plugin update

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "talkthrough",
   "description": "Turn screen recordings into transcript, exact frames, OCR and wall-clock evidence — then into ready-to-file bug drafts, specs, backlogs and meeting actions. Bundles the talkthrough MCP server, six workflow commands, a triage agent, and an agent skill.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": {
     "name": "korovin-aa97",
     "url": "https://github.com/korovin-aa97"

--- a/integrations/claude-desktop/manifest.json
+++ b/integrations/claude-desktop/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "talkthrough",
   "display_name": "Talkthrough — narrated recordings for your agent",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Turn narrated screen recordings into structured evidence: local Whisper transcript, scene keyframes, OCR, wall-clock anchoring. Record, talk — Claude writes the bug report.",
   "author": {
     "name": "korovin-aa97",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "talkthrough-mcp"
-version = "0.2.4"
+version = "0.2.5"
 description = "Local MCP server: turn screen recordings into transcript, exact frames, OCR and wall-clock evidence for coding agents."
 readme = "README.md"
 authors = [
@@ -35,7 +35,10 @@ classifiers = [
 ]
 dependencies = [
     "faster-whisper>=1.2.1",
-    "mcp>=1.28.1",
+    # <2: SDK 2.0.0 (2026-07-28) removed mcp.server.fastmcp, which server.py
+    # imports — every environment resolved without this bound dies at startup.
+    # Porting to SDK 2.x is a separate task; the bound stays until it lands.
+    "mcp>=1.28.1,<2",
     "pillow>=12.3.0",
     "rapidocr>=3.9.1",
     "static-ffmpeg>=3.0",

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/korovin-aa97/talkthrough-mcp",
     "source": "github"
   },
-  "version": "0.2.4",
+  "version": "0.2.5",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "talkthrough-mcp",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1634,7 +1634,7 @@ wheels = [
 
 [[package]]
 name = "talkthrough-mcp"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "faster-whisper" },
@@ -1660,7 +1660,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "faster-whisper", specifier = ">=1.2.1" },
-    { name = "mcp", specifier = ">=1.28.1" },
+    { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "rapidocr", specifier = ">=3.9.1" },
     { name = "sherpa-onnx", marker = "extra == 'diarization'", specifier = ">=1.13.4" },


### PR DESCRIPTION
## Incident

The MCP Python SDK released **2.0.0 on 2026-07-28**, removing the `mcp.server.fastmcp` module that `server.py:20` imports. Our dependency was declared `mcp>=1.28.1` with **no upper bound**, so every environment resolved after that date — `uvx` first installs, plugin installs, cache refreshes — installs mcp 2.0.0 and the server dies at import before the MCP handshake. Claude Code surfaces this as `Failed to reconnect … -32000`. Warm pre-2.0 uv caches masked it until their next re-resolve, so reports look intermittent and machine-specific; they are neither. **Every fresh install has been broken since 2026-07-28.**

Diagnosis comes from an external incident report (`talkthrough-mcp-0.2.4-mcp-sdk-2-breakage.md`, untracked) and was reproduced verbatim before fixing.

## Fix

One line: `mcp>=1.28.1,<2` in `pyproject.toml`. Everything else is release mechanics for **0.2.5**: version bump, regenerated integration artifacts (`gen_integrations.py`), CHANGELOG section, TROUBLESHOOTING entry for the `-32000` symptom. **No code or behavior changes** — which is why this ships as an emergency pin-only release and the honesty/robustness release moves to 0.2.6. Porting to SDK 2.x is a separate follow-up.

## Verification

- **Repro (before):** `uvx --refresh-package mcp 'talkthrough-mcp[diarization]'` → `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`, exit 1 — byte-identical to the report.
- **Fix (after):** fresh resolve of the built 0.2.5 wheel with `[diarization]` → resolves **mcp 1.29.0**, `from mcp.server.fastmcp import FastMCP` OK, `talkthrough-mcp` starts and exits 0 on stdin EOF, zero tracebacks.
- PyPI check: mcp `2.0.0` is latest, no compat shim (`requires_dist: mcp-types==2.0.0`), so the bound is required, not optional.
- Gates: ruff clean, mypy clean, 207 unit tests passed (drift test included).

## Rollout notes

- Already-broken user environments **heal automatically** on their next uv re-resolve once 0.2.5 is on PyPI; `uvx --refresh "talkthrough-mcp[diarization]"` forces it.
- The `--with 'mcp<2'` interim workaround from the incident report is compatible with 0.2.5 and can be dropped.
- Plugin stays unpinned per the standing decision — no plugin-side change needed; it resolves 0.2.5 automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)