### PR TITLE
fix: 0.2.6 — honesty + robustness (the payload tells the outcome, not the attempt)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketplace for the talkthrough plugin: narrated screen recordings in, agent-ready evidence out.",
-    "version": "0.2.5"
+    "version": "0.2.6"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,82 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [SemVer](https://semver.org/).
 
+## [0.2.6] — 2026-08-10
+
+One theme: **the payload tells the truth about the outcome, not the
+attempt** — the same line 0.2.2 (amend honesty) and 0.2.3 (fail-fast,
+`diarization_note`) followed. Every item traces to an external evaluation of
+0.2.4 (2026-07-27); each finding was reproduced against the code before
+fixing. No new features.
+
+### Fixed
+
+- **`get_transcript` on a silent recording returns an honest empty payload
+  instead of an error.** Silent recordings are a headline input, and the
+  flagship `bug` prompt described the silent case as "the transcript is
+  empty" while the tool raised `ToolError`. Now the payload has the same
+  shape as a served transcript (`segments: []` / `text: ""` / `srt: ""`,
+  zero counts), plus `transcript_available: false`, the stored `reason`, and
+  a note routing to `search` (OCR is indexed) and `get_frames`/`get_moment`.
+  `list_jobs` entries carry `has_transcript` — `segment_count: 0` alone
+  could not tell "no audio stream" from "sound present, nobody spoke". The
+  `bug` prompt text now matches the behavior it promises.
+- **A diarization amend that changed nothing now says so.** A re-run with a
+  different `num_speakers` can converge on the exact same clusters (measured
+  on a real meeting: k=8 and k=9 both → 7 clusters, 0 of 605 segments
+  relabelled — reported as plain success). The amend path now compares the
+  roster and per-segment labels before/after and records
+  `diarization.labels_changed`; when nothing changed, the summary and
+  `get_transcript` serve one byte-identical note: "nothing was relabelled;
+  num_speakers is a target the clusterer may not reach, not a constraint".
+- **A no-op amend no longer silences the over-detection warning.** Any
+  explicit `num_speakers` used to suppress the threshold-escalation note —
+  so the exact flow the note recommends (ask the user, re-run with k) could
+  end with the same dusty roster and no warning, reading as
+  "human-confirmed". The note now survives when `labels_changed` is false.
+- **Amend provenance is no longer ambiguous.** An amend re-saves the
+  manifest but must not re-stamp `tool_versions` (that records what
+  *transcribed* the job). The new `diarization.produced_by` records which
+  version wrote the *current speaker labels*, on fresh runs and amends
+  alike; after an amend the two can legitimately differ, and
+  TROUBLESHOOTING explains the split.
+- **`gc` now sweeps manifest-less partial directories.** A failure before
+  the manifest exists could leave a directory holding only `job.lock`
+  (litter 0.2.4 learned not to create but could not remove) — invisible to
+  `list_jobs` and therefore to the age-based pass by construction. `gc`
+  adds a second pass: manifest-less directories older than a day are
+  removed under their own non-blocking job lock via the same
+  "no manifest ⇒ safe" cleanup a live run uses; a held lock (a live run) is
+  never touched. The CLI reports "removed N job(s)" and "swept M partial
+  dir(s)" separately.
+- **`job_lock` hardening.** The lock-retake loop (after a holder cleaned up
+  the directory) now honors the same `wait_seconds` deadline as the flock
+  wait, with a short backoff, instead of looping unbounded; a directory
+  vanishing between `mkdir` and opening the lock file is retried instead of
+  leaking a raw `FileNotFoundError`.
+- Docs: two surviving falsified "in seconds" claims removed (README
+  Speakers, TROUBLESHOOTING threshold advice), and the threshold-tuning
+  advice corrected — a `TALKTHROUGH_DIARIZATION_THRESHOLD` change alone
+  does not invalidate stored labels; applying it means a `force=true`
+  re-run of the whole pipeline.
+
+### Added
+
+- The implausible-speaker-count note names the escape hatch for genuinely
+  large meetings: "if that many people really did speak, pass
+  num_speakers=N to confirm it" — the 16-cluster boundary itself is
+  unchanged.
+- Diarization model download failures that look like TLS interception
+  (certificate errors) now point at `SSL_CERT_FILE` and TROUBLESHOOTING in
+  the error text; CONTRIBUTING notes the same for first
+  `pytest tests/integration` runs on corporate networks.
+- `num_speakers` is documented as a target, not a guarantee — engine
+  docstring, tool guidance, and README now agree, and the payload proves it
+  via `labels_changed`.
+- README Privacy names what the calling agent actually sees: only the
+  payloads the MCP tools return (text and selected frames) in your existing
+  session; talkthrough itself makes no LLM calls.
+
 ## [0.2.5] — 2026-07-31
 
 An emergency one-line release: a dependency bound, no code or behavior

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,11 @@ static ffmpeg build once:
 uv run pytest -q
 ```
 
+On corporate networks with TLS interception the first full run can fail on
+the diarization model downloads with certificate errors — set
+`SSL_CERT_FILE` (see docs/TROUBLESHOOTING.md → "Corporate networks") and
+re-run; warm runs never touch the network.
+
 ## Checks that must be green
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -422,13 +422,16 @@ torch, no accounts, no GPU):
   roster with talk time in `get_transcript`, `speakers_in_range` in
   `get_moment`, `speaker` on `search` hits, `S1:` prefixes in the text/SRT
   formats, a speaker count in `list_jobs`.
-- **Know the headcount? Pass `num_speakers`.** Clustering to an exact k
+- **Know the headcount? Pass `num_speakers`.** Clustering toward an exact k
   removes the main failure mode of unknown-count mode (similar voices merging
-  or one voice splitting). Agents are instructed to do this via the tool
-  guidance; do the same in your own calls.
+  or one voice splitting). It is a target, not a guarantee: the clusterer can
+  converge on fewer clusters than k, and a re-run that changed nothing says
+  so in the payload (`labels_changed: false`). Agents are instructed to pass
+  the headcount via the tool guidance; do the same in your own calls.
 - **Already processed a recording?** Calling `process_media(diarize=true)` on
-  it re-runs *only* diarization — whisper is not re-run, and labels appear in
-  the existing job in seconds. Same for changing `num_speakers`.
+  it re-runs *only* diarization — whisper is not re-run, and labels land in
+  the existing job. Same for changing `num_speakers`. The diarization stage
+  itself still re-scans the full audio: minutes on long recordings.
 - Labels are anonymous by design; mapping `S1` → "Alice" is the calling
   agent's job (self-introductions, vocatives, the `attendees` argument of the
   `meeting-actions` prompt). The server never guesses names.
@@ -466,7 +469,9 @@ ONNX inference, and there is no telemetry. The only network access is one-time
 tool/model downloads (ffmpeg build, whisper model, OCR models, diarization
 models — the latter pinned by URL + sha256). Diarization keeps no voiceprint
 database: voice embeddings live only in process memory, and only anonymous
-turn labels (`S1`/`S2`) land on disk.
+turn labels (`S1`/`S2`) land on disk. Your agent sees only the payloads the
+MCP tools return (text and selected frames) in your existing session;
+talkthrough itself makes no LLM calls.
 
 ## Languages
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -41,7 +41,13 @@ are offline and unaffected):
 
 Set both in the MCP server config (`"env": {...}`) or the shell that runs
 the first `process_media`. Once the models are cached, neither is needed —
-processing is zero-network by design.
+processing is zero-network by design. Since 0.2.6 the diarization download
+error itself names this fix when the failure looks like TLS interception.
+
+The same applies to running the test suite on such networks: the
+diarization integration tests download models on first run, so a fresh
+`uv run pytest tests/integration` can fail with certificate errors until
+`SSL_CERT_FILE` is set (the rest of the suite is unaffected).
 
 ## `pip install` says "No matching distribution found"
 
@@ -89,7 +95,10 @@ the OLD version until the session/client restarts. Restart the session (or the
 client) after updating; headless and CI runs pick up the new version on
 their next launch because they spawn a fresh server every time. To verify
 what is actually running, check `tool_versions` in any `process_media`
-summary or manifest.
+summary or manifest. Note the split (0.2.6+): `tool_versions` names what
+*transcribed* the job and is deliberately never re-stamped by a diarization
+amend; `diarization.produced_by` names the version that wrote the *current
+speaker labels* — after an amend the two can legitimately differ.
 
 The update command needs the marketplace-qualified id — plain `claude plugin
 update talkthrough` fails with `Plugin "talkthrough" not found`. `claude
@@ -151,11 +160,17 @@ same file is an instant re-call, and `list_jobs()` finds the job.
 - **Pass `num_speakers` first.** If the headcount is known, an exact k
   removes the failure mode entirely — unknown-count clustering is the
   fragile part, not the voice fingerprints.
+- `num_speakers` is a **target, not a guarantee**: the clusterer can
+  converge on fewer clusters than the k you passed. Since 0.2.6 a re-run
+  that changed nothing says so instead of reporting plain success — look for
+  `labels_changed: false` and the "nothing was relabelled" note.
 - No headcount? Tune `TALKTHROUGH_DIARIZATION_THRESHOLD` (default `0.5`):
   **too few** speakers detected (voices merged) → **lower** it (try `0.4`);
-  **too many** (one voice split) → **raise** it (try `0.6`). Re-run with
-  `diarize=true` — an explicit request re-clusters the stored job in seconds
-  without re-transcribing.
+  **too many** (one voice split) → **raise** it (try `0.6`), then re-process
+  with `force=true`. A threshold change alone does not invalidate the stored
+  labels (only an explicit `num_speakers` change or a failed previous run
+  triggers the cheap diarization-only amend), and a `force=true` re-run
+  redoes the whole pipeline — budget accordingly (see the note above).
 - Sub-second interjections ("yeah", "mhm") being absorbed into the other
   speaker's segment is expected at segment-level attribution — see README →
   Limitations.

--- a/examples/prompts/bug.md
+++ b/examples/prompts/bug.md
@@ -8,9 +8,11 @@ before everything else — and this is a bug report, not a fix: change no code.
    whole. Long recording: search(job_id="<job_id>", query="<distinctive
    word>") (error text, feature names) and read only the relevant ranges.
    If the job_id looks wrong, verify with list_jobs().
-2. A silent recording (no narration) is a VALID input, not an error: the
-   transcript is empty, but frames and on-screen text are still indexed —
-   orient with search (OCR hits) and get_frames across the timeline instead.
+2. A silent recording (no narration) is a VALID input, not an error:
+   get_transcript returns an empty transcript with a note (and list_jobs
+   shows has_transcript: false), while frames and on-screen text are still
+   indexed — orient with search (OCR hits) and get_frames across the
+   timeline instead.
 3. Pick ONE bug — the highest-confidence, highest-severity problem the
    evidence supports. Mention anything else in a single "Also observed" line
    at the end of the draft; do not investigate it.

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "talkthrough",
   "description": "Turn screen recordings into transcript, exact frames, OCR and wall-clock evidence — then into ready-to-file bug drafts, specs, backlogs and meeting actions. Bundles the talkthrough MCP server, six workflow commands, a triage agent, and an agent skill.",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "author": {
     "name": "korovin-aa97",
     "url": "https://github.com/korovin-aa97"

--- a/integrations/claude-code/commands/bug.md
+++ b/integrations/claude-code/commands/bug.md
@@ -14,9 +14,11 @@ before everything else — and this is a bug report, not a fix: change no code.
    whole. Long recording: search(job_id="$ARGUMENTS", query="<distinctive
    word>") (error text, feature names) and read only the relevant ranges.
    If the job_id looks wrong, verify with list_jobs().
-2. A silent recording (no narration) is a VALID input, not an error: the
-   transcript is empty, but frames and on-screen text are still indexed —
-   orient with search (OCR hits) and get_frames across the timeline instead.
+2. A silent recording (no narration) is a VALID input, not an error:
+   get_transcript returns an empty transcript with a note (and list_jobs
+   shows has_transcript: false), while frames and on-screen text are still
+   indexed — orient with search (OCR hits) and get_frames across the
+   timeline instead.
 3. Pick ONE bug — the highest-confidence, highest-severity problem the
    evidence supports. Mention anything else in a single "Also observed" line
    at the end of the draft; do not investigate it.

--- a/integrations/claude-desktop/manifest.json
+++ b/integrations/claude-desktop/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "talkthrough",
   "display_name": "Talkthrough — narrated recordings for your agent",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Turn narrated screen recordings into structured evidence: local Whisper transcript, scene keyframes, OCR, wall-clock anchoring. Record, talk — Claude writes the bug report.",
   "author": {
     "name": "korovin-aa97",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "talkthrough-mcp"
-version = "0.2.5"
+version = "0.2.6"
 description = "Local MCP server: turn screen recordings into transcript, exact frames, OCR and wall-clock evidence for coding agents."
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/korovin-aa97/talkthrough-mcp",
     "source": "github"
   },
-  "version": "0.2.5",
+  "version": "0.2.6",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "talkthrough-mcp",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/talkthrough_mcp/cli.py
+++ b/src/talkthrough_mcp/cli.py
@@ -139,10 +139,12 @@ def _cmd_process(args: argparse.Namespace) -> int:
 def _cmd_gc(args: argparse.Namespace) -> int:
     from .core import jobs
 
-    removed = jobs.gc(keep_days=args.keep_days)
-    if removed:
-        print(f"removed {len(removed)} job(s): {', '.join(removed)}")
-    else:
+    result = jobs.gc(keep_days=args.keep_days)
+    if result.removed:
+        print(f"removed {len(result.removed)} job(s): {', '.join(result.removed)}")
+    if result.swept:
+        print(f"swept {len(result.swept)} partial dir(s): {', '.join(result.swept)}")
+    if not result.removed and not result.swept:
         print(f"nothing to remove (keep-days={args.keep_days})")
     return 0
 

--- a/src/talkthrough_mcp/core/diarize.py
+++ b/src/talkthrough_mcp/core/diarize.py
@@ -147,6 +147,14 @@ class Diarization:
     speakers: list[SpeakerStat] = field(default_factory=list)
     turns: list[Turn] = field(default_factory=list)
     speaker_names: dict[str, str] | None = None
+    # v0.2.6 — both None on manifests written before the fields existed.
+    # ``labels_changed``: set only by the amend path — did the re-run actually
+    # relabel anything? ``produced_by``: the package version that wrote THIS
+    # block; ``tool_versions`` keeps naming what transcribed the job (an amend
+    # must not re-stamp it — transcription provenance and diarization
+    # provenance are different facts).
+    labels_changed: bool | None = None
+    produced_by: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -173,6 +181,10 @@ class Diarization:
         }
         if self.speaker_names is not None:
             payload["speaker_names"] = dict(self.speaker_names)
+        if self.labels_changed is not None:
+            payload["labels_changed"] = self.labels_changed
+        if self.produced_by is not None:
+            payload["produced_by"] = self.produced_by
         return payload
 
     @staticmethod
@@ -430,10 +442,20 @@ def ensure_model_file(spec: ModelSpec) -> Path:
         try:
             _download(spec.url, download_path)
         except OSError as exc:
-            raise ToolFailureError(
+            message = (
                 f"could not download diarization model {spec.name!r} from {spec.url}: {exc} — "
                 "check network access; the download happens once, warm runs are offline"
-            ) from exc
+            )
+            detail = str(exc).lower()
+            if "certificate" in detail or "ssl" in detail:
+                # the 20-minute investigation a one-liner prevents: corporate
+                # TLS interception re-signs traffic with a CA Python's bundled
+                # store doesn't trust
+                message += (
+                    " (corporate TLS interception? point SSL_CERT_FILE at your "
+                    "system store — see docs/TROUBLESHOOTING.md)"
+                )
+            raise ToolFailureError(message) from exc
         digest = _sha256_file(download_path)
         if digest != spec.sha256:
             raise ToolFailureError(
@@ -569,8 +591,11 @@ class Diarizer:
     ) -> list[Turn]:
         """Run diarization over mono float32 samples → relabeled, sorted turns.
 
-        ``num_speakers`` > 0 clusters to exactly k (threshold is ignored by
-        the engine then); otherwise the threshold decides the speaker count.
+        ``num_speakers`` > 0 asks the engine to cluster toward k speakers
+        (threshold is ignored by the engine then) — a TARGET, not a
+        guarantee: the clusterer may converge on fewer clusters than k
+        (measured: k=8 and k=9 both yielded 7 on a real meeting). Otherwise
+        the threshold decides the speaker count.
         """
         import sherpa_onnx
 

--- a/src/talkthrough_mcp/core/jobs.py
+++ b/src/talkthrough_mcp/core/jobs.py
@@ -15,6 +15,7 @@ import shutil
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -26,6 +27,9 @@ logger = logging.getLogger(__name__)
 JOB_ID_LENGTH = 16
 LOCK_NAME = "job.lock"
 _HASH_CHUNK_BYTES = 1 << 20
+# A manifest-less job dir this old cannot be a live run (processing is capped
+# at 2 h by default) — it is litter from a failure before cleanup existed.
+PARTIAL_SWEEP_MIN_AGE_S = 24 * 3600.0
 
 
 def talkthrough_home() -> Path:
@@ -72,7 +76,10 @@ def job_lock(job_id: str, *, wait_seconds: int = 600) -> Iterator[None]:
     is re-checked: the holder we waited on may have failed and cleaned up the
     whole partial job directory (``cleanup_partial_job``) — then the flock we
     hold is on an orphaned inode, and it must be retaken on the fresh path so
-    two waiters can never both "win" on different inodes.
+    two waiters can never both "win" on different inodes. Every retake
+    iteration honors the same ``wait_seconds`` deadline the flock wait does
+    (v0.2.6) — a lock file that keeps vanishing must end in a clean error,
+    not an unbounded busy loop.
     """
     directory = job_dir(job_id)
     lock_path = directory / LOCK_NAME
@@ -85,10 +92,26 @@ def job_lock(job_id: str, *, wait_seconds: int = 600) -> Iterator[None]:
         lock_path.touch(exist_ok=True)
         yield
         return
+
+    def check_deadline(deadline: float) -> None:
+        if time.monotonic() >= deadline:
+            raise ToolFailureError(
+                f"could not acquire the lock for job {job_id!r} within {wait_seconds}s "
+                "— another process keeps recreating it; retry later"
+            ) from None
+
     deadline = time.monotonic() + wait_seconds
     while True:
         directory.mkdir(parents=True, exist_ok=True)
-        handle = lock_path.open("w")
+        try:
+            handle = lock_path.open("w")
+        except FileNotFoundError:
+            # the directory vanished between mkdir and open (a concurrent
+            # cleanup_partial_job) — retry on a fresh directory instead of
+            # leaking a raw FileNotFoundError to the caller
+            check_deadline(deadline)
+            time.sleep(0.05)
+            continue
         try:
             while True:
                 try:
@@ -111,6 +134,8 @@ def job_lock(job_id: str, *, wait_seconds: int = 600) -> Iterator[None]:
         if same_file:
             break
         handle.close()  # lock file vanished/was replaced under us — retake
+        check_deadline(deadline)
+        time.sleep(0.05)
     try:
         yield
     finally:
@@ -174,8 +199,50 @@ def delete_job(job_id: str) -> None:
         shutil.rmtree(directory)
 
 
-def gc(keep_days: int) -> list[str]:
-    """Delete jobs older than ``keep_days``; returns the removed job ids."""
+@dataclass(frozen=True)
+class GcResult:
+    """What one ``gc`` pass did: completed jobs deleted by age, plus
+    manifest-less partial directories swept (litter from failures that
+    predate the in-run cleanup — invisible to ``list_jobs`` by construction,
+    so the age pass alone can never reach them)."""
+
+    removed: list[str]
+    swept: list[str]
+
+
+def _sweep_partial_dirs(min_age_s: float = PARTIAL_SWEEP_MIN_AGE_S) -> list[str]:
+    """Remove manifest-less job directories older than ``min_age_s``.
+
+    Each candidate is taken under its own job lock, non-blocking — a held
+    lock means a live run owns the directory, and a live run is never swept.
+    The removal itself goes through ``cleanup_partial_job``, which re-checks
+    under the lock that no manifest exists.
+    """
+    root = jobs_root()
+    if not root.is_dir():
+        return []
+    now = time.time()
+    swept: list[str] = []
+    for directory in root.iterdir():
+        if not directory.is_dir() or (directory / MANIFEST_NAME).is_file():
+            continue
+        try:
+            age_s = now - directory.stat().st_mtime
+        except OSError:
+            continue  # vanished mid-scan
+        if age_s < min_age_s:
+            continue
+        try:
+            with job_lock(directory.name, wait_seconds=0):
+                if cleanup_partial_job(directory.name):
+                    swept.append(directory.name)
+        except ToolFailureError:
+            continue  # a live run holds the lock — leave its directory alone
+    return swept
+
+
+def gc(keep_days: int) -> GcResult:
+    """Delete jobs older than ``keep_days`` and sweep stale partial dirs."""
     cutoff = datetime.now(UTC) - timedelta(days=keep_days)
     removed: list[str] = []
     for manifest in list_jobs():
@@ -188,4 +255,4 @@ def gc(keep_days: int) -> list[str]:
         if created < cutoff:
             delete_job(manifest.job_id)
             removed.append(manifest.job_id)
-    return removed
+    return GcResult(removed=removed, swept=_sweep_partial_dirs())

--- a/src/talkthrough_mcp/core/pipeline.py
+++ b/src/talkthrough_mcp/core/pipeline.py
@@ -241,7 +241,7 @@ def _run_diarization(
             diarizer = diarize.create_diarizer()
         if diarizer is None:
             transcript.diarization = Diarization(
-                available=False, reason=diarize.MISSING_EXTRA_REASON
+                available=False, reason=diarize.MISSING_EXTRA_REASON, produced_by=__version__
             )
             return
 
@@ -266,10 +266,13 @@ def _run_diarization(
             threshold=diarizer.threshold,
             speakers=diarize.speaker_roster(turns),
             turns=turns,
+            produced_by=__version__,
         )
     except Exception as exc:
         logger.warning("diarization failed, keeping the transcript without speakers: %s", exc)
-        transcript.diarization = Diarization(available=False, reason=str(exc))
+        transcript.diarization = Diarization(
+            available=False, reason=str(exc), produced_by=__version__
+        )
 
 
 def _needs_diarize_amend(manifest: Manifest, request: _DiarizeRequest) -> bool:
@@ -301,6 +304,24 @@ def _needs_diarize_amend(manifest: Manifest, request: _DiarizeRequest) -> bool:
     )
 
 
+def _labels_snapshot(transcript: Transcript) -> tuple[Any, list[str | None]]:
+    """The comparable identity of a diarization outcome: the roster (label,
+    talk time, turn count) plus the per-segment speaker labels.
+
+    The amend path snapshots this before and after to answer the one question
+    the ``amended`` flag cannot: did the re-run actually relabel anything?
+    (Tester evidence, 2026-07-27: a 353 s amend with a different ``k``
+    returned the byte-identical roster — and reported plain success.)
+    """
+    diarization = transcript.diarization
+    roster = None
+    if diarization is not None and diarization.available:
+        roster = [
+            (stat.label, stat.talk_time_ms, stat.turn_count) for stat in diarization.speakers
+        ]
+    return roster, [segment.speaker for segment in transcript.segments]
+
+
 def _amend_diarization(
     media: Path, manifest: Manifest, request: _DiarizeRequest, report: ProgressFn
 ) -> Manifest:
@@ -329,12 +350,18 @@ def _amend_diarization(
     directory = jobs.job_dir(manifest.job_id)
     tool_timeout = max(600, int(manifest.media.duration_s * 4) + 120)
     wav_path = directory / "audio.wav"
+    before = _labels_snapshot(manifest.transcript)
     report("extracting audio", 0.10)
     try:
         audio.extract_wav(media, wav_path, timeout=tool_timeout)
         _run_diarization(wav_path, manifest.transcript, request, report, diarizer=diarizer)
     finally:
         wav_path.unlink(missing_ok=True)
+    diarization = manifest.transcript.diarization
+    if diarization is not None and diarization.available:
+        # outcome, not attempt (the ProcessResult.amended rule): a re-run that
+        # converged on the same labels must say so instead of reading as a fix
+        diarization.labels_changed = _labels_snapshot(manifest.transcript) != before
     report("writing manifest", 0.99)
     save_manifest(manifest, directory)
     report("done", 1.0)
@@ -480,7 +507,9 @@ def process_media(
                     _run_diarization(wav_path, transcript, diarize_request, report)
                 elif diarize_request.engine_missing:
                     transcript.diarization = Diarization(
-                        available=False, reason=diarize.MISSING_EXTRA_REASON
+                        available=False,
+                        reason=diarize.MISSING_EXTRA_REASON,
+                        produced_by=__version__,
                     )
             finally:
                 wav_path.unlink(missing_ok=True)
@@ -594,8 +623,15 @@ def threshold_escalation_note(diarization: Diarization) -> str | None:
     that serves it (``process_media`` summary, ``get_transcript`` header) —
     an agent starting from either entry point must meet the same escalation
     contract; a summary-only note never reaches transcript-first agents.
+
+    An explicit ``requested_num_speakers`` silences the note ONLY when the
+    re-run actually changed something (v0.2.6): a no-op amend
+    (``labels_changed`` False) left the exact roster the warning was about,
+    and dropping the warning then would read as "a human confirmed this".
     """
-    if not diarization.available or diarization.requested_num_speakers is not None:
+    if not diarization.available:
+        return None
+    if diarization.requested_num_speakers is not None and diarization.labels_changed is not False:
         return None
     detected = diarization.detected_num_speakers or 0
     if detected > IMPLAUSIBLE_SPEAKER_COUNT:
@@ -605,6 +641,7 @@ def threshold_escalation_note(diarization: Diarization) -> str | None:
             "a headcount. ASK YOUR USER how many people actually spoke (the "
             "talk_time_ms roster above shows which voices dominate), then "
             + _AMEND_HONESTY
+            + "; if that many people really did speak, pass num_speakers=N to confirm it"
         )
     if substantial_speaker_count(diarization) >= detected:
         return None
@@ -613,6 +650,29 @@ def threshold_escalation_note(diarization: Diarization) -> str | None:
         "count is unreliable and is NOT a headcount. ASK YOUR USER how many "
         "people actually spoke (the talk_time_ms roster above shows which "
         "voices dominate), then " + _AMEND_HONESTY
+    )
+
+
+def amend_noop_note(diarization: Diarization) -> str | None:
+    """The no-op amend note: a re-run with an explicit ``num_speakers`` that
+    converged on the exact same labels, or None.
+
+    Same contract as ``threshold_escalation_note``: ONE text, byte-identical
+    on every surface that serves it (``process_media`` summary,
+    ``get_transcript`` header). Without it, "353 s of CPU, same roster,
+    amended: true" reads as a successful fix (tester evidence, 2026-07-27).
+    """
+    if (
+        not diarization.available
+        or diarization.labels_changed is not False
+        or diarization.requested_num_speakers is None
+    ):
+        return None
+    return (
+        f"the re-run converged on the SAME {diarization.detected_num_speakers or 0} "
+        f"clusters for num_speakers={diarization.requested_num_speakers} — nothing was "
+        "relabelled; num_speakers is a target the clusterer may not reach, not a "
+        "constraint"
     )
 
 
@@ -672,16 +732,21 @@ def _summarize_diarization(diarization: Diarization) -> dict[str, Any]:
     }
     if hidden:
         payload["speakers_truncated"] = hidden
+    if diarization.labels_changed is not None:
+        payload["labels_changed"] = diarization.labels_changed
     if diarization.requested_num_speakers is not None:
         payload["requested_num_speakers"] = diarization.requested_num_speakers
-    else:
-        # threshold-mode honesty (v0.2.2): the cluster count is NOT a
-        # headcount, and no server heuristic is trusted to guess one — the
-        # note escalates to the user, who always knows their own meeting.
-        note = threshold_escalation_note(diarization)
-        if note is not None:
-            payload["speakers_with_30s_plus"] = substantial_speaker_count(diarization)
-            payload["note"] = note
+    noop = amend_noop_note(diarization)
+    if noop is not None:
+        payload["amend_note"] = noop
+    # threshold-mode honesty (v0.2.2): the cluster count is NOT a headcount,
+    # and no server heuristic is trusted to guess one — the note escalates to
+    # the user, who always knows their own meeting. Since v0.2.6 it also
+    # survives a no-op amend (the helper decides).
+    note = threshold_escalation_note(diarization)
+    if note is not None:
+        payload["speakers_with_30s_plus"] = substantial_speaker_count(diarization)
+        payload["note"] = note
     return payload
 
 

--- a/src/talkthrough_mcp/guidance.py
+++ b/src/talkthrough_mcp/guidance.py
@@ -29,7 +29,7 @@ speech locally (whisper), extracts scene-change keyframes, OCRs on-screen text, 
 the wall-clock start time, and (opt-in) labels who said what via local speaker diarization. \
 Returns a compact summary (job_id, media info, wall_clock, transcript preview, speaker \
 roster when diarized) — full data stays on disk and is served lazily by the other tools. \
-Idempotent by content hash: re-calling on an already-processed file returns instantly. For MULTI-PERSON recordings (meetings, interviews, calls) diarize=true is part of a proper analysis — pass it even when the user only asks for a summary.
+Idempotent by content hash: re-calling on an already-processed file returns instantly. For MULTI-PERSON recordings (meetings, interviews, calls) diarize=true is part of a proper analysis — pass it even when the user only asks for a summary. num_speakers is a target the clusterer may not reach, not a constraint — the payload says when a re-run changed nothing (labels_changed).
 When NOT to use: to re-fetch data you already processed (use the retrieval tools), or for \
 URLs — local file paths only.
 Examples:
@@ -245,9 +245,11 @@ before everything else — and this is a bug report, not a fix: change no code.
    whole. Long recording: search(job_id="{job_id}", query="<distinctive
    word>") (error text, feature names) and read only the relevant ranges.
    If the job_id looks wrong, verify with list_jobs().
-2. A silent recording (no narration) is a VALID input, not an error: the
-   transcript is empty, but frames and on-screen text are still indexed —
-   orient with search (OCR hits) and get_frames across the timeline instead.
+2. A silent recording (no narration) is a VALID input, not an error:
+   get_transcript returns an empty transcript with a note (and list_jobs
+   shows has_transcript: false), while frames and on-screen text are still
+   indexed — orient with search (OCR hits) and get_frames across the
+   timeline instead.
 3. Pick ONE bug — the highest-confidence, highest-severity problem the
    evidence supports. Mention anything else in a single "Also observed" line
    at the end of the draft; do not investigate it.

--- a/src/talkthrough_mcp/server.py
+++ b/src/talkthrough_mcp/server.py
@@ -193,9 +193,36 @@ def get_transcript(
 ) -> dict[str, Any]:
     manifest = _load(job_id)
     if not manifest.transcript.available:
-        raise ToolError(
-            f"job {job_id!r} has no transcript ({manifest.transcript.reason or 'unavailable'})"
-        )
+        # honesty, not an error (v0.2.6): silent recordings are a headline
+        # input, and the `bug` prompt's step 1 sends agents here first — an
+        # empty transcript is the truthful answer, in the exact shape of a
+        # served one so the calling code never branches
+        empty: dict[str, Any] = {
+            "job_id": job_id,
+            "format": format,
+            "language": manifest.transcript.language,
+            "media_kind": manifest.media.kind,
+            "transcript_available": False,
+            "reason": manifest.transcript.reason or "unavailable",
+            "segment_count_total": 0,
+            "segments_returned": 0,
+            "range": {"start_ms": start_ms, "end_ms": end_ms},
+            "truncated": False,
+            "next_start_ms": None,
+            "note": (
+                "no audio stream in this recording — narration was never captured; "
+                "the frames and on-screen text ARE indexed: use search(job_id, "
+                "query=...) for OCR hits and get_frames/get_moment for the visual "
+                "timeline"
+            ),
+        }
+        if format == "segments":
+            empty["segments"] = []
+        elif format == "text":
+            empty["text"] = ""
+        else:
+            empty["srt"] = ""
+        return empty
     picked = slice_segments(manifest.transcript.segments, start_ms, end_ms)
 
     served: list[Any] = []
@@ -230,12 +257,20 @@ def get_transcript(
         payload["speakers"], hidden = pipeline.roster_payload(diarization)
         if hidden:
             payload["speakers_truncated"] = hidden
+        if diarization.labels_changed is not None:
+            # additive (v0.2.6): the amend outcome rides the same header the
+            # roster does — whether the last re-run relabelled anything must
+            # not require re-running process_media to find out
+            payload["labels_changed"] = diarization.labels_changed
         escalation = pipeline.threshold_escalation_note(diarization)
         if escalation is not None:
             # additive (v0.2.3): the same byte-identical text the process
             # summary carries — agents that start transcript-first (list_jobs
             # → get_transcript) never see that summary
             payload["diarization_note"] = escalation
+        noop = pipeline.amend_noop_note(diarization)
+        if noop is not None:
+            payload["amend_note"] = noop
     if format == "segments":
         payload["segments"] = [
             {
@@ -520,6 +555,9 @@ def list_jobs() -> dict[str, Any]:
                 ),
                 "wall_clock_source": manifest.wall_clock.source if manifest.wall_clock else None,
                 "segment_count": len(manifest.transcript.segments),
+                # v0.2.6: segment_count alone cannot tell a silent recording
+                # from "sound present but nobody spoke" — the flag can
+                "has_transcript": manifest.transcript.available,
                 "frames_unique": manifest.frames.unique_count,
                 "frames_total": manifest.frames.count,
                 **(

--- a/tests/unit/test_diarize.py
+++ b/tests/unit/test_diarize.py
@@ -182,6 +182,25 @@ def test_diarization_serializes_speaker_names_when_present() -> None:
     assert Diarization.from_dict(payload).speaker_names == {"S1": "Alice"}
 
 
+def test_diarization_round_trips_v026_outcome_fields() -> None:
+    """labels_changed + produced_by (v0.2.6): serialized only when set, so
+    pre-0.2.6 manifests stay byte-identical and load back to None."""
+    diarization = make_diarization()
+    diarization.labels_changed = False
+    diarization.produced_by = "0.2.6"
+    payload = diarization.to_dict()
+    assert payload["labels_changed"] is False
+    assert payload["produced_by"] == "0.2.6"
+    rebuilt = Diarization.from_dict(payload)
+    assert rebuilt.labels_changed is False
+    assert rebuilt.produced_by == "0.2.6"
+
+    bare = make_diarization().to_dict()
+    assert "labels_changed" not in bare and "produced_by" not in bare
+    legacy = Diarization.from_dict(bare)
+    assert legacy.labels_changed is None and legacy.produced_by is None
+
+
 def test_diarization_from_dict_ignores_unknown_and_malformed() -> None:
     payload = make_diarization().to_dict()
     payload["embedding_dim"] = 256  # field from a future version

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import hashlib
+import os
+import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -10,7 +12,7 @@ import pytest
 from tests.conftest import make_manifest
 
 from talkthrough_mcp.core import jobs
-from talkthrough_mcp.core.errors import UnknownJobError
+from talkthrough_mcp.core.errors import ToolFailureError, UnknownJobError
 from talkthrough_mcp.core.manifest import save_manifest
 
 
@@ -65,8 +67,9 @@ def test_gc_removes_only_stale_jobs(isolated_home: Path) -> None:
     _store_job("1111111111111111", fresh)
     _store_job("2222222222222222", stale)
 
-    removed = jobs.gc(keep_days=30)
-    assert removed == ["2222222222222222"]
+    result = jobs.gc(keep_days=30)
+    assert result.removed == ["2222222222222222"]
+    assert result.swept == []
     assert jobs.job_exists("1111111111111111")
     assert not jobs.job_exists("2222222222222222")
 
@@ -117,6 +120,115 @@ def test_partial_job_cleanup_context_removes_only_manifestless_dirs(
     ):
         raise RuntimeError("amend failed after the manifest existed")
     assert jobs.job_exists(completed)
+
+
+# --- v0.2.6 F6: gc sweeps manifest-less partial dirs ---------------------------
+
+
+def _partial_dir(job_id: str, *, age_days: float) -> Path:
+    """A failed-run leftover: a job dir holding only ``job.lock``."""
+    directory = jobs.job_dir(job_id)
+    directory.mkdir(parents=True)
+    (directory / jobs.LOCK_NAME).touch()
+    stamp = time.time() - age_days * 86_400
+    os.utime(directory, (stamp, stamp))
+    return directory
+
+
+def test_gc_sweeps_old_partial_dirs_but_not_fresh_ones(isolated_home: Path) -> None:
+    """The litter class 0.2.4 learned not to CREATE but could not remove:
+    invisible to list_jobs (no manifest), therefore invisible to the age
+    pass by construction."""
+    old = _partial_dir("600f9e1dc9c8d909", age_days=3)  # the real-store specimen
+    fresh = _partial_dir("aaaaaaaaaaaaaaaa", age_days=0)
+    result = jobs.gc(keep_days=30)
+    assert result.swept == ["600f9e1dc9c8d909"]
+    assert result.removed == []
+    assert not old.exists()
+    assert fresh.exists(), "a fresh dir may be a live run warming up — never swept"
+
+
+def test_gc_never_sweeps_a_dir_with_a_manifest_even_at_old_mtime(
+    isolated_home: Path,
+) -> None:
+    recent = (datetime.now(UTC) - timedelta(days=1)).isoformat(timespec="seconds")
+    _store_job("dddddddddddddddd", recent)
+    directory = jobs.job_dir("dddddddddddddddd")
+    stamp = time.time() - 10 * 86_400
+    os.utime(directory, (stamp, stamp))
+    result = jobs.gc(keep_days=30)
+    assert result.removed == [] and result.swept == []
+    assert jobs.job_exists("dddddddddddddddd")
+
+
+def test_gc_sweep_leaves_unreadable_manifest_dirs_alone(isolated_home: Path) -> None:
+    """A manifest that EXISTS but does not parse is a job to repair, not
+    litter — the sweep's contract is "no manifest file at all"."""
+    broken = jobs.jobs_root() / "cccccccccccccccc"
+    broken.mkdir(parents=True)
+    (broken / "manifest.json").write_text("{not json", encoding="utf-8")
+    stamp = time.time() - 10 * 86_400
+    os.utime(broken, (stamp, stamp))
+    assert jobs.gc(keep_days=30).swept == []
+    assert broken.exists()
+
+
+def test_gc_sweep_skips_a_partial_dir_under_a_held_lock(isolated_home: Path) -> None:
+    fcntl = pytest.importorskip("fcntl")
+    directory = _partial_dir("bbbbbbbbbbbbbbbb", age_days=3)
+    handle = (directory / jobs.LOCK_NAME).open("w")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        result = jobs.gc(keep_days=30)
+        assert result.swept == []
+        assert directory.exists(), "a held lock means a live run — never sweep it"
+    finally:
+        handle.close()
+
+
+# --- v0.2.6 F8: job_lock robustness --------------------------------------------
+
+
+def test_job_lock_retries_when_the_dir_vanishes_between_mkdir_and_open(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A concurrent cleanup can remove the directory in the mkdir→open window;
+    the caller must get a retried acquisition, not a raw FileNotFoundError."""
+    pytest.importorskip("fcntl")
+    real_open = Path.open
+    tripped = {"done": False}
+
+    def flaky_open(self: Path, *args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        if self.name == jobs.LOCK_NAME and not tripped["done"]:
+            tripped["done"] = True
+            raise FileNotFoundError(self)
+        return real_open(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "open", flaky_open)
+    with jobs.job_lock("a" * 16, wait_seconds=5):
+        assert (jobs.job_dir("a" * 16) / jobs.LOCK_NAME).exists()
+    assert tripped["done"], "the failure injection never fired"
+
+
+def test_job_lock_retake_loop_hits_the_deadline_instead_of_spinning(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A lock file that keeps failing the identity re-check must end in a
+    clean ToolFailureError once wait_seconds is spent — the outer retake
+    loop used to have no deadline at all."""
+    pytest.importorskip("fcntl")
+    real_stat = os.stat
+
+    def stat_lock_missing(path, *args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        if str(path).endswith(jobs.LOCK_NAME):
+            raise FileNotFoundError(path)
+        return real_stat(path, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(jobs.os, "stat", stat_lock_missing)
+    with pytest.raises(ToolFailureError, match="retry later"), jobs.job_lock(
+        "b" * 16, wait_seconds=0
+    ):
+        raise AssertionError("the lock must never be acquired here")
 
 
 def test_waiter_retakes_the_lock_after_holder_cleans_up(isolated_home: Path) -> None:

--- a/tests/unit/test_pipeline_config.py
+++ b/tests/unit/test_pipeline_config.py
@@ -570,6 +570,9 @@ def test_implausible_cluster_count_gets_the_stronger_note() -> None:
     assert "transcription is reused" in note
     assert "still takes minutes" in note
     assert "takes seconds" not in note
+    # v0.2.6 S1 escape hatch: a real 20-person all-hands is not accused
+    assert "if that many people really did speak" in note
+    assert "confirm it" in note
 
 
 def test_implausible_note_fires_even_when_every_cluster_is_substantial() -> None:
@@ -590,6 +593,7 @@ def test_boundary_sixteen_clusters_keeps_the_plain_escalation_text() -> None:
     assert "threshold clustering over-detected" in note
     assert "transcription is reused" in note
     assert "takes seconds" not in note
+    assert "really did speak" not in note  # the escape hatch is implausible-only
 
 
 def test_threshold_escalation_note_is_one_text_on_every_surface() -> None:
@@ -614,6 +618,168 @@ def test_threshold_escalation_note_is_one_text_on_every_surface() -> None:
 
     failed = Diarization(available=False, reason="engine exploded")
     assert threshold_escalation_note(failed) is None
+
+
+# --- v0.2.6 F2: the escalation note survives a no-op amend ----------------------
+
+
+def test_escalation_note_survives_a_noop_amend() -> None:
+    """Before 0.2.6 ANY requested_num_speakers silenced the note — so the
+    exact flow the note itself recommends (ask the user, re-run with k)
+    could end with the same dusty roster and NO warning, reading as
+    human-confirmed. A no-op amend must keep the warning."""
+    from talkthrough_mcp.core.pipeline import (
+        _summarize_diarization,
+        threshold_escalation_note,
+    )
+
+    dusty = dusty_diarization(majors=5, dust=118)
+    dusty.requested_num_speakers = 123
+    dusty.labels_changed = False
+    note = threshold_escalation_note(dusty)
+    assert note is not None and "NOT a headcount" in note
+    summary = _summarize_diarization(dusty)
+    assert summary["note"] == note
+    assert summary["labels_changed"] is False
+
+    dusty.labels_changed = True  # the amend DID change labels → user decided
+    assert threshold_escalation_note(dusty) is None
+    fresh = dusty_diarization(majors=5, dust=118)
+    fresh.requested_num_speakers = 123  # fresh k-run (labels_changed None)
+    assert threshold_escalation_note(fresh) is None
+
+
+def test_amend_noop_note_fires_only_for_explicit_k_noops() -> None:
+    from talkthrough_mcp.core.pipeline import _summarize_diarization, amend_noop_note
+
+    diarization = dusty_diarization(majors=2, dust=0)
+    assert amend_noop_note(diarization) is None  # fresh run: labels_changed unset
+    diarization.labels_changed = False
+    assert amend_noop_note(diarization) is None  # no explicit k requested
+    diarization.requested_num_speakers = 3
+    note = amend_noop_note(diarization)
+    assert note is not None
+    assert "SAME 2" in note and "num_speakers=3" in note
+    assert "nothing was relabelled" in note
+    assert "a target the clusterer may not reach" in note
+    assert _summarize_diarization(diarization)["amend_note"] == note  # one text, every surface
+
+    diarization.labels_changed = True
+    assert amend_noop_note(diarization) is None
+    failed = Diarization(available=False, reason="engine exploded")
+    failed.labels_changed = False
+    failed.requested_num_speakers = 3
+    assert amend_noop_note(failed) is None
+
+
+# --- v0.2.6 F2+F3: the real amend path measures its own outcome -----------------
+
+
+class _FakeDiarizer:
+    """Stands in for the sherpa engine so the REAL _run_diarization and
+    _amend_diarization run end-to-end (snapshot, attribution, provenance)."""
+
+    engine = "fake-engine"
+    engine_version = "0.0"
+    segmentation_model = "seg-model"
+    embedding_model = diarize.DEFAULT_EMBEDDING_MODEL
+    threshold = 0.5
+
+    def __init__(self, turns) -> None:  # type: ignore[no-untyped-def]
+        self._turns = turns
+
+    def diarize(self, samples, sample_rate, *, num_speakers=None, on_progress=None):  # type: ignore[no-untyped-def]
+        return list(self._turns)
+
+
+def _stored_attributed_job(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """A realistic diarized store entry: roster AND attributed segments,
+    saved with a stale tool_versions stamp (the F3 evidence shape)."""
+    from talkthrough_mcp.core import jobs
+    from talkthrough_mcp.core.diarize import Turn, attribute_segments, speaker_roster
+    from talkthrough_mcp.core.manifest import save_manifest
+
+    monkeypatch.setenv("TALKTHROUGH_HOME", str(tmp_path / "home"))
+    media = tmp_path / "meeting.mp4"
+    media.write_bytes(b"two voices, only ever hashed")
+    job_id = jobs.compute_job_id(media)
+    manifest = make_manifest(job_id=job_id)
+    manifest.media = type(manifest.media)(**{**manifest.media.__dict__, "path": str(media)})
+    turns = [Turn(0, 5000, "S1"), Turn(5000, 8000, "S2")]
+    manifest.transcript.segments = attribute_segments(manifest.transcript.segments, turns)
+    manifest.transcript.diarization = Diarization(
+        available=True,
+        reason="",
+        embedding_model=diarize.DEFAULT_EMBEDDING_MODEL,
+        requested_num_speakers=2,
+        detected_num_speakers=2,
+        speakers=speaker_roster(turns),
+        turns=turns,
+        produced_by="0.2.2",
+    )
+    manifest.tool_versions = {"talkthrough-mcp": "0.2.2"}
+    directory = jobs.job_dir(job_id)
+    directory.mkdir(parents=True)
+    save_manifest(manifest, directory)
+    return media, turns
+
+
+def _amend_through_fake_engine(media, monkeypatch: pytest.MonkeyPatch, *, turns, k: int):
+    from talkthrough_mcp.core import audio, pipeline
+
+    engine(monkeypatch, available=True)
+    monkeypatch.delenv("TALKTHROUGH_DIARIZATION_EMB_MODEL", raising=False)
+    monkeypatch.setattr(diarize, "create_diarizer", lambda: _FakeDiarizer(turns))
+    monkeypatch.setattr(diarize, "load_wav_float32", lambda path: ([], 16000))
+    monkeypatch.setattr(audio, "extract_wav", lambda *a, **kw: None)
+    return pipeline.process_media(str(media), diarize_speakers=True, num_speakers=k)
+
+
+def test_noop_amend_reports_labels_unchanged_and_keeps_provenance(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The tester's 353-second no-op: k'≠k re-run converges on the same
+    roster. The payload must say labels_changed=false + the noop note, the
+    stale transcription stamp must survive, and produced_by must move."""
+    from talkthrough_mcp import __version__
+    from talkthrough_mcp.core import jobs, pipeline
+
+    media, turns = _stored_attributed_job(tmp_path, monkeypatch)
+    result = _amend_through_fake_engine(media, monkeypatch, turns=turns, k=3)
+    assert result.amended is True  # the amend RAN and landed labels…
+    diarization = result.manifest.transcript.diarization
+    assert diarization is not None
+    assert diarization.labels_changed is False  # …but changed nothing, and says so
+    summary = pipeline.summarize(result)["diarization"]
+    assert summary["labels_changed"] is False
+    assert "nothing was relabelled" in summary["amend_note"]
+    assert "not a constraint" in summary["amend_note"]
+
+    stored = jobs.load_job(result.manifest.job_id)
+    assert stored.tool_versions == {"talkthrough-mcp": "0.2.2"}, (
+        "an amend must NOT re-stamp transcription provenance"
+    )
+    stored_diarization = stored.transcript.diarization
+    assert stored_diarization is not None
+    assert stored_diarization.produced_by == __version__
+    assert stored_diarization.labels_changed is False
+
+
+def test_relabelling_amend_reports_labels_changed_and_no_noop_note(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from talkthrough_mcp.core import pipeline
+    from talkthrough_mcp.core.diarize import Turn
+
+    media, _ = _stored_attributed_job(tmp_path, monkeypatch)
+    different = [Turn(0, 3000, "S1"), Turn(3000, 8000, "S2")]  # boundary moved
+    result = _amend_through_fake_engine(media, monkeypatch, turns=different, k=3)
+    diarization = result.manifest.transcript.diarization
+    assert diarization is not None
+    assert diarization.labels_changed is True
+    summary = pipeline.summarize(result)["diarization"]
+    assert summary["labels_changed"] is True
+    assert "amend_note" not in summary
 
 
 # --- longest_turn_ms roster anchor (v0.2.3) ------------------------------------

--- a/tests/unit/test_server_tools.py
+++ b/tests/unit/test_server_tools.py
@@ -7,13 +7,14 @@ transport needed.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 from tests.conftest import make_manifest
 
 from talkthrough_mcp.core.diarize import Diarization, Turn, attribute_segments, speaker_roster
 from talkthrough_mcp.core.jobs import job_dir
-from talkthrough_mcp.core.manifest import Manifest, save_manifest
+from talkthrough_mcp.core.manifest import Manifest, Transcript, save_manifest
 
 
 def _store(manifest: Manifest) -> str:
@@ -219,6 +220,118 @@ def test_search_zero_hit_multiword_notes_explain_the_miss(isolated_home: Path) -
     # non-zero-hit payloads stay note-free
     hit = search(job_id, "dashboard error")
     assert hit["hit_count"] >= 1 and "note" not in hit
+
+
+# --- v0.2.6 F7: a silent recording serves an honest empty payload --------------
+
+
+def _silent(manifest: Manifest) -> Manifest:
+    """The Game Bar shape: video stream, no audio stream, no transcript."""
+    manifest.transcript = Transcript(
+        available=False, reason="no audio stream in recording", language=None, model=None
+    )
+    manifest.media = replace(manifest.media, has_audio=False)
+    return manifest
+
+
+def test_silent_job_transcript_is_a_payload_not_an_error(isolated_home: Path) -> None:
+    """The flagship `bug` prompt sends agents to get_transcript first and
+    promises an empty transcript on silent recordings — the tool must keep
+    that promise in all three formats (it raised ToolError before 0.2.6)."""
+    from talkthrough_mcp.server import get_transcript
+
+    job_id = _store(_silent(make_manifest()))
+    for fmt, body_key, empty_body in (
+        ("segments", "segments", []),
+        ("text", "text", ""),
+        ("srt", "srt", ""),
+    ):
+        payload = get_transcript(job_id, format=fmt)  # type: ignore[arg-type]
+        assert payload["job_id"] == job_id
+        assert payload["format"] == fmt
+        assert payload["media_kind"] == "video"
+        assert payload["transcript_available"] is False
+        assert payload["reason"] == "no audio stream in recording"
+        assert payload["segment_count_total"] == 0
+        assert payload["segments_returned"] == 0
+        assert payload["truncated"] is False
+        assert payload["next_start_ms"] is None
+        assert payload[body_key] == empty_body
+        assert "search" in payload["note"] and "get_frames" in payload["note"]
+        assert "never captured" in payload["note"]
+    ranged = get_transcript(job_id, start_ms=1000, end_ms=2000)
+    assert ranged["range"] == {"start_ms": 1000, "end_ms": 2000}
+    assert ranged["segments"] == []
+
+
+def test_voiced_job_payload_shape_is_unchanged(isolated_home: Path) -> None:
+    """The empty-payload keys are additive to the silent case only — a served
+    transcript stays byte-shaped like 0.2.5 (no flags, no note)."""
+    from talkthrough_mcp.server import get_transcript
+
+    payload = get_transcript(_store(make_manifest()))
+    assert "transcript_available" not in payload
+    assert "reason" not in payload
+    assert "note" not in payload
+    assert payload["segment_count_total"] == 3
+
+
+def test_list_jobs_flags_silent_jobs(isolated_home: Path) -> None:
+    from talkthrough_mcp.server import list_jobs
+
+    voiced = _store(make_manifest())
+    silent = _store(_silent(make_manifest(job_id="fedcba9876543210")))
+    entries = {entry["job_id"]: entry for entry in list_jobs()["jobs"]}
+    assert entries[voiced]["has_transcript"] is True
+    assert entries[silent]["has_transcript"] is False
+    # segment_count 0 alone cannot make the distinction — that is the point
+    assert entries[silent]["segment_count"] == 0
+
+
+# --- v0.2.6 F2: the amend outcome reaches the transcript-first agent -----------
+
+
+def test_get_transcript_serves_amend_outcome_and_noop_note(isolated_home: Path) -> None:
+    from talkthrough_mcp.core import pipeline
+    from talkthrough_mcp.server import get_transcript
+
+    manifest = _diarize(make_manifest())
+    diarization = manifest.transcript.diarization
+    assert diarization is not None
+    diarization.requested_num_speakers = 4
+    diarization.labels_changed = False
+    payload = get_transcript(_store(manifest))
+    assert payload["labels_changed"] is False
+    assert payload["amend_note"] == pipeline.amend_noop_note(diarization)
+    assert "nothing was relabelled" in payload["amend_note"]
+
+    changed = _diarize(make_manifest(job_id="fedcba9876543210"))
+    changed_diarization = changed.transcript.diarization
+    assert changed_diarization is not None
+    changed_diarization.requested_num_speakers = 2
+    changed_diarization.labels_changed = True
+    relabelled = get_transcript(_store(changed))
+    assert relabelled["labels_changed"] is True
+    assert "amend_note" not in relabelled
+
+    fresh = get_transcript(_store(_diarize(make_manifest(job_id="1111111111111111"))))
+    assert "labels_changed" not in fresh  # fresh runs never set it
+
+
+def test_escalation_note_survives_a_noop_amend_on_the_wire(isolated_home: Path) -> None:
+    """The F2 trap: a useless amend used to SILENCE the over-detection
+    warning — the roster it warned about is still being served, so the
+    warning must be too, alongside the noop explanation."""
+    from talkthrough_mcp.server import get_transcript
+
+    manifest = _dusty_threshold(make_manifest())
+    diarization = manifest.transcript.diarization
+    assert diarization is not None
+    diarization.requested_num_speakers = 28
+    diarization.labels_changed = False
+    payload = get_transcript(_store(manifest))
+    assert "NOT a headcount" in payload["diarization_note"]
+    assert "nothing was relabelled" in payload["amend_note"]
 
 
 def test_search_zero_hit_multiword_respects_the_speaker_filter(

--- a/uv.lock
+++ b/uv.lock
@@ -1634,7 +1634,7 @@ wheels = [
 
 [[package]]
 name = "talkthrough-mcp"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "faster-whisper" },


### PR DESCRIPTION
## What

The 0.2.6 "honesty + robustness" release (the plan formerly numbered 0.2.5, renumbered after the emergency mcp<2 pin took that version). One theme, same line as 0.2.2 and 0.2.3: **the payload tells the truth about the outcome, not the attempt.** Every item traces to the external evaluation of 0.2.4 (2026-07-27); all 8 findings + 3 suggestions were verified against the code before fixing. No new features.

- **F7 (headline):** `get_transcript` on a silent recording returns an honest empty payload (same shape as a served transcript, plus `transcript_available: false`, `reason`, and a note routing to `search`/`get_frames`) instead of raising. `list_jobs` gains `has_transcript`. The `bug` prompt now matches the behavior it promises — and the public Reddit promise ("the next release returns an honest empty payload with a note") ships here.
- **F2:** `diarization.labels_changed` — a re-run that converged on the same labels says so ("nothing was relabelled; num_speakers is a target the clusterer may not reach, not a constraint"), byte-identical in the summary and `get_transcript`. A no-op amend no longer silences the over-detection warning.
- **F3:** `diarization.produced_by` (which version wrote the current labels); `tool_versions` is deliberately never re-stamped by amends.
- **F6:** `gc` sweeps manifest-less partial dirs (>1 day old) under their own non-blocking lock; live runs are never touched.
- **F8:** `job_lock` retake loop honors the deadline with backoff; the mkdir→open race is retried instead of leaking `FileNotFoundError`.
- **S1:** implausible-count note gains the escape hatch for genuinely large meetings; the 16 boundary is unchanged.
- **S3:** TLS-shaped model download errors point at `SSL_CERT_FILE`.
- Docs: two surviving falsified "in seconds" claims removed; threshold-tuning advice corrected; README Privacy names what the agent sees; version 0.2.6 synced across pyproject / plugin / marketplace / mcpb / server.json.

## Compatibility

Server changes are compatible with the 0.2.4/0.2.5 command pack (release checklist invariant): F7 is a contract relaxation (error → payload), everything else is additive payload fields and notes. Old manifests load unchanged (`known_fields` tolerance, new fields serialized only when set).

## Testing

- `ruff check`, `mypy src` clean; full suite **263 passed** locally (unit 223 + integration/e2e, including all 16 diarization integration tests with the extra installed).
- New units: silent-payload ×3 formats, `has_transcript`, real-amend-path `labels_changed` (fake engine, real `_amend_diarization`), provenance split, note interplay, gc sweep matrix, lock deadline/retry.
- The full pre-release battery (v026: TSIL-LIST both-versions delta, TAMEND-NOOP, TGC-SWEEP + 1:1 regression grid vs v024) runs **before merge**; merge criterion is regressions = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)