### PR TITLE
fix: close v0.2.6 findings for v0.3.0

### DIFF
--- a/.agents/skills/talkthrough/SKILL.md
+++ b/.agents/skills/talkthrough/SKILL.md
@@ -75,7 +75,7 @@ friendly), `correlate-with-logs`.
 - Speaker labels are anonymous (`S1`/`S2`, ordered by first voice). Mapping
   them to names is YOUR job: self-introductions, vocatives, the attendees
   list — and on video jobs the screen check is MANDATORY: for every label
-  you map, `get_frames(at_ms=<that label's longest_turn_ms from the
+  you map, `get_frames(at_ms=<that label's longest_turn_at_ms from the
   roster>)` and read the meeting-app name plates, the recording's title
   card, the active-speaker highlight BEFORE asserting the mapping. STT
   homophones lie about name spellings (spoken "profit" vs on-screen

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -67,7 +67,7 @@ failing scenario (0/12 recurrences on the headcount case).
   don't auto-fetch MCP prompt or skill text, so instruction steps that
   live there — e.g. the mandatory on-screen name-plate check before
   asserting a speaker mapping — reach interactive clients only. The
-  payload half (per-speaker `longest_turn_ms` anchors) is served to every
+  payload half (per-speaker `longest_turn_at_ms` anchors) is served to every
   client; in the v0.2.3 battery, transcript evidence alone sufficed for
   correct mappings, but that's this corpus, not a guarantee.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -39,6 +39,11 @@ are offline and unaffected):
   SSL_CERT_FILE=/etc/ssl/cert.pem
   ```
 
+  On a machine without system ffmpeg, the first cold-start download may
+  instead come from the third-party `static-ffmpeg` package. Its raw
+  certificate error has the same cause, and the same `SSL_CERT_FILE` setting
+  applies to that one-time ffmpeg download too.
+
 Set both in the MCP server config (`"env": {...}`) or the shell that runs
 the first `process_media`. Once the models are cached, neither is needed —
 processing is zero-network by design. Since 0.2.6 the diarization download

--- a/examples/prompts/meeting-actions.md
+++ b/examples/prompts/meeting-actions.md
@@ -19,7 +19,7 @@ them, and that is fine.
    vocatives ("thanks, Tom"), the attendees list above — and, on video
    jobs, the SCREEN. The screen check is MANDATORY on video jobs, not
    optional: for EVERY label you map, call get_frames(job_id="<job_id>",
-   at_ms=<that label's longest_turn_ms from the roster>) and read the
+   at_ms=<that label's longest_turn_at_ms from the roster>) and read the
    meeting-app name plates, the recording's title card (who
    started/organized it), and the active-speaker highlight BEFORE asserting
    the mapping — vocative evidence alone mis-attributes (a remark spoken TO

--- a/integrations/claude-code/.mcp.json
+++ b/integrations/claude-code/.mcp.json
@@ -3,7 +3,7 @@
     "talkthrough": {
       "command": "uvx",
       "args": [
-        "talkthrough-mcp[diarization]"
+        "talkthrough-mcp[diarization]==0.2.6"
       ]
     }
   }

--- a/integrations/claude-code/commands/meeting-actions.md
+++ b/integrations/claude-code/commands/meeting-actions.md
@@ -25,7 +25,7 @@ them, and that is fine.
    vocatives ("thanks, Tom"), the attendees list above — and, on video
    jobs, the SCREEN. The screen check is MANDATORY on video jobs, not
    optional: for EVERY label you map, call get_frames(job_id="$ARGUMENTS",
-   at_ms=<that label's longest_turn_ms from the roster>) and read the
+   at_ms=<that label's longest_turn_at_ms from the roster>) and read the
    meeting-app name plates, the recording's title card (who
    started/organized it), and the active-speaker highlight BEFORE asserting
    the mapping — vocative evidence alone mis-attributes (a remark spoken TO

--- a/integrations/claude-code/skills/talkthrough/SKILL.md
+++ b/integrations/claude-code/skills/talkthrough/SKILL.md
@@ -75,7 +75,7 @@ friendly), `correlate-with-logs`.
 - Speaker labels are anonymous (`S1`/`S2`, ordered by first voice). Mapping
   them to names is YOUR job: self-introductions, vocatives, the attendees
   list — and on video jobs the screen check is MANDATORY: for every label
-  you map, `get_frames(at_ms=<that label's longest_turn_ms from the
+  you map, `get_frames(at_ms=<that label's longest_turn_at_ms from the
   roster>)` and read the meeting-app name plates, the recording's title
   card, the active-speaker highlight BEFORE asserting the mapping. STT
   homophones lie about name spellings (spoken "profit" vs on-screen

--- a/scripts/gen_integrations.py
+++ b/scripts/gen_integrations.py
@@ -61,6 +61,11 @@ PROJECT_VERSION: str = tomllib.loads((REPO / "pyproject.toml").read_text(encodin
     "project"
 ]["version"]
 
+# A released Claude Code plugin pack must always start its matching server.
+# User-facing install snippets intentionally remain unpinned latest via
+# UVX_ARGS; only the versioned plugin artifact gets this exact pin.
+CLAUDE_PLUGIN_UVX_ARGS = [f"{_PYPI_SPEC}=={PROJECT_VERSION}"]
+
 ENV_DOC = (
     "Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use "
     "`large-v3-turbo` for non-English narration — agents can also pass "
@@ -411,7 +416,11 @@ def build_mcp_configs() -> dict[str, str]:
     return {
         # Plugin config: distribution form (uvx).
         "integrations/claude-code/.mcp.json": _jsonc(
-            {"mcpServers": {"talkthrough": {"command": "uvx", "args": UVX_ARGS}}}
+            {
+                "mcpServers": {
+                    "talkthrough": {"command": "uvx", "args": CLAUDE_PLUGIN_UVX_ARGS}
+                }
+            }
         ),
         # Checkout config: contributors get the LOCAL server when opening this repo.
         ".mcp.json": _jsonc(

--- a/src/talkthrough_mcp/core/dedup.py
+++ b/src/talkthrough_mcp/core/dedup.py
@@ -1,9 +1,10 @@
-"""Perceptual dedup of extracted frames: dHash + Hamming distance.
+"""Perceptual dedup of extracted frames: dHash + Hamming distance + luma.
 
 The 1 fps floor keeps static scenes flowing into the frame set; dHash marks
 near-identical consecutive frames as duplicates so OCR and frame serving
-work on unique frames only. Pillow-only (9x8 grayscale difference hash), no
-numpy.
+work on unique frames only. Absolute mean luma is the tie-break dHash needs
+for otherwise indistinguishable solid-color frames. Pillow-only (9x8
+grayscale thumbnail), no numpy.
 """
 
 from __future__ import annotations
@@ -16,10 +17,11 @@ from .frames import Frame
 
 HASH_SIZE = 8  # 8x8 bits from a 9x8 grayscale downscale
 DEFAULT_HAMMING_THRESHOLD = 4
+DEFAULT_MEAN_LUMA_THRESHOLD = 12.0
 
 
-def dhash_image(image: Image.Image, hash_size: int = HASH_SIZE) -> int:
-    """Difference hash: brightness gradient sign between horizontal neighbours."""
+def _fingerprint_image(image: Image.Image, hash_size: int) -> tuple[int, float]:
+    """Return the dHash and mean luma of the same grayscale thumbnail."""
     gray = image.convert("L").resize((hash_size + 1, hash_size), Image.Resampling.LANCZOS)
     pixels = gray.tobytes()  # mode "L": one byte per pixel, row-major
     bits = 0
@@ -28,12 +30,22 @@ def dhash_image(image: Image.Image, hash_size: int = HASH_SIZE) -> int:
             left = pixels[row * (hash_size + 1) + col]
             right = pixels[row * (hash_size + 1) + col + 1]
             bits = (bits << 1) | (1 if left > right else 0)
-    return bits
+    return bits, sum(pixels) / len(pixels)
+
+
+def dhash_image(image: Image.Image, hash_size: int = HASH_SIZE) -> int:
+    """Difference hash: brightness gradient sign between horizontal neighbours."""
+    return _fingerprint_image(image, hash_size)[0]
 
 
 def dhash_file(path: Path, hash_size: int = HASH_SIZE) -> int:
     with Image.open(path) as image:
         return dhash_image(image, hash_size)
+
+
+def _fingerprint_file(path: Path, hash_size: int = HASH_SIZE) -> tuple[int, float]:
+    with Image.open(path) as image:
+        return _fingerprint_image(image, hash_size)
 
 
 def hamming(a: int, b: int) -> int:
@@ -45,19 +57,27 @@ def mark_duplicates(
     frames_dir: Path,
     *,
     threshold: int = DEFAULT_HAMMING_THRESHOLD,
+    mean_luma_threshold: float = DEFAULT_MEAN_LUMA_THRESHOLD,
 ) -> None:
     """Mark frames near-identical to the last unique frame as duplicates (in time order)."""
     last_unique_hash: int | None = None
+    last_unique_luma: float | None = None
     last_unique_ms: int | None = None
     for frame in sorted(frames, key=lambda item: item.ms):
-        frame_hash = dhash_file(frames_dir / frame.file)
+        frame_hash, frame_luma = _fingerprint_file(frames_dir / frame.file)
         if (
             last_unique_hash is not None
+            and last_unique_luma is not None
             and last_unique_ms is not None
             and hamming(frame_hash, last_unique_hash) <= threshold
+            # dHash intentionally discards absolute brightness. The separate
+            # threshold keeps black/white and red/blue cuts reachable while
+            # tolerating the small mean shifts introduced by JPEG encoding.
+            and abs(frame_luma - last_unique_luma) <= mean_luma_threshold
         ):
             frame.duplicate_of = last_unique_ms
             continue
         frame.duplicate_of = None
         last_unique_hash = frame_hash
+        last_unique_luma = frame_luma
         last_unique_ms = frame.ms

--- a/src/talkthrough_mcp/core/diarize.py
+++ b/src/talkthrough_mcp/core/diarize.py
@@ -36,7 +36,7 @@ import wave
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field, fields, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from .errors import ToolFailureError, ValidationError
 from .stt import SttSegment
@@ -44,6 +44,9 @@ from .stt import SttSegment
 if TYPE_CHECKING:
     import numpy as np
     from numpy.typing import NDArray
+
+AmendReason = Literal["num_speakers", "embedding_model", "both"]
+AMEND_REASONS: frozenset[str] = frozenset({"num_speakers", "embedding_model", "both"})
 
 logger = logging.getLogger(__name__)
 
@@ -147,13 +150,14 @@ class Diarization:
     speakers: list[SpeakerStat] = field(default_factory=list)
     turns: list[Turn] = field(default_factory=list)
     speaker_names: dict[str, str] | None = None
-    # v0.2.6 — both None on manifests written before the fields existed.
+    # Amend outcome metadata; each field stays absent on legacy manifests.
     # ``labels_changed``: set only by the amend path — did the re-run actually
-    # relabel anything? ``produced_by``: the package version that wrote THIS
-    # block; ``tool_versions`` keeps naming what transcribed the job (an amend
-    # must not re-stamp it — transcription provenance and diarization
-    # provenance are different facts).
+    # relabel anything? ``amend_reason``: which explicit input invalidated the
+    # old labels. ``produced_by``: the package version that wrote THIS block;
+    # ``tool_versions`` keeps naming what transcribed the job (an amend must
+    # not re-stamp it — transcription and diarization provenance differ).
     labels_changed: bool | None = None
+    amend_reason: AmendReason | None = None
     produced_by: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -183,6 +187,8 @@ class Diarization:
             payload["speaker_names"] = dict(self.speaker_names)
         if self.labels_changed is not None:
             payload["labels_changed"] = self.labels_changed
+        if self.amend_reason is not None:
+            payload["amend_reason"] = self.amend_reason
         if self.produced_by is not None:
             payload["produced_by"] = self.produced_by
         return payload
@@ -203,6 +209,8 @@ class Diarization:
         known["speaker_names"] = (
             {str(k): str(v) for k, v in names.items()} if isinstance(names, dict) else None
         )
+        amend_reason = payload.get("amend_reason")
+        known["amend_reason"] = amend_reason if amend_reason in AMEND_REASONS else None
         return Diarization(**known)
 
 

--- a/src/talkthrough_mcp/core/jobs.py
+++ b/src/talkthrough_mcp/core/jobs.py
@@ -176,8 +176,8 @@ def partial_job_cleanup(job_id: str) -> Iterator[None]:
         raise
 
 
-def list_jobs() -> list[Manifest]:
-    """All readable job manifests, newest first. Unreadable job dirs are skipped."""
+def _list_jobs(*, warn_missing_manifest: bool) -> list[Manifest]:
+    """Implementation hook letting gc defer expected partial-dir reporting."""
     root = jobs_root()
     if not root.is_dir():
         return []
@@ -187,10 +187,18 @@ def list_jobs() -> list[Manifest]:
             continue
         try:
             manifests.append(load_manifest(directory))
+        except FileNotFoundError as exc:
+            if warn_missing_manifest:
+                logger.warning("skipping unreadable job dir %s: %s", directory.name, exc)
         except Exception as exc:
             logger.warning("skipping unreadable job dir %s: %s", directory.name, exc)
     manifests.sort(key=lambda manifest: manifest.created_at, reverse=True)
     return manifests
+
+
+def list_jobs() -> list[Manifest]:
+    """All readable job manifests, newest first. Unreadable job dirs are skipped."""
+    return _list_jobs(warn_missing_manifest=True)
 
 
 def delete_job(job_id: str) -> None:
@@ -231,12 +239,19 @@ def _sweep_partial_dirs(min_age_s: float = PARTIAL_SWEEP_MIN_AGE_S) -> list[str]
         except OSError:
             continue  # vanished mid-scan
         if age_s < min_age_s:
+            logger.info(
+                "found partial dir %s, left in place (younger than %.0f hours)",
+                directory.name,
+                min_age_s / 3600,
+            )
             continue
         try:
             with job_lock(directory.name, wait_seconds=0):
                 if cleanup_partial_job(directory.name):
                     swept.append(directory.name)
+                    logger.info("found partial dir %s, swept", directory.name)
         except ToolFailureError:
+            logger.info("found partial dir %s, left in place (job lock is held)", directory.name)
             continue  # a live run holds the lock — leave its directory alone
     return swept
 
@@ -245,7 +260,10 @@ def gc(keep_days: int) -> GcResult:
     """Delete jobs older than ``keep_days`` and sweep stale partial dirs."""
     cutoff = datetime.now(UTC) - timedelta(days=keep_days)
     removed: list[str] = []
-    for manifest in list_jobs():
+    # A missing manifest is precisely the partial-dir class handled by the
+    # sweep below, so gc defers that expected case instead of warning first.
+    # Corrupt manifests remain warnings: the sweep deliberately preserves them.
+    for manifest in _list_jobs(warn_missing_manifest=False):
         try:
             created = datetime.fromisoformat(manifest.created_at)
         except ValueError:

--- a/src/talkthrough_mcp/core/pipeline.py
+++ b/src/talkthrough_mcp/core/pipeline.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from .. import __version__
 from . import audio, dedup, diarize, frames, jobs, ocr, stt
-from .diarize import Diarization
+from .diarize import AmendReason, Diarization
 from .errors import ValidationError
 from .ffmpeg import ffmpeg_version
 from .manifest import (
@@ -293,15 +293,35 @@ def _needs_diarize_amend(manifest: Manifest, request: _DiarizeRequest) -> bool:
     stored = manifest.transcript.diarization
     if stored is None or not stored.available:
         return True
-    if (
-        stored.embedding_model is not None
-        and stored.embedding_model != diarize.resolved_embedding_label()
-    ):
-        return True
     return (
-        request.num_speakers is not None
-        and stored.requested_num_speakers != request.num_speakers
+        _amend_reason(stored, request, diarize.resolved_embedding_label()) is not None
     )
+
+
+def _amend_reason(
+    stored: Diarization | None,
+    request: _DiarizeRequest,
+    current_embedding_model: str,
+) -> AmendReason | None:
+    """Why an explicit request invalidates stored labels, if it does."""
+    k_changed = request.num_speakers is not None and (
+        stored is None
+        or not stored.available
+        or stored.requested_num_speakers != request.num_speakers
+    )
+    model_changed = (
+        stored is not None
+        and stored.available
+        and stored.embedding_model is not None
+        and stored.embedding_model != current_embedding_model
+    )
+    if k_changed and model_changed:
+        return "both"
+    if k_changed:
+        return "num_speakers"
+    if model_changed:
+        return "embedding_model"
+    return None
 
 
 def _labels_snapshot(transcript: Transcript) -> tuple[Any, list[str | None]]:
@@ -347,6 +367,11 @@ def _amend_diarization(
         # unreachable through the tool layer (explicit requests without the
         # extra fail in _resolve_diarize_request) — kept for direct callers
         raise ValidationError(diarize.MISSING_EXTRA_REASON)
+    amend_reason = _amend_reason(
+        manifest.transcript.diarization,
+        request,
+        getattr(diarizer, "embedding_model", diarize.resolved_embedding_label()),
+    )
     directory = jobs.job_dir(manifest.job_id)
     tool_timeout = max(600, int(manifest.media.duration_s * 4) + 120)
     wav_path = directory / "audio.wav"
@@ -362,6 +387,7 @@ def _amend_diarization(
         # outcome, not attempt (the ProcessResult.amended rule): a re-run that
         # converged on the same labels must say so instead of reading as a fix
         diarization.labels_changed = _labels_snapshot(manifest.transcript) != before
+        diarization.amend_reason = amend_reason
     report("writing manifest", 0.99)
     save_manifest(manifest, directory)
     report("done", 1.0)
@@ -654,36 +680,50 @@ def threshold_escalation_note(diarization: Diarization) -> str | None:
 
 
 def amend_noop_note(diarization: Diarization) -> str | None:
-    """The no-op amend note: a re-run with an explicit ``num_speakers`` that
-    converged on the exact same labels, or None.
+    """Explain an intentional k/model amend that converged on the same labels.
 
     Same contract as ``threshold_escalation_note``: ONE text, byte-identical
     on every surface that serves it (``process_media`` summary,
     ``get_transcript`` header). Without it, "353 s of CPU, same roster,
     amended: true" reads as a successful fix (tester evidence, 2026-07-27).
     """
-    if (
-        not diarization.available
-        or diarization.labels_changed is not False
-        or diarization.requested_num_speakers is None
-    ):
+    if not diarization.available or diarization.labels_changed is not False:
         return None
+    reason = diarization.amend_reason
+    # Compatibility with 0.2.6 manifests, which persisted labels_changed and
+    # requested_num_speakers but did not yet record amend_reason.
+    if reason is None and diarization.requested_num_speakers is not None:
+        reason = "num_speakers"
+    if reason is None:
+        return None
+    same = f"the re-run converged on the SAME {diarization.detected_num_speakers or 0} clusters"
+    if reason == "embedding_model":
+        return (
+            f"{same} with the new embedding model {diarization.embedding_model or 'unknown'} "
+            "— nothing was relabelled; the new model agreed with the stored labels"
+        )
+    if reason == "both":
+        return (
+            f"{same} with the new embedding model {diarization.embedding_model or 'unknown'} "
+            f"and num_speakers={diarization.requested_num_speakers} — nothing was "
+            "relabelled; the new model and target agreed with the stored labels"
+        )
     return (
-        f"the re-run converged on the SAME {diarization.detected_num_speakers or 0} "
-        f"clusters for num_speakers={diarization.requested_num_speakers} — nothing was "
+        f"{same} for num_speakers={diarization.requested_num_speakers} — nothing was "
         "relabelled; num_speakers is a target the clusterer may not reach, not a "
         "constraint"
     )
 
 
-def _longest_turn_starts(diarization: Diarization) -> dict[str, int]:
-    """label → ``t0_ms`` of that speaker's longest turn (ties → the earliest).
+def _longest_turns(diarization: Diarization) -> dict[str, tuple[int, int]]:
+    """label → ``(t0_ms, duration_ms)`` for the longest turn.
 
     Serve-time only, computed from the stored turns — the manifest schema
     stays untouched. This is the "where to LOOK" anchor for screen-evidence
-    speaker mapping: ``get_frames(at_ms=<longest_turn_ms>)`` lands
+    speaker mapping: ``get_frames(at_ms=<longest_turn_at_ms>)`` lands
     mid-monologue, where name plates and the active-speaker highlight are
-    most likely to show the person actually talking.
+    most likely to show the person actually talking. Equal durations resolve
+    to the earliest turn for deterministic output.
     """
     best: dict[str, tuple[int, int]] = {}
     for turn in diarization.turns:
@@ -691,7 +731,7 @@ def _longest_turn_starts(diarization: Diarization) -> dict[str, int]:
         current = best.get(turn.speaker)
         if current is None or (duration, -turn.t0_ms) > (current[0], -current[1]):
             best[turn.speaker] = (duration, turn.t0_ms)
-    return {label: t0_ms for label, (_, t0_ms) in best.items()}
+    return {label: (t0_ms, duration) for label, (duration, t0_ms) in best.items()}
 
 
 def roster_payload(diarization: Diarization) -> tuple[list[dict[str, Any]], int]:
@@ -704,14 +744,22 @@ def roster_payload(diarization: Diarization) -> tuple[list[dict[str, Any]], int]
     """
     ranked = sorted(diarization.speakers, key=lambda s: -s.talk_time_ms)[:SUMMARY_ROSTER_CAP]
     kept = {stat.label for stat in ranked}
-    longest = _longest_turn_starts(diarization)
+    longest = _longest_turns(diarization)
     entries = [
         {
             "label": stat.label,
             "talk_time_ms": stat.talk_time_ms,
             "turn_count": stat.turn_count,
             **(
-                {"longest_turn_ms": longest[stat.label]} if stat.label in longest else {}
+                {
+                    "longest_turn_at_ms": longest[stat.label][0],
+                    "longest_turn_duration_ms": longest[stat.label][1],
+                    # Deprecated compatibility alias for the 0.2.6 command
+                    # pack. Remove no earlier than 0.4.0.
+                    "longest_turn_ms": longest[stat.label][0],
+                }
+                if stat.label in longest
+                else {}
             ),
         }
         for stat in diarization.speakers
@@ -734,6 +782,8 @@ def _summarize_diarization(diarization: Diarization) -> dict[str, Any]:
         payload["speakers_truncated"] = hidden
     if diarization.labels_changed is not None:
         payload["labels_changed"] = diarization.labels_changed
+    if diarization.amend_reason is not None:
+        payload["amend_reason"] = diarization.amend_reason
     if diarization.requested_num_speakers is not None:
         payload["requested_num_speakers"] = diarization.requested_num_speakers
     noop = amend_noop_note(diarization)

--- a/src/talkthrough_mcp/guidance.py
+++ b/src/talkthrough_mcp/guidance.py
@@ -423,7 +423,7 @@ them, and that is fine.
    vocatives ("thanks, Tom"), the attendees list above — and, on video
    jobs, the SCREEN. The screen check is MANDATORY on video jobs, not
    optional: for EVERY label you map, call get_frames(job_id="{job_id}",
-   at_ms=<that label's longest_turn_ms from the roster>) and read the
+   at_ms=<that label's longest_turn_at_ms from the roster>) and read the
    meeting-app name plates, the recording's title card (who
    started/organized it), and the active-speaker highlight BEFORE asserting
    the mapping — vocative evidence alone mis-attributes (a remark spoken TO

--- a/src/talkthrough_mcp/server.py
+++ b/src/talkthrough_mcp/server.py
@@ -269,6 +269,8 @@ def get_transcript(
             # roster does — whether the last re-run relabelled anything must
             # not require re-running process_media to find out
             payload["labels_changed"] = diarization.labels_changed
+        if diarization.amend_reason is not None:
+            payload["amend_reason"] = diarization.amend_reason
         escalation = pipeline.threshold_escalation_note(diarization)
         if escalation is not None:
             # additive (v0.2.3): the same byte-identical text the process

--- a/tests/e2e/test_mcp_client.py
+++ b/tests/e2e/test_mcp_client.py
@@ -250,9 +250,12 @@ async def _run_session(home: Path) -> None:
             assert block["available"] is True
             assert block["detected_num_speakers"] == TWO_VOICE_NUM_SPEAKERS
             assert [speaker["label"] for speaker in block["speakers"]] == ["S1", "S2"]
-            # v0.2.3: the roster carries the screen-check anchor on the wire
+            # v0.3.0: the roster names both the screen-check anchor and duration;
+            # the old ambiguous field remains an additive compatibility alias.
             assert all(
-                isinstance(speaker["longest_turn_ms"], int)
+                isinstance(speaker["longest_turn_at_ms"], int)
+                and isinstance(speaker["longest_turn_duration_ms"], int)
+                and speaker["longest_turn_ms"] == speaker["longest_turn_at_ms"]
                 for speaker in block["speakers"]
             )
             assert any(

--- a/tests/integration/test_diarization_integration.py
+++ b/tests/integration/test_diarization_integration.py
@@ -152,9 +152,14 @@ def test_summary_carries_compact_diarization_block(two_voice: ProcessResult) -> 
     assert block["available"] is True
     assert block["detected_num_speakers"] == TWO_VOICE_NUM_SPEAKERS
     assert block["requested_num_speakers"] == TWO_VOICE_NUM_SPEAKERS
-    assert {"label", "talk_time_ms", "turn_count", "longest_turn_ms"} == set(
-        block["speakers"][0]
-    )
+    assert {
+        "label",
+        "talk_time_ms",
+        "turn_count",
+        "longest_turn_at_ms",
+        "longest_turn_duration_ms",
+        "longest_turn_ms",
+    } == set(block["speakers"][0])
     preview = summary["transcript"]["preview_segments"]
     assert any(entry.get("speaker") for entry in preview)
 
@@ -187,16 +192,23 @@ def test_get_transcript_serves_speakers_roster_and_prefixes(two_voice: ProcessRe
     payload = get_transcript(job_id)
     assert payload["diarized"] is True
     assert [entry["label"] for entry in payload["speakers"]] == ["S1", "S2"]
-    assert {"label", "talk_time_ms", "turn_count", "longest_turn_ms"} == set(
-        payload["speakers"][0]
-    )
+    assert {
+        "label",
+        "talk_time_ms",
+        "turn_count",
+        "longest_turn_at_ms",
+        "longest_turn_duration_ms",
+        "longest_turn_ms",
+    } == set(payload["speakers"][0])
     # the anchor points INSIDE one of that speaker's stored turns
     diarization = two_voice.manifest.transcript.diarization
     assert diarization is not None
     for entry in payload["speakers"]:
         own_turns = [t for t in diarization.turns if t.speaker == entry["label"]]
-        assert any(t.t0_ms == entry["longest_turn_ms"] for t in own_turns)
-        longest = max(own_turns, key=lambda t: t.t1_ms - t.t0_ms)
+        assert any(t.t0_ms == entry["longest_turn_at_ms"] for t in own_turns)
+        longest = max(own_turns, key=lambda t: (t.t1_ms - t.t0_ms, -t.t0_ms))
+        assert entry["longest_turn_at_ms"] == longest.t0_ms
+        assert entry["longest_turn_duration_ms"] == longest.t1_ms - longest.t0_ms
         assert entry["longest_turn_ms"] == longest.t0_ms
     speakers_seen = {entry.get("speaker") for entry in payload["segments"]}
     assert {"S1", "S2"} <= speakers_seen
@@ -328,6 +340,7 @@ def test_explicit_diarize_amends_on_embedding_model_change(
     after = amended.manifest.transcript.diarization
     assert after is not None and after.available
     assert after.embedding_model == str(wespeaker)
+    assert after.amend_reason == "embedding_model"
     assert after.detected_num_speakers == TWO_VOICE_NUM_SPEAKERS
     assert [stat.label for stat in after.speakers] == ["S1", "S2"]
 

--- a/tests/integration/test_pipeline_integration.py
+++ b/tests/integration/test_pipeline_integration.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import itertools
 import json
 import os
+import subprocess
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -142,6 +143,54 @@ def test_frame_budget_spreads_across_the_whole_video(tmp_path: Path) -> None:
         f"budgeted frames stop at {last_ms}ms of {duration_s * 1000:.0f}ms — "
         f"head-truncation regressed: {[f.ms for f in extracted]}"
     )
+
+
+def test_solid_color_cut_remains_reachable_through_frame_serving(
+    integration_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Full F1 repro: dHash alone collapses every uniform screen to zero."""
+    from PIL import Image
+
+    from talkthrough_mcp.core.ffmpeg import ffmpeg_path
+    from talkthrough_mcp.server import get_frames
+
+    assert integration_home.is_dir()
+    media = tmp_path / "red-blue.mp4"
+    subprocess.run(
+        [
+            ffmpeg_path(),
+            "-y",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=red:s=320x240:d=2:r=10",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=blue:s=320x240:d=2:r=10",
+            "-filter_complex",
+            "[0:v][1:v]concat=n=2:v=1[v]",
+            "-map",
+            "[v]",
+            "-an",
+            str(media),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    monkeypatch.setenv("TALKTHROUGH_OCR", "off")
+    result = pipeline.process_media(str(media))
+    assert result.manifest.frames.count == 4
+    assert len(result.manifest.unique_frames()) == 2
+
+    payload = json.loads(get_frames(result.manifest.job_id, at_ms=3000, max_frames=1)[0])
+    assert payload["frames"][0]["t_ms"] >= 1900
+    with Image.open(payload["frames"][0]["path"]).convert("RGB") as image:
+        red, _green, blue = image.resize((1, 1)).getpixel((0, 0))
+    assert blue > red, "the 3-second lookup must serve blue, not the red predecessor"
 
 
 # --- server tool layer on the processed job ---------------------------------

--- a/tests/unit/test_dedup.py
+++ b/tests/unit/test_dedup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from PIL import Image, ImageDraw
 
 from talkthrough_mcp.core.dedup import dhash_file, dhash_image, hamming, mark_duplicates
@@ -48,6 +49,35 @@ def test_mark_duplicates_chains_to_last_unique(tmp_path: Path) -> None:
     assert frames[1].duplicate_of == 0
     assert frames[2].duplicate_of == 0  # chained to the last UNIQUE frame, not the previous one
     assert frames[3].duplicate_of is None
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [("red", "blue"), ("black", "white")],
+)
+def test_solid_color_cuts_stay_unique(tmp_path: Path, first: str, second: str) -> None:
+    """dHash alone is all zeroes for every uniform frame; mean luma keeps
+    materially different screens from lying about their validity span."""
+    Image.new("RGB", (320, 180), first).save(tmp_path / "first.jpg")
+    Image.new("RGB", (320, 180), second).save(tmp_path / "second.jpg")
+    frames = [Frame(ms=0, file="first.jpg"), Frame(ms=3000, file="second.jpg")]
+
+    mark_duplicates(frames, tmp_path)
+
+    assert all(frame.duplicate_of is None for frame in frames)
+
+
+def test_nearly_identical_jpegs_stay_duplicates(tmp_path: Path) -> None:
+    first = _image_with_box(30)
+    second = _image_with_box(30)
+    ImageDraw.Draw(second).point((0, 0), fill=239)
+    first.save(tmp_path / "first.jpg", quality=90)
+    second.save(tmp_path / "second.jpg", quality=92)
+    frames = [Frame(ms=0, file="first.jpg"), Frame(ms=1000, file="second.jpg")]
+
+    mark_duplicates(frames, tmp_path)
+
+    assert frames[1].duplicate_of == 0
 
 
 def test_dhash_file_round_trip(tmp_path: Path) -> None:

--- a/tests/unit/test_diarize.py
+++ b/tests/unit/test_diarize.py
@@ -182,23 +182,30 @@ def test_diarization_serializes_speaker_names_when_present() -> None:
     assert Diarization.from_dict(payload).speaker_names == {"S1": "Alice"}
 
 
-def test_diarization_round_trips_v026_outcome_fields() -> None:
-    """labels_changed + produced_by (v0.2.6): serialized only when set, so
-    pre-0.2.6 manifests stay byte-identical and load back to None."""
+def test_diarization_round_trips_amend_outcome_fields() -> None:
+    """Outcome fields serialize only when set, preserving legacy manifests."""
     diarization = make_diarization()
     diarization.labels_changed = False
+    diarization.amend_reason = "embedding_model"
     diarization.produced_by = "0.2.6"
     payload = diarization.to_dict()
     assert payload["labels_changed"] is False
+    assert payload["amend_reason"] == "embedding_model"
     assert payload["produced_by"] == "0.2.6"
     rebuilt = Diarization.from_dict(payload)
     assert rebuilt.labels_changed is False
+    assert rebuilt.amend_reason == "embedding_model"
     assert rebuilt.produced_by == "0.2.6"
 
     bare = make_diarization().to_dict()
-    assert "labels_changed" not in bare and "produced_by" not in bare
+    assert "labels_changed" not in bare and "amend_reason" not in bare
+    assert "produced_by" not in bare
     legacy = Diarization.from_dict(bare)
-    assert legacy.labels_changed is None and legacy.produced_by is None
+    assert legacy.labels_changed is None and legacy.amend_reason is None
+    assert legacy.produced_by is None
+
+    bare["amend_reason"] = "future_reason"
+    assert Diarization.from_dict(bare).amend_reason is None
 
 
 def test_diarization_from_dict_ignores_unknown_and_malformed() -> None:

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -1,0 +1,15 @@
+"""Stable documentation contracts for operational failure modes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_corporate_tls_docs_cover_the_first_static_ffmpeg_download() -> None:
+    text = (REPO_ROOT / "docs" / "TROUBLESHOOTING.md").read_text(encoding="utf-8")
+    normalized = " ".join(text.split())
+    assert "third-party `static-ffmpeg` package" in normalized
+    assert "same `SSL_CERT_FILE` setting" in normalized
+    assert "one-time ffmpeg download" in normalized

--- a/tests/unit/test_guidance.py
+++ b/tests/unit/test_guidance.py
@@ -156,6 +156,27 @@ def test_install_buttons_encode_the_batteries_included_command() -> None:
     assert "quality=insiders" in block
 
 
+def test_claude_plugin_server_is_pinned_to_its_generated_pack_version() -> None:
+    """The versioned plugin and server move together; general latest-install
+    snippets stay intentionally unpinned."""
+    import json
+
+    from scripts.gen_integrations import (
+        CLAUDE_PLUGIN_UVX_ARGS,
+        PROJECT_VERSION,
+        UVX_ARGS,
+    )
+
+    assert UVX_ARGS == ["talkthrough-mcp[diarization]"]
+    assert [f"talkthrough-mcp[diarization]=={PROJECT_VERSION}"] == CLAUDE_PLUGIN_UVX_ARGS
+    plugin_config = json.loads(
+        (REPO_ROOT / "integrations" / "claude-code" / ".mcp.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert plugin_config["mcpServers"]["talkthrough"]["args"] == CLAUDE_PLUGIN_UVX_ARGS
+
+
 def test_generator_covers_every_engine_folder() -> None:
     """No hand-made stragglers: every integrations/<engine>/ has generated docs."""
     artifacts = _generated_artifacts()

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import time
 from datetime import UTC, datetime, timedelta
@@ -135,17 +136,26 @@ def _partial_dir(job_id: str, *, age_days: float) -> Path:
     return directory
 
 
-def test_gc_sweeps_old_partial_dirs_but_not_fresh_ones(isolated_home: Path) -> None:
+def test_gc_sweeps_old_partial_dirs_but_not_fresh_ones(
+    isolated_home: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """The litter class 0.2.4 learned not to CREATE but could not remove:
     invisible to list_jobs (no manifest), therefore invisible to the age
     pass by construction."""
     old = _partial_dir("600f9e1dc9c8d909", age_days=3)  # the real-store specimen
     fresh = _partial_dir("aaaaaaaaaaaaaaaa", age_days=0)
-    result = jobs.gc(keep_days=30)
+    with caplog.at_level(logging.INFO, logger=jobs.__name__):
+        result = jobs.gc(keep_days=30)
     assert result.swept == ["600f9e1dc9c8d909"]
     assert result.removed == []
     assert not old.exists()
     assert fresh.exists(), "a fresh dir may be a live run warming up — never swept"
+    assert not [record for record in caplog.records if record.levelno >= logging.WARNING]
+    assert "found partial dir 600f9e1dc9c8d909, swept" in caplog.text
+    assert (
+        "found partial dir aaaaaaaaaaaaaaaa, left in place (younger than 24 hours)"
+        in caplog.text
+    )
 
 
 def test_gc_never_sweeps_a_dir_with_a_manifest_even_at_old_mtime(
@@ -173,15 +183,20 @@ def test_gc_sweep_leaves_unreadable_manifest_dirs_alone(isolated_home: Path) -> 
     assert broken.exists()
 
 
-def test_gc_sweep_skips_a_partial_dir_under_a_held_lock(isolated_home: Path) -> None:
+def test_gc_sweep_skips_a_partial_dir_under_a_held_lock(
+    isolated_home: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     fcntl = pytest.importorskip("fcntl")
     directory = _partial_dir("bbbbbbbbbbbbbbbb", age_days=3)
     handle = (directory / jobs.LOCK_NAME).open("w")
     try:
         fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        result = jobs.gc(keep_days=30)
+        with caplog.at_level(logging.INFO, logger=jobs.__name__):
+            result = jobs.gc(keep_days=30)
         assert result.swept == []
         assert directory.exists(), "a held lock means a live run — never sweep it"
+        assert "left in place (job lock is held)" in caplog.text
+        assert not [record for record in caplog.records if record.levelno >= logging.WARNING]
     finally:
         handle.close()
 

--- a/tests/unit/test_pipeline_config.py
+++ b/tests/unit/test_pipeline_config.py
@@ -649,7 +649,7 @@ def test_escalation_note_survives_a_noop_amend() -> None:
     assert threshold_escalation_note(fresh) is None
 
 
-def test_amend_noop_note_fires_only_for_explicit_k_noops() -> None:
+def test_amend_noop_note_explains_k_and_embedding_model_noops() -> None:
     from talkthrough_mcp.core.pipeline import _summarize_diarization, amend_noop_note
 
     diarization = dusty_diarization(majors=2, dust=0)
@@ -663,6 +663,23 @@ def test_amend_noop_note_fires_only_for_explicit_k_noops() -> None:
     assert "nothing was relabelled" in note
     assert "a target the clusterer may not reach" in note
     assert _summarize_diarization(diarization)["amend_note"] == note  # one text, every surface
+
+    diarization.requested_num_speakers = None
+    diarization.amend_reason = "embedding_model"
+    diarization.embedding_model = "new-embedding.onnx"
+    model_note = amend_noop_note(diarization)
+    assert model_note is not None
+    assert "new embedding model new-embedding.onnx" in model_note
+    assert "agreed with the stored labels" in model_note
+    model_summary = _summarize_diarization(diarization)
+    assert model_summary["amend_reason"] == "embedding_model"
+    assert model_summary["amend_note"] == model_note
+
+    diarization.requested_num_speakers = 3
+    diarization.amend_reason = "both"
+    both_note = amend_noop_note(diarization)
+    assert both_note is not None
+    assert "new embedding model" in both_note and "num_speakers=3" in both_note
 
     diarization.labels_changed = True
     assert amend_noop_note(diarization) is None
@@ -750,6 +767,7 @@ def test_noop_amend_reports_labels_unchanged_and_keeps_provenance(
     diarization = result.manifest.transcript.diarization
     assert diarization is not None
     assert diarization.labels_changed is False  # …but changed nothing, and says so
+    assert diarization.amend_reason == "num_speakers"
     summary = pipeline.summarize(result)["diarization"]
     assert summary["labels_changed"] is False
     assert "nothing was relabelled" in summary["amend_note"]
@@ -763,6 +781,30 @@ def test_noop_amend_reports_labels_unchanged_and_keeps_provenance(
     assert stored_diarization is not None
     assert stored_diarization.produced_by == __version__
     assert stored_diarization.labels_changed is False
+    assert stored_diarization.amend_reason == "num_speakers"
+
+
+def test_embedding_model_noop_amend_persists_and_explains_reason(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from talkthrough_mcp.core import jobs, pipeline
+    from talkthrough_mcp.core.manifest import save_manifest
+
+    media, turns = _stored_attributed_job(tmp_path, monkeypatch)
+    stored = jobs.load_job(jobs.compute_job_id(media))
+    diarization = stored.transcript.diarization
+    assert diarization is not None
+    diarization.embedding_model = "old-embedding-model"
+    save_manifest(stored, jobs.job_dir(stored.job_id))
+
+    result = _amend_through_fake_engine(media, monkeypatch, turns=turns, k=2)
+    amended = result.manifest.transcript.diarization
+    assert amended is not None
+    assert amended.labels_changed is False
+    assert amended.amend_reason == "embedding_model"
+    summary = pipeline.summarize(result)["diarization"]
+    assert summary["amend_reason"] == "embedding_model"
+    assert "new embedding model" in summary["amend_note"]
 
 
 def test_relabelling_amend_reports_labels_changed_and_no_noop_note(
@@ -782,7 +824,7 @@ def test_relabelling_amend_reports_labels_changed_and_no_noop_note(
     assert "amend_note" not in summary
 
 
-# --- longest_turn_ms roster anchor (v0.2.3) ------------------------------------
+# --- longest-turn roster anchor + duration (v0.3.0) -----------------------------
 
 
 def test_roster_payload_carries_longest_turn_anchor() -> None:
@@ -807,8 +849,12 @@ def test_roster_payload_carries_longest_turn_anchor() -> None:
     entries, hidden = roster_payload(diarization)
     assert hidden == 0
     by_label = {entry["label"]: entry for entry in entries}
-    assert by_label["S1"]["longest_turn_ms"] == 0  # 4000ms tie → earliest t0
-    assert by_label["S2"]["longest_turn_ms"] == 9000  # 11000ms beats 1000ms
+    assert by_label["S1"]["longest_turn_at_ms"] == 0  # 4000ms tie → earliest t0
+    assert by_label["S1"]["longest_turn_duration_ms"] == 4000
+    assert by_label["S1"]["longest_turn_ms"] == 0  # deprecated alias through 0.3.x
+    assert by_label["S2"]["longest_turn_at_ms"] == 9000  # 11000ms beats 1000ms
+    assert by_label["S2"]["longest_turn_duration_ms"] == 11_000
+    assert by_label["S2"]["longest_turn_ms"] == 9000
 
     shuffled = Diarization(
         available=True,
@@ -822,4 +868,6 @@ def test_roster_payload_carries_longest_turn_anchor() -> None:
 
     no_turns = dusty_diarization(majors=2, dust=0)
     bare_entries, _ = roster_payload(no_turns)
+    assert all("longest_turn_at_ms" not in entry for entry in bare_entries)
+    assert all("longest_turn_duration_ms" not in entry for entry in bare_entries)
     assert all("longest_turn_ms" not in entry for entry in bare_entries)

--- a/tests/unit/test_server_tools.py
+++ b/tests/unit/test_server_tools.py
@@ -300,8 +300,10 @@ def test_get_transcript_serves_amend_outcome_and_noop_note(isolated_home: Path) 
     assert diarization is not None
     diarization.requested_num_speakers = 4
     diarization.labels_changed = False
+    diarization.amend_reason = "num_speakers"
     payload = get_transcript(_store(manifest))
     assert payload["labels_changed"] is False
+    assert payload["amend_reason"] == "num_speakers"
     assert payload["amend_note"] == pipeline.amend_noop_note(diarization)
     assert "nothing was relabelled" in payload["amend_note"]
 


### PR DESCRIPTION
## Summary
- F1: combine dHash with a mean-luma threshold so solid-color cuts remain distinct and frame validity stays truthful
- F2: add `longest_turn_at_ms` and `longest_turn_duration_ms`, retaining `longest_turn_ms` as the deprecated 0.3.x compatibility alias
- F3: persist and serve `amend_reason` for k/model/both, including honest no-op notes after embedding-model changes
- F4: defer expected partial-directory reporting during `gc` and emit calm swept/left-in-place results
- F5: document first-run `static-ffmpeg` TLS failures and the `SSL_CERT_FILE` remedy
- F6: generate an exact server version pin for the versioned Claude Code plugin while keeping general install snippets on latest

## Verification
- `uv run --extra diarization pytest -q` — 273 passed
- `uv run ruff check` — clean
- `uv run mypy src` — clean
- F1 full-pipeline red→blue repro — 4 frames, 2 unique, 3000 ms serves blue
- hostile gate — 13/13
- zero-network warm-cache gate — 3 pipelines, 0 connect attempts
- generated integration artifacts — no drift

Part of the v0.3.0 implementation plan.
