### PR TITLE
fix: report early frame-cap exhaustion honestly

### DIFF
--- a/src/talkthrough_mcp/core/pipeline.py
+++ b/src/talkthrough_mcp/core/pipeline.py
@@ -909,10 +909,20 @@ def _summarize_frames(manifest: Manifest) -> dict[str, Any]:
     if manifest.media.has_video and floor_s > 1.0:
         interval_s = round(floor_s)
         payload["sampling_interval_s"] = interval_s
-        payload["note"] = (
-            f"frames sampled every ~{interval_s}s across the whole recording — "
-            "exact instants via extract_frame"
-        )
+        if manifest.frames.cap_hit and manifest.frames.items:
+            last_sample_ms = max(item.ms for item in manifest.frames.items)
+            duration_ms = round(manifest.media.duration_s * 1000)
+            payload["note"] = (
+                f"adaptive ~{interval_s}s sampling plus scene changes filled the "
+                f"{manifest.frames.count}-frame cap at t_ms={last_sample_ms} of "
+                f"duration_ms={duration_ms}; later moments may lack a sampled frame — "
+                "exact instants via extract_frame"
+            )
+        else:
+            payload["note"] = (
+                f"frames sampled every ~{interval_s}s across the whole recording — "
+                "exact instants via extract_frame"
+            )
     return payload
 
 

--- a/tests/unit/test_summarize.py
+++ b/tests/unit/test_summarize.py
@@ -23,6 +23,25 @@ def test_long_recording_summary_names_the_sampling_interval() -> None:
     assert "extract_frame" in frames["note"]
 
 
+def test_scene_dense_long_recording_does_not_claim_whole_recording_coverage() -> None:
+    manifest = make_manifest()
+    manifest.media = replace(manifest.media, duration_s=1576.363)
+    manifest.frames.cap_hit = True
+    manifest.frames.items[-1].ms = 1_430_240
+    manifest.frames.count = 600
+
+    frames = summarize(
+        ProcessResult(manifest=manifest, reused=False, elapsed_s=1.0)
+    )["frames"]
+
+    assert frames["sampling_interval_s"] == 3
+    assert "600-frame cap" in frames["note"]
+    assert "t_ms=1430240" in frames["note"]
+    assert "duration_ms=1576363" in frames["note"]
+    assert "later moments may lack" in frames["note"]
+    assert "across the whole recording" not in frames["note"]
+
+
 def test_short_recording_summary_stays_byte_stable() -> None:
     frames = _summary(duration_s=18.0)["frames"]
     assert frames == {"count": 4, "unique_count": 3, "cap_hit": False}


### PR DESCRIPTION
## Summary
- report the exact last sampled timestamp when scene changes exhaust the frame cap
- stop claiming whole-recording frame coverage for an early capped extraction
- keep the existing adaptive interval and exact-frame guidance

## Acceptance evidence
`brew.mp4` produced 600 frames through `t_ms=1430240` for a `duration_ms=1576363` recording. The old note claimed coverage across the whole recording; the new note exposes the gap.

## Tests
- `uv run pytest tests/unit -q` (273 passed)
- `uv run ruff check src/talkthrough_mcp/core/pipeline.py tests/unit/test_summarize.py`
- `uv run mypy src`