### PR TITLE
chore(deps): tell Dependabot to skip mcp major bumps while the <2 pin stands

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
       python-deps:
         patterns: ["*"]
     open-pull-requests-limit: 3
+    ignore:
+      # mcp 2.0 removed mcp.server.fastmcp and broke every fresh install
+      # (the 0.2.5 emergency pin, #39/#40). pyproject bounds mcp to <2 until
+      # the SDK 2.x port lands; major-bump PRs would rewrite that bound (#41).
+      - dependency-name: "mcp"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Why

Dependabot's #41 bumped mcp 1.28.1 to 2.0.0 and, to do it, rewrote the intentional `mcp>=1.28.1,<2` bound in pyproject.toml to `<3` — right under the comment explaining why the bound exists. CI went red on all three platforms with exactly the 0.2.5 incident signature: `mcp.server.fastmcp` gone, `ToolAnnotations` fields renamed (#39, #40).

#41 is closed via `@dependabot ignore this major version`, which stops re-opens for 2.x. This PR makes the policy visible in the repo config and also covers any future 3.x proposal.

## What

One `ignore` entry in `.github/dependabot.yml`: skip `version-update:semver-major` for `mcp` only. Minor and patch updates within `<2` keep flowing in the weekly python-deps group. The rule comes off when the SDK 2.x port lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)