### PR TITLE
feat: improve lexical search quality

### DIFF
--- a/.agents/skills/talkthrough/SKILL.md
+++ b/.agents/skills/talkthrough/SKILL.md
@@ -36,7 +36,9 @@ install it: `claude mcp add -s user talkthrough -- uvx talkthrough-mcp`
    re-transcription) — still minutes on long recordings.
 2. **Orient**: `get_transcript(job_id)` (paginate via `next_start_ms` when
    `truncated`) or `search(job_id, "<distinctive word>")` to jump straight
-   to the relevant moments (searches speech AND on-screen OCR text).
+   to the relevant moments (searches speech AND on-screen OCR text). Multi-word
+   search defaults to `match_mode="all_words"`; use `"any_word"` for broader
+   lexical recall.
 3. **Evidence per remark**: `get_moment(job_id, t0-2000, t1+2000)` — one
    call returns the transcript slice + up to 3 unique frames + their OCR
    text + the wall-clock range. This is the workhorse; describe `observed`

--- a/README.md
+++ b/README.md
@@ -361,10 +361,10 @@ Then, in your agent:
 | `get_transcript(job_id, start_ms?, end_ms?, format?)` | Paginated transcript as `segments`, `text`, or `srt` (speaker-prefixed when diarized, plus a roster header); truncation returns `next_start_ms`. |
 | `get_frames(job_id, at_ms? \| start_ms?+end_ms?, max_frames?, include_duplicates?)` | Keyframe images nearest a timestamp or evenly thinned across a range (unique frames by default, max 6/call); each frame names its absolute `path`. |
 | `get_moment(job_id, start_ms, end_ms)` | The "one remark" bundle: transcript slice + up to 3 frames + their OCR text + wall-clock range (+ `speakers_in_range` when diarized). |
-| `search(job_id, query, speaker?)` | Substring search over the transcript AND on-screen OCR text; hits carry `t_ms`/`t_wall`, frame refs, and the speaker when diarized. The optional filter accepts a raw label or saved name. |
+| `search(job_id, query, speaker?, match_mode?)` | Substring search over the transcript AND on-screen OCR text. `all_words` remains the default; `any_word` broadens lexical recall. Hits carry `t_ms`/`t_wall`, frame refs, and the speaker when diarized. The optional filter accepts a raw label or saved name. |
 | `label_speakers(job_id, labels, evidence?)` | Atomically persist verified names for anonymous speaker labels. Raw `S1`/`S2` labels remain canonical; blank/null removes a name. |
 | `extract_frame(job_id, at_ms, crop?)` | Exact-timestamp full-resolution re-extract from the source video (optional crop) when keyframes miss the instant; returns the file's absolute `path`. |
-| `list_jobs()` | Recent processed recordings with durations, wall-clock starts, counts, and speaker counts when diarized. |
+| `list_jobs()` | Recent processed recordings with source paths, durations, wall-clock starts, counts, and speaker counts when diarized. |
 
 Every tool description ships 10+ usage examples, so agents pick the right tool
 without extra prompting.

--- a/integrations/claude-code/skills/talkthrough/SKILL.md
+++ b/integrations/claude-code/skills/talkthrough/SKILL.md
@@ -36,7 +36,9 @@ install it: `claude mcp add -s user talkthrough -- uvx talkthrough-mcp`
    re-transcription) — still minutes on long recordings.
 2. **Orient**: `get_transcript(job_id)` (paginate via `next_start_ms` when
    `truncated`) or `search(job_id, "<distinctive word>")` to jump straight
-   to the relevant moments (searches speech AND on-screen OCR text).
+   to the relevant moments (searches speech AND on-screen OCR text). Multi-word
+   search defaults to `match_mode="all_words"`; use `"any_word"` for broader
+   lexical recall.
 3. **Evidence per remark**: `get_moment(job_id, t0-2000, t1+2000)` — one
    call returns the transcript slice + up to 3 unique frames + their OCR
    text + the wall-clock range. This is the workhorse; describe `observed`

--- a/src/talkthrough_mcp/core/manifest.py
+++ b/src/talkthrough_mcp/core/manifest.py
@@ -14,7 +14,7 @@ import tempfile
 import unicodedata
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from .diarize import Diarization, known_fields
 from .frames import Frame, frame_floor_s
@@ -376,6 +376,17 @@ class SearchHit:
     speaker: str | None = None  # transcript hits on diarized jobs
 
 
+@dataclass(frozen=True)
+class StraddleHint:
+    """Bounded evidence for a query split across adjacent segments."""
+
+    t_ms: int
+    quote: str
+
+
+STRADDLE_QUOTE_MAX_CHARS = 240
+
+
 def _fold_for_search(text: str) -> str:
     """Match-time normalization applied to BOTH query and indexed text (#16).
 
@@ -388,13 +399,19 @@ def _fold_for_search(text: str) -> str:
 
 
 def search_manifest(
-    manifest: Manifest, query: str, *, speaker: str | None = None
+    manifest: Manifest,
+    query: str,
+    *,
+    speaker: str | None = None,
+    match_mode: Literal["all_words", "any_word"] = "all_words",
 ) -> list[SearchHit]:
     """Word-level match over transcript segments AND frame OCR text.
 
-    The query is tokenized on whitespace; a text hits when EVERY token
-    matches as a substring — any order, any distance (#16). A single-word
-    query therefore behaves exactly like the old exact-substring match.
+    The query is tokenized on whitespace. ``all_words`` preserves the
+    existing contract: every token must match as a substring, in any order
+    and at any distance. ``any_word`` matches when at least one token does.
+    A single-word query therefore behaves exactly like the old
+    exact-substring match in either mode.
     ``speaker`` filters transcript hits to one diarized label; OCR hits are
     excluded then (on-screen text has no voice).
     """
@@ -402,10 +419,13 @@ def search_manifest(
     hits: list[SearchHit] = []
     if not tokens:
         return hits
+    if match_mode not in {"all_words", "any_word"}:
+        raise ValueError(f"unknown match_mode: {match_mode}")
 
     def matches(text: str) -> bool:
         folded = _fold_for_search(text)
-        return all(token in folded for token in tokens)
+        matched = (token in folded for token in tokens)
+        return any(matched) if match_mode == "any_word" else all(matched)
 
     for segment in manifest.transcript.segments:
         if speaker is not None and segment.speaker != speaker:
@@ -443,21 +463,19 @@ def search_manifest(
     return hits
 
 
-def straddle_hint_t_ms(
+def straddle_hint(
     manifest: Manifest, query: str, *, speaker: str | None = None
-) -> int | None:
-    """``t0_ms`` of the first ADJACENT segment pair whose combined text
-    matches every query token — the cheap cross-boundary check behind the
-    zero-hit search note.
+) -> StraddleHint | None:
+    """First adjacent segment pair whose combined text matches every token.
 
     Word-AND is per-segment BY CONTRACT (#16); a phrase split over a segment
     boundary ("recurring | invites") legitimately misses, and the note should
-    say where the words do meet instead of leaving the miss indistinguishable
-    from "never said". Same normalization as the search itself. OCR text
-    stays out — frames are not contiguous prose. With ``speaker`` both
-    segments of the pair must be that speaker's, mirroring the filter the
-    zero-hit search ran under. Not a search mode: the hit contract is
-    untouched, this feeds one prose note.
+    say where the words do meet and show a bounded quote instead of leaving
+    the miss indistinguishable from "never said". Same normalization as the
+    search itself. OCR text stays out — frames are not contiguous prose. With
+    ``speaker`` both segments of the pair must be that speaker's, mirroring
+    the filter the zero-hit search ran under. Not a search mode: this feeds
+    one prose note.
     """
     tokens = _fold_for_search(query).split()
     if len(tokens) < 2:
@@ -467,5 +485,16 @@ def straddle_hint_t_ms(
             continue
         combined = _fold_for_search(first.text + " " + second.text)
         if all(token in combined for token in tokens):
-            return first.t0_ms
+            quote = " ".join((first.text + " " + second.text).split())
+            if len(quote) > STRADDLE_QUOTE_MAX_CHARS:
+                quote = quote[: STRADDLE_QUOTE_MAX_CHARS - 3].rstrip() + "..."
+            return StraddleHint(t_ms=first.t0_ms, quote=quote)
     return None
+
+
+def straddle_hint_t_ms(
+    manifest: Manifest, query: str, *, speaker: str | None = None
+) -> int | None:
+    """Compatibility helper returning only the adjacent-pair timestamp."""
+    hint = straddle_hint(manifest, query, speaker=speaker)
+    return hint.t_ms if hint is not None else None

--- a/src/talkthrough_mcp/guidance.py
+++ b/src/talkthrough_mcp/guidance.py
@@ -119,9 +119,9 @@ Examples:
 - keep ranges under ~30 s; a 5-min "moment" dilutes the bundle and wastes tokens
 """,
     "search": """\
-Case-insensitive word search across BOTH transcript segments and frame OCR text: a text \
-hits when EVERY word of the query matches it as a substring — any order, any distance \
-(ё and е are interchangeable). Hits carry source (transcript|ocr), t_ms, t_wall when \
+Case-insensitive word search across BOTH transcript segments and frame OCR text. The default \
+match_mode="all_words" requires EVERY query word as a substring; match_mode="any_word" \
+requires at least one (ё and е are interchangeable). Hits carry source (transcript|ocr), t_ms, t_wall when \
 known, the matched text, and the nearest frame position — everything needed to jump \
 straight to evidence. Optional speaker accepts a raw label ("S2") or saved name and narrows \
 to that voice's transcript hits. Duplicate saved names search all matching labels honestly. No \
@@ -134,7 +134,7 @@ Examples:
 - search(job_id, "TypeError") — on-screen stack traces and error text are OCR-indexed; great for bug repros
 - search(job_id, "€49") — prices, IDs, and literals on screen are findable via OCR
 - take hit.t_wall and grep your server logs ±30 s around it to pair remark ↔ log line
-- no hits? shorten the stem: "notif" matches notification / notifications / notify
+- broad lexical recall: search(job_id, "timeout latency", match_mode="any_word")
 - multi-word = ALL words as substrings, any order: "first phase" hits "the first real phase"
 - stems beat inflected phrases: "кнопк отправк" finds «Кнопка отправки» and «кнопку отправки»
 - every hit has nearest_frame_ms → get_frames(job_id, at_ms=<that>) shows the moment

--- a/src/talkthrough_mcp/server.py
+++ b/src/talkthrough_mcp/server.py
@@ -37,7 +37,7 @@ from .core.manifest import (
     save_manifest,
     search_manifest,
     slice_segments,
-    straddle_hint_t_ms,
+    straddle_hint,
 )
 from .core.speaker_labels import apply_speaker_label_patch
 
@@ -433,10 +433,17 @@ def get_moment(job_id: str, start_ms: int, end_ms: int) -> list[str | Image]:
 
 
 @mcp.tool(description=guidance.TOOL_DESCRIPTIONS["search"], annotations=READONLY_TOOL)
-def search(job_id: str, query: str, speaker: str | None = None) -> dict[str, Any]:
+def search(
+    job_id: str,
+    query: str,
+    speaker: str | None = None,
+    match_mode: Literal["all_words", "any_word"] = "all_words",
+) -> dict[str, Any]:
     manifest = _load(job_id)
     if not query.strip():
         raise ToolError("query is empty — pass a distinctive word or phrase")
+    if match_mode not in {"all_words", "any_word"}:
+        raise ToolError("match_mode must be 'all_words' or 'any_word'")
     diarization = manifest.transcript.diarization
     speaker_query = speaker.strip() if speaker and speaker.strip() else None
     speaker_labels: list[str] = []
@@ -447,6 +454,7 @@ def search(job_id: str, query: str, speaker: str | None = None) -> dict[str, Any
             return {
                 "job_id": job_id,
                 "query": query,
+                **({"match_mode": match_mode} if match_mode != "all_words" else {}),
                 "speaker": speaker_query.upper(),
                 "hit_count": 0,
                 "truncated": False,
@@ -496,6 +504,7 @@ def search(job_id: str, query: str, speaker: str | None = None) -> dict[str, Any
             return {
                 "job_id": job_id,
                 "query": query,
+                **({"match_mode": match_mode} if match_mode != "all_words" else {}),
                 "speaker": canonical_label if canonical_label.startswith("S") else speaker_query,
                 "hit_count": 0,
                 "truncated": False,
@@ -506,11 +515,11 @@ def search(job_id: str, query: str, speaker: str | None = None) -> dict[str, Any
         hits = [
             hit
             for label in speaker_labels
-            for hit in search_manifest(manifest, query, speaker=label)
+            for hit in search_manifest(manifest, query, speaker=label, match_mode=match_mode)
         ]
         hits.sort(key=lambda hit: (hit.t_ms, hit.source, hit.seq or 0))
     else:
-        hits = search_manifest(manifest, query)
+        hits = search_manifest(manifest, query, match_mode=match_mode)
     truncated = len(hits) > SEARCH_MAX_HITS
     notes: list[str] = []
     if speaker_labels:
@@ -522,20 +531,25 @@ def search(job_id: str, query: str, speaker: str | None = None) -> dict[str, Any
                 f"saved name {speaker_value!r} maps to multiple labels: "
                 + ", ".join(speaker_labels)
             )
-    if not hits and len(query.split()) >= 2:
+    if not hits and len(query.split()) >= 2 and match_mode == "all_words":
         # v0.2.3: a zero-hit multi-word query stops being mute. Word-AND is
         # per-segment; the cheap adjacent-pair scan tells apart "phrase
         # straddles a segment boundary" from "words never co-occur".
-        straddle_candidates = [
-            straddle_hint_t_ms(manifest, query, speaker=label) for label in speaker_labels
-        ] if speaker_labels else [straddle_hint_t_ms(manifest, query)]
-        straddle_ms = min(
-            (value for value in straddle_candidates if value is not None), default=None
+        straddle_candidates = (
+            [straddle_hint(manifest, query, speaker=label) for label in speaker_labels]
+            if speaker_labels
+            else [straddle_hint(manifest, query)]
         )
-        if straddle_ms is not None:
+        straddle_match = min(
+            (value for value in straddle_candidates if value is not None),
+            key=lambda value: value.t_ms,
+            default=None,
+        )
+        if straddle_match is not None:
             notes.append(
-                f"the words appear together around t_ms={straddle_ms}, split across "
-                "adjacent segments (matching is per-segment) — read get_transcript there"
+                f"the words appear together around t_ms={straddle_match.t_ms}, split "
+                "across adjacent segments (matching is per-segment); bounded quote: "
+                f"{straddle_match.quote!r} — read get_transcript there"
             )
         else:
             notes.append(
@@ -545,6 +559,7 @@ def search(job_id: str, query: str, speaker: str | None = None) -> dict[str, Any
     return {
         "job_id": job_id,
         "query": query,
+        **({"match_mode": match_mode} if match_mode != "all_words" else {}),
         **({"speaker": speaker_value} if speaker_value else {}),
         **({"speaker_labels": speaker_labels} if len(speaker_labels) > 1 else {}),
         "hit_count": len(hits),
@@ -662,6 +677,7 @@ def list_jobs() -> dict[str, Any]:
         "jobs": [
             {
                 "job_id": manifest.job_id,
+                "media": {"path": manifest.media.path},
                 "filename": manifest.media.filename,
                 "kind": manifest.media.kind,
                 "duration_s": manifest.media.duration_s,

--- a/tests/e2e/test_mcp_client.py
+++ b/tests/e2e/test_mcp_client.py
@@ -184,6 +184,18 @@ async def _run_session(home: Path) -> None:
             )
         )
         assert multiword["hit_count"] >= 1, "order-free multi-word query must hit"
+        any_word = _payload(
+            await session.call_tool(
+                "search",
+                {
+                    "job_id": job_id,
+                    "query": "login zzznonexistent",
+                    "match_mode": "any_word",
+                },
+            )
+        )
+        assert any_word["match_mode"] == "any_word"
+        assert any_word["hit_count"] >= 1
         undiarized_filter = _payload(
             await session.call_tool(
                 "search", {"job_id": job_id, "query": "login", "speaker": "S1"}
@@ -215,7 +227,8 @@ async def _run_session(home: Path) -> None:
         # 7. list_jobs sees the processed job.
         jobs_result = await session.call_tool("list_jobs", {})
         jobs_payload = _payload(jobs_result)
-        assert any(job["job_id"] == job_id for job in jobs_payload["jobs"])
+        stored_job = next(job for job in jobs_payload["jobs"] if job["job_id"] == job_id)
+        assert stored_job["media"]["path"] == str(DEMO_MP4)
 
         # 8. Issues #13 + #14 on the wire: every served frame carries an
         # absolute existing path AND its validity span.

--- a/tests/unit/test_guidance.py
+++ b/tests/unit/test_guidance.py
@@ -60,6 +60,12 @@ def test_registered_tools_match_guidance_exactly() -> None:
         assert len(guidance.example_lines(tool.description or "")) >= MIN_EXAMPLES
 
 
+def test_search_guidance_documents_both_match_modes() -> None:
+    description = guidance.TOOL_DESCRIPTIONS["search"]
+    assert 'match_mode="all_words"' in description
+    assert 'match_mode="any_word"' in description
+
+
 def test_every_tool_carries_honest_annotations() -> None:
     """Non-interactive clients (codex exec) silently cancel un-annotated tool
     calls — every tool must ship hints, and they must stay truthful."""

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -31,6 +31,7 @@ from talkthrough_mcp.core.manifest import (
     save_manifest,
     search_manifest,
     slice_segments,
+    straddle_hint,
     straddle_hint_t_ms,
 )
 from talkthrough_mcp.core.stt import SttWord
@@ -170,6 +171,17 @@ def test_whitespace_only_tokens_return_nothing() -> None:
     assert search_manifest(manifest, " \t\n ") == []
 
 
+def test_any_word_mode_broadens_multiword_recall_without_changing_default() -> None:
+    manifest = make_manifest()
+    assert search_manifest(manifest, "login settings") == []
+    hits = search_manifest(manifest, "login settings", match_mode="any_word")
+    assert {hit.t_ms for hit in hits} == {0, 6000, 12_012}
+    assert {hit.source for hit in hits} == {"transcript", "ocr"}
+
+    with pytest.raises(ValueError, match="unknown match_mode"):
+        search_manifest(manifest, "login", match_mode="unsupported")  # type: ignore[arg-type]
+
+
 # --- search(speaker=) --------------------------------------------------------
 
 
@@ -199,12 +211,28 @@ def test_straddle_hint_names_the_first_boundary_pair() -> None:
     # "dashboard settings" never lands in ONE segment but meets across 2|3
     assert search_manifest(manifest, "dashboard settings") == []
     assert straddle_hint_t_ms(manifest, "dashboard settings") == 2500
+    hint = straddle_hint(manifest, "dashboard settings")
+    assert hint is not None
+    assert hint.quote == "The dashboard shows an error message. Settings look fine."
     # same normalization as the search: case + ё/е fold
     assert straddle_hint_t_ms(manifest, "DASHBOARD Settings") == 2500
     # words that never meet even across adjacent segments
     assert straddle_hint_t_ms(manifest, "login settings") is None
     # single-word queries never produce the hint (behavior unchanged there)
     assert straddle_hint_t_ms(manifest, "dashboard") is None
+
+
+def test_straddle_hint_quote_is_bounded() -> None:
+    manifest = make_manifest()
+    segment_type = type(manifest.transcript.segments[0])
+    manifest.transcript.segments = [
+        segment_type(seq=1, t0_ms=0, t1_ms=1000, text="start " + "a" * 300),
+        segment_type(seq=2, t0_ms=1000, t1_ms=2000, text="finish"),
+    ]
+    hint = straddle_hint(manifest, "start finish")
+    assert hint is not None
+    assert len(hint.quote) == 240
+    assert hint.quote.endswith("...")
 
 
 def test_straddle_hint_ignores_ocr_text() -> None:

--- a/tests/unit/test_server_tools.py
+++ b/tests/unit/test_server_tools.py
@@ -213,6 +213,7 @@ def test_search_zero_hit_multiword_notes_explain_the_miss(isolated_home: Path) -
     straddle = search(job_id, "dashboard settings")
     assert straddle["hit_count"] == 0
     assert "t_ms=2500" in straddle["note"]
+    assert "The dashboard shows an error message. Settings look fine." in straddle["note"]
     assert "get_transcript" in straddle["note"]
     # "login settings" never meets even across adjacent segments → generic note
     generic = search(job_id, "login settings")
@@ -224,6 +225,25 @@ def test_search_zero_hit_multiword_notes_explain_the_miss(isolated_home: Path) -
     # non-zero-hit payloads stay note-free
     hit = search(job_id, "dashboard error")
     assert hit["hit_count"] >= 1 and "note" not in hit
+
+
+def test_search_any_word_mode_and_validation(isolated_home: Path) -> None:
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    from talkthrough_mcp.server import search
+
+    job_id = _store(make_manifest())
+    default = search(job_id, "login settings")
+    assert "match_mode" not in default  # default payload shape remains byte-compatible
+    assert default["hit_count"] == 0
+
+    broadened = search(job_id, "login settings", match_mode="any_word")
+    assert broadened["match_mode"] == "any_word"
+    assert broadened["hit_count"] == 4
+    assert "note" not in broadened
+
+    with pytest.raises(ToolError, match="match_mode must be"):
+        search(job_id, "login", match_mode="unsupported")  # type: ignore[arg-type]
 
 
 # --- v0.2.6 F7: a silent recording serves an honest empty payload --------------
@@ -288,6 +308,7 @@ def test_list_jobs_flags_silent_jobs(isolated_home: Path) -> None:
     entries = {entry["job_id"]: entry for entry in list_jobs()["jobs"]}
     assert entries[voiced]["has_transcript"] is True
     assert entries[silent]["has_transcript"] is False
+    assert entries[voiced]["media"]["path"] == f"/recordings/{voiced}.mp4"
     # segment_count 0 alone cannot make the distinction — that is the point
     assert entries[silent]["segment_count"] == 0
 


### PR DESCRIPTION
## Summary
- expose the stored source as `list_jobs.jobs[].media.path`
- add opt-in `search(..., match_mode="any_word")` while preserving the default all-words payload and behavior
- include a bounded adjacent-segment quote in the existing straddle note
- update canonical guidance/skill, generated Claude skill, README, unit coverage, and real MCP E2E

## Verification
- `uv run pytest tests/unit -q` (272 passed)
- `uv run pytest tests/e2e/test_mcp_client.py -q` (1 passed)
- `uv run pytest -q` (314 passed)
- `uv run ruff check`
- `uv run mypy src`
- `uv run python scripts/gen_integrations.py` + drift unit test
- `git diff --check`