### PR TITLE
feat: port server to MCP SDK 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,8 @@ updates:
         patterns: ["*"]
     open-pull-requests-limit: 3
     ignore:
-      # mcp 2.0 removed mcp.server.fastmcp and broke every fresh install
-      # (the 0.2.5 emergency pin, #39/#40). pyproject bounds mcp to <2 until
-      # the SDK 2.x port lands; major-bump PRs would rewrite that bound (#41).
+      # The runtime is deliberately bounded to the tested MCP 2.x line.
+      # Ignore the future 3.x major; minor/patch 2.x updates remain enabled.
       - dependency-name: "mcp"
         update-types: ["version-update:semver-major"]
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ CI = ruff + mypy + unit + integration + e2e on ubuntu; ruff + unit on macos.
 
 `src/talkthrough_mcp/core/` — deterministic pipeline (no MCP imports):
 probe → wallclock → stt → frames → dedup → ocr → manifest → jobs, orchestrated
-by `core/pipeline.py`. `server.py` — thin FastMCP layer (7 tools, 6 prompts).
+by `core/pipeline.py`. `server.py` — thin MCPServer layer (7 tools, 6 prompts).
 `cli.py` — serve/process/gc. Full map: `docs/DESIGN.md`.
 
 ## Hard rules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ CI runs the same three on ubuntu (full suite) and macos (lint + unit).
 ## Layout in one breath
 
 `core/` is the deterministic pipeline (no MCP imports); `server.py` is a thin
-FastMCP layer over it; `guidance.py` is the single source of truth for tool
+MCPServer layer over it; `guidance.py` is the single source of truth for tool
 descriptions and prompt templates — **never edit a tool description or prompt
 anywhere else**. Everything under `integrations/` (plus `examples/prompts/`
 and `.mcp.json`) is rendered by `scripts/gen_integrations.py`; edit the

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -38,7 +38,7 @@ exact instants.
 
 | Module | Responsibility |
 |---|---|
-| `server.py` | FastMCP app: 7 tools, 6 prompts, progress, MCP error mapping |
+| `server.py` | MCPServer app: 7 tools, 6 prompts, progress, MCP error mapping |
 | `guidance.py` | Tool descriptions (10-15 examples each) + prompt templates; unit-gated |
 | `cli.py` | `serve` (default) / `process` / `gc` |
 | `core/pipeline.py` | Orchestrates stages, caps, progress callbacks, summary |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -67,6 +67,18 @@ create the venv from a modern interpreter, e.g. `python3.12 -m venv`.
 
 ## Claude Code says `Failed to reconnect … -32000` / `No module named 'mcp.server.fastmcp'`
 
+Talkthrough **0.3.0 and newer** use the MCP Python SDK 2.x public API
+(`mcp>=2.1.1,<3`) and import `mcp.server.mcpserver`; the old `mcp<2`
+workaround must be removed. `uvx --with 'mcp<2' ...` adds a real dependency
+constraint rather than overriding the package metadata, so using it with
+0.3.0 fails resolution as unsatisfiable. Refresh the tool environment instead:
+
+```bash
+uvx --refresh "talkthrough-mcp[diarization]" --help
+```
+
+The history below applies only to older Talkthrough releases.
+
 The server process died on import before the MCP handshake. On any
 talkthrough-mcp **≤ 0.2.4** resolved after 2026-07-28 the cause is the MCP
 Python SDK: its 2.0.0 release removed the `mcp.server.fastmcp` module the
@@ -75,16 +87,16 @@ upper bound, so a fresh resolve picked the incompatible SDK. Machines with a
 warm pre-2.0 uv cache kept working until uv re-resolved — which made the
 breakage look intermittent and machine-specific. It is neither.
 
-Fixed in **0.2.5** (`mcp>=1.28.1,<2`). Unpinned `uvx` setups — the plugin
-included — pick 0.2.5 up on their next resolve; to force it now:
+Fixed for the 0.2.x line in **0.2.5** (`mcp>=1.28.1,<2`). Unpinned `uvx`
+setups picked that bound up on their next resolve; the historical refresh was:
 
 ```bash
 uvx --refresh "talkthrough-mcp[diarization]" --help
 ```
 
-then reconnect (`/mcp`). If you applied the interim workaround of adding
-`"--with", "mcp<2"` to the server args, it is compatible with 0.2.5 and can
-be dropped at your leisure.
+then reconnect (`/mcp`). The interim `"--with", "mcp<2"` launch argument is
+compatible only with the old 0.2.x dependency line and must not remain in a
+0.3.0 config.
 
 ## Updated the plugin, but the server behaves like the old version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,9 @@ classifiers = [
 ]
 dependencies = [
     "faster-whisper>=1.2.1",
-    # <2: SDK 2.0.0 (2026-07-28) removed mcp.server.fastmcp, which server.py
-    # imports — every environment resolved without this bound dies at startup.
-    # Porting to SDK 2.x is a separate task; the bound stays until it lands.
-    "mcp>=1.28.1,<2",
+    # 2.1.1 is the first stable 2.x release tested by the v0.3 port. Keep the
+    # next-major bound explicit: MCP 3.x may change the public server contract.
+    "mcp>=2.1.1,<3",
     "pillow>=12.3.0",
     "rapidocr>=3.9.1",
     "static-ffmpeg>=3.0",

--- a/src/talkthrough_mcp/server.py
+++ b/src/talkthrough_mcp/server.py
@@ -1,4 +1,4 @@
-"""FastMCP server: 7 lazy-retrieval tools + 6 workflow prompts, stdio transport.
+"""MCP server: 7 lazy-retrieval tools + 6 workflow prompts, stdio transport.
 
 Design rule: ``process_media`` returns a compact summary, never the full
 payload; everything else is lazy and capped. Image responses are MCP image
@@ -17,11 +17,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
-from mcp.server.fastmcp import Context, FastMCP, Image
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import Context, Image, MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
-from . import guidance
+from . import __version__, guidance
 from .core import jobs, pipeline
 from .core.diarize import Diarization, speakers_in_range
 from .core.errors import AudioOnlyJobError, TalkthroughError
@@ -49,16 +49,23 @@ LIST_JOBS_MAX = 50
 # silently cancels un-annotated calls). Both shapes stay honest: nothing here
 # destroys user data or reaches beyond the local machine.
 READONLY_TOOL = ToolAnnotations(
-    readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    read_only_hint=True,
+    destructive_hint=False,
+    idempotent_hint=True,
+    open_world_hint=False,
 )
 # Writes only inside TALKTHROUGH_HOME (new job dirs / frame extracts);
 # content-addressing keeps it idempotent.
 LOCAL_WRITE_TOOL = ToolAnnotations(
-    readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    read_only_hint=False,
+    destructive_hint=False,
+    idempotent_hint=True,
+    open_world_hint=False,
 )
 
-mcp = FastMCP(
+mcp = MCPServer(
     "talkthrough",
+    version=__version__,
     instructions=(
         "Local-first recording analysis. Workflow: process_media(path) once per file "
         "(idempotent, content-addressed), then query lazily by job_id — get_transcript "
@@ -133,7 +140,7 @@ class _ProgressState:
 @mcp.tool(description=guidance.TOOL_DESCRIPTIONS["process_media"], annotations=LOCAL_WRITE_TOOL)
 async def process_media(
     path: str,
-    ctx: Context,  # type: ignore[type-arg]
+    ctx: Context,
     recorded_at: str | None = None,
     vocabulary: str | None = None,
     language: str | None = None,

--- a/tests/e2e/test_mcp_client.py
+++ b/tests/e2e/test_mcp_client.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
@@ -22,11 +21,12 @@ from mcp import ClientSession, StdioServerParameters, types
 from mcp.client.stdio import stdio_client
 from tests.integration.fixture_facts import DEMO_MP4, TWO_VOICE_M4A, TWO_VOICE_NUM_SPEAKERS
 
+from talkthrough_mcp import __version__ as package_version
 from talkthrough_mcp import guidance
 from talkthrough_mcp.core import diarize
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-PROCESS_TIMEOUT = timedelta(seconds=600)
+PROCESS_TIMEOUT = 600.0
 
 
 def _preseed_model_env() -> dict[str, str]:
@@ -76,9 +76,9 @@ def _server_params(home: Path) -> StdioServerParameters:
 
 
 def _payload(result: types.CallToolResult) -> dict[str, Any]:
-    assert not result.isError, f"tool errored: {result.content}"
-    if isinstance(result.structuredContent, dict) and result.structuredContent:
-        candidate = result.structuredContent
+    assert not result.is_error, f"tool errored: {result.content}"
+    if isinstance(result.structured_content, dict) and result.structured_content:
+        candidate = result.structured_content
         return candidate.get("result", candidate) if "result" in candidate else candidate
     first = result.content[0]
     assert isinstance(first, types.TextContent)
@@ -92,14 +92,22 @@ async def _run_session(home: Path) -> None:
         stdio_client(_server_params(home)) as (read, write),
         ClientSession(read, write) as session,
     ):
-        await session.initialize()
+        initialized = await session.initialize()
+        assert initialized.server_info.name == "talkthrough"
+        assert initialized.server_info.version == package_version
+        assert (
+            initialized.instructions
+            and "Local-first recording analysis" in initialized.instructions
+        )
 
         # 1. Tool discovery: 7 tools, schemas, guidance examples ON THE WIRE.
         tools_result = await session.list_tools()
         tools = {tool.name: tool for tool in tools_result.tools}
         assert sorted(tools) == sorted(guidance.TOOL_NAMES), sorted(tools)
         for name, tool in tools.items():
-            assert tool.inputSchema and tool.inputSchema.get("type") == "object", name
+            assert tool.input_schema and tool.input_schema.get("type") == "object", name
+            assert tool.annotations is not None, name
+            assert tool.annotations.destructive_hint is False, name
             lines = guidance.example_lines(tool.description or "")
             assert len(lines) >= 10, f"{name}: only {len(lines)} example lines over the wire"
 
@@ -109,17 +117,28 @@ async def _run_session(home: Path) -> None:
         assert prompt_names == sorted(guidance.PROMPT_NAMES)
 
         # 3. Process the committed fixture (the long call).
+        progress_updates: list[tuple[float, float | None, str | None]] = []
+
+        async def record_progress(
+            progress: float, total: float | None, message: str | None
+        ) -> None:
+            progress_updates.append((progress, total, message))
+
         process_result = await session.call_tool(
             "process_media",
             {"path": str(DEMO_MP4)},
             read_timeout_seconds=PROCESS_TIMEOUT,
+            progress_callback=record_progress,
         )
+        assert isinstance(process_result, types.CallToolResult)
         summary = _payload(process_result)
         job_id = summary["job_id"]
         assert summary["transcript"]["segment_count"] >= 1
         assert summary["frames"]["unique_count"] >= 3
         assert summary["wall_clock"]["source"] == "metadata"
         assert summary["transcript"]["preview_segments"], "summary must carry a preview"
+        assert progress_updates, "process_media must report progress over MCP"
+        assert progress_updates[-1][:2] == (1.0, 1.0)
 
         # 3b. Prompt renders non-empty for the real job and names its tools.
         prompt = await session.get_prompt("triage-recording", {"job_id": job_id})
@@ -134,7 +153,8 @@ async def _run_session(home: Path) -> None:
         moment_result = await session.call_tool(
             "get_moment", {"job_id": job_id, "start_ms": 5000, "end_ms": 9000}
         )
-        assert not moment_result.isError
+        assert isinstance(moment_result, types.CallToolResult)
+        assert not moment_result.is_error
         image_blocks = [
             block for block in moment_result.content if isinstance(block, types.ImageContent)
         ]
@@ -142,7 +162,7 @@ async def _run_session(home: Path) -> None:
             block for block in moment_result.content if isinstance(block, types.TextContent)
         ]
         assert len(image_blocks) >= 1, "moment must return at least one image content block"
-        assert image_blocks[0].mimeType.startswith("image/")
+        assert image_blocks[0].mime_type.startswith("image/")
         assert len(image_blocks[0].data) > 1000, "image payload suspiciously small"
         moment_meta = json.loads(text_blocks[0].text)
         assert moment_meta["transcript"], "moment must include transcript text"
@@ -205,7 +225,8 @@ async def _run_session(home: Path) -> None:
         extract_result = await session.call_tool(
             "extract_frame", {"job_id": job_id, "at_ms": 6500}
         )
-        assert not extract_result.isError
+        assert isinstance(extract_result, types.CallToolResult)
+        assert not extract_result.is_error
         extract_text = next(
             block for block in extract_result.content if isinstance(block, types.TextContent)
         )
@@ -284,7 +305,8 @@ async def _run_session(home: Path) -> None:
                 {"path": str(TWO_VOICE_M4A), "diarize": True},
                 read_timeout_seconds=PROCESS_TIMEOUT,
             )
-            assert failed.isError, "explicit diarize without the extra must error"
+            assert isinstance(failed, types.CallToolResult)
+            assert failed.is_error, "explicit diarize without the extra must error"
             error_text = failed.content[0]
             assert isinstance(error_text, types.TextContent)
             assert "[diarization]" in error_text.text

--- a/tests/integration/test_pipeline_integration.py
+++ b/tests/integration/test_pipeline_integration.py
@@ -158,7 +158,7 @@ def test_get_transcript_srt_is_valid(demo: ProcessResult) -> None:
 
 
 def test_get_moment_bundles_slice_frames_ocr(demo: ProcessResult) -> None:
-    from mcp.server.fastmcp import Image as McpImage
+    from mcp.server.mcpserver import Image as McpImage
 
     from talkthrough_mcp.server import get_moment
 
@@ -254,7 +254,7 @@ def test_audio_only_yields_transcript_only_manifest(meeting: ProcessResult) -> N
 
 
 def test_audio_only_frame_tools_error_clearly(meeting: ProcessResult) -> None:
-    from mcp.server.fastmcp.exceptions import ToolError
+    from mcp.server.mcpserver.exceptions import ToolError
 
     from talkthrough_mcp.server import extract_frame, get_frames, get_moment
 

--- a/tests/unit/test_guidance.py
+++ b/tests/unit/test_guidance.py
@@ -67,10 +67,10 @@ def test_every_tool_carries_honest_annotations() -> None:
     for tool in tools:
         ann = tool.annotations
         assert ann is not None, f"{tool.name}: missing ToolAnnotations"
-        assert ann.destructiveHint is False
-        assert ann.idempotentHint is True
-        assert ann.openWorldHint is False
-        assert ann.readOnlyHint is (tool.name not in writers), tool.name
+        assert ann.destructive_hint is False
+        assert ann.idempotent_hint is True
+        assert ann.open_world_hint is False
+        assert ann.read_only_hint is (tool.name not in writers), tool.name
 
 
 def test_exactly_six_prompts_registered() -> None:

--- a/tests/unit/test_sdk_contract.py
+++ b/tests/unit/test_sdk_contract.py
@@ -1,0 +1,37 @@
+"""Packaging and documentation guards for the MCP SDK 2.x port."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from mcp.server.mcpserver import MCPServer
+
+from talkthrough_mcp.server import mcp
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_runtime_uses_the_tested_mcp_2x_line() -> None:
+    project = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    dependencies = project["project"]["dependencies"]
+    assert "mcp>=2.1.1,<3" in dependencies
+    assert isinstance(mcp, MCPServer)
+
+
+def test_no_runtime_or_test_import_uses_removed_fastmcp_path() -> None:
+    offenders: list[str] = []
+    removed_import = "mcp.server." + "fastmcp"
+    for root in (REPO_ROOT / "src", REPO_ROOT / "tests"):
+        for path in root.rglob("*.py"):
+            if removed_import in path.read_text(encoding="utf-8"):
+                offenders.append(str(path.relative_to(REPO_ROOT)))
+    assert offenders == []
+
+
+def test_troubleshooting_removes_the_old_sdk_workaround_for_v030() -> None:
+    text = (REPO_ROOT / "docs" / "TROUBLESHOOTING.md").read_text(encoding="utf-8")
+    prose = " ".join(text.split())
+    assert "Talkthrough **0.3.0 and newer** use the MCP Python SDK 2.x" in prose
+    assert "adds a real dependency constraint" in prose
+    assert "must not remain in a 0.3.0 config" in prose

--- a/uv.lock
+++ b/uv.lock
@@ -410,6 +410,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -425,12 +438,29 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -479,7 +509,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -647,15 +677,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -665,9 +695,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6e/21fb8e5d579dbe21d96ea4d5034200d46d8bdf2261053b5bd041f3c2f612/mcp-2.1.1.tar.gz", hash = "sha256:50b7ba1ebbe117008ea7bdd288234043e69c20b403d6851d19661e6d431a75ef", size = 3984589, upload-time = "2026-08-25T16:14:02.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/50/af/8644cc5fa26a59afd2df2e98eeb19e72926887fa4b7441aba4ff661140db/mcp-2.1.1-py3-none-any.whl", hash = "sha256:1c6c31c5d6471c58db76af3af8af67f46d11d01f0a59077d0a308cbdb3d3e915", size = 357912, upload-time = "2026-08-25T16:13:59.024Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674, upload-time = "2026-08-25T16:14:03.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656, upload-time = "2026-08-25T16:14:00.667Z" },
 ]
 
 [[package]]
@@ -917,6 +960,18 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1134,20 +1189,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1196,15 +1237,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -1660,7 +1692,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "faster-whisper", specifier = ">=1.2.1" },
-    { name = "mcp", specifier = ">=1.28.1,<2" },
+    { name = "mcp", specifier = ">=2.1.1,<3" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "rapidocr", specifier = ">=3.9.1" },
     { name = "sherpa-onnx", marker = "extra == 'diarization'", specifier = ">=1.13.4" },
@@ -1713,6 +1745,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/5f/57ff8b434839e70dab45601284ea413e947a63799891b7553e5960a793a8/tqdm-4.68.4.tar.gz", hash = "sha256:19829c9673638f2a0b8617da4cdcb927e831cd88bcfcb6e78d42a4d1af131520", size = 792418, upload-time = "2026-07-07T09:58:18.369Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/2a/5e5e750890ada51017d18d0d4c30da696e5b5bd3180947729927628fc3cb/tqdm-4.68.4-py3-none-any.whl", hash = "sha256:5168118b2368f48c561afda8020fd79195b1bdb0bdf8086b88442c267a315dc2", size = 676612, upload-time = "2026-07-07T09:58:16.256Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- port the server from the removed `mcp.server.fastmcp` API to the public MCP SDK 2.1.1 `MCPServer` API
- migrate SDK model attributes and client timeout/progress assertions to the 2.x contract
- bound the runtime to the tested `mcp>=2.1.1,<3` line and document removal of the old `mcp<2` workaround
- add guards against reintroducing the removed import path

## Verification
- `uv run pytest -q` — 266 passed
- `uv run ruff check` — clean
- `uv run mypy src` — clean
- `uv build` — sdist and wheel built
- clean wheel install — MCP handshake, 7 tools, 6 prompts
- hostile gate — 13/13
- zero-network warm-cache gate — 3 pipelines, 0 connect attempts
- generated integration artifacts — no drift

Part of the v0.3.0 implementation plan.
