### PR TITLE
chore: prepare talkthrough-mcp v0.3.2

### DIFF
--- a/.agents/skills/talkthrough/SKILL.md
+++ b/.agents/skills/talkthrough/SKILL.md
@@ -19,7 +19,7 @@ never ask for more than the moment you are analyzing.
 
 The `talkthrough` MCP server must be connected (tools like
 `process_media` / `get_transcript` are visible). If not, tell the user to
-install it: `claude mcp add -s user talkthrough -- uvx talkthrough-mcp`
+install it: `claude mcp add -s user talkthrough -- uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"`
 (see the repository README for other clients).
 
 ## Core workflow
@@ -56,7 +56,10 @@ install it: `claude mcp add -s user talkthrough -- uvx talkthrough-mcp`
    old-roster context anchors to re-check them. A pending label still in the
    roster can be confirmed, replaced, or removed; a stale pending label can
    only be removed with `labels={"Sx":null}`. Never use a pending name in
-   minutes or search as though it were active.
+   minutes or search as though it were active. A full `force=true` rebuild of
+   a job with active or pending names must also use `diarize=true`; it rebuilds
+   safely and moves every old identity to pending review, while omitting
+   diarization is refused without changing the stored job.
 6. **Recall across sessions**: `list_jobs()` — the store persists; a file
    processed yesterday (even via CLI) is queryable by `job_id` today.
 
@@ -69,7 +72,8 @@ VERBATIM from the payload — never compute it from `t_ms` yourself
 correlate remarks with server/app logs (±30 s grep window). If
 `wall_clock` is null or low-confidence, ask the user when the recording
 started and re-anchor: `process_media(path, recorded_at="<ISO 8601>",
-force=true)`.
+force=true)`; when the job already has speaker identities, include
+`diarize=true` as required by the safe-rebuild contract.
 
 ## Packaged workflows (server prompts)
 
@@ -97,6 +101,10 @@ friendly), `correlate-with-logs`.
   UI text, a job title, or somebody else's name. Inspect the cited frame and
   persist only defensible mappings with `label_speakers`; never auto-save a
   candidate.
+  A `name_candidates_note` on a pre-0.3.1 video job explains that its legacy
+  flat OCR may not yield hints. The job remains readable; regenerate only when
+  useful, with `force=true, diarize=true`, so old identities become pending
+  review instead of being lost.
   `diarize=true` needs the `[diarization]` extra — its absence produces an
   actionable install-hint error.
 - Findings/quotes must cite the narrator's exact words + `t_ms` (+ `t_wall`

--- a/.agents/skills/talkthrough/SKILL.md
+++ b/.agents/skills/talkthrough/SKILL.md
@@ -52,9 +52,11 @@ install it: `claude mcp add -s user talkthrough -- uvx talkthrough-mcp`
    evidence={"S1":"intro or frame proof"})`. Saved names appear in later
    transcript, moment, and search calls while raw `S1`/`S2` labels remain.
    If a diarization amend changes labels, those names move to
-   `speaker_names_pending_review` and stop being identities. Re-check the
-   current roster, then explicitly confirm or remove each affected label;
-   never use a pending name in minutes or search as though it were active.
+   `speaker_names_pending_review` and stop being identities. Use the stored
+   old-roster context anchors to re-check them. A pending label still in the
+   roster can be confirmed, replaced, or removed; a stale pending label can
+   only be removed with `labels={"Sx":null}`. Never use a pending name in
+   minutes or search as though it were active.
 6. **Recall across sessions**: `list_jobs()` — the store persists; a file
    processed yesterday (even via CLI) is queryable by `job_id` today.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketplace for the talkthrough plugin: narrated screen recordings in, agent-ready evidence out.",
-    "version": "0.3.1"
+    "version": "0.3.2"
   },
   "plugins": [
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,14 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
+          python-version: "3.12"
       - name: Cache whisper model + venv (static-ffmpeg/OCR binaries live inside)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ~/.cache/huggingface
             .venv
-          key: ${{ runner.os }}-talkthrough-${{ hashFiles('uv.lock') }}
+          key: ${{ runner.os }}-py3.12-talkthrough-${{ hashFiles('uv.lock') }}
       - name: Cache diarization models (URLs + sha256 are pinned, assets immutable)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
@@ -40,6 +41,40 @@ jobs:
       - run: uv run pytest tests/unit -q
       - run: uv run pytest tests/integration -q
       - run: uv run pytest tests/e2e -q
+      - name: Generated launcher in bash
+        run: uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]" --help
+      - name: Generated launcher in POSIX sh
+        shell: sh
+        run: |
+          uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]" --help
+          test ! -e '=3.11,'
+
+  python-compat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    env:
+      TALKTHROUGH_WHISPER_MODEL: tiny
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+      - name: Sync frozen environment for Python ${{ matrix.python-version }}
+        run: uv sync --frozen --extra diarization --python ${{ matrix.python-version }}
+      - run: uv run --python ${{ matrix.python-version }} pytest tests/unit -q
+      - run: uv run --python ${{ matrix.python-version }} python -c "import talkthrough_mcp, sherpa_onnx; print(talkthrough_mcp.__version__)"
+      - run: uv run --python ${{ matrix.python-version }} talkthrough-mcp --help
+      - run: uv run --python ${{ matrix.python-version }} python scripts/check_mcp_inventory.py
+      - name: Real CLI fixture smoke on Python 3.13
+        if: matrix.python-version == '3.13'
+        env:
+          TALKTHROUGH_HOME: ${{ github.workspace }}/.talkthrough-py313
+        run: uv run --python 3.13 talkthrough-mcp process tests/fixtures/talkthrough-demo.mp4
 
   macos:
     runs-on: macos-latest
@@ -49,9 +84,18 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
+          python-version: "3.12"
       - run: uv sync --frozen
       - run: uv run ruff check
       - run: uv run pytest tests/unit -q
+      - name: Generated launcher in zsh
+        shell: zsh {0}
+        run: |
+          uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]" --help
+          test ! -e '=3.11,'
+      - name: Generated launcher in POSIX sh
+        shell: sh
+        run: uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]" --help
 
   # Keeps the Windows path honest (issue #1): imports, unit suite, and a real
   # CLI smoke over the fixture (static-ffmpeg Windows build + whisper tiny +
@@ -73,11 +117,12 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
+          python-version: "3.12"
       - name: Cache whisper model
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/huggingface
-          key: ${{ runner.os }}-talkthrough-${{ hashFiles('uv.lock') }}
+          key: ${{ runner.os }}-py3.12-talkthrough-${{ hashFiles('uv.lock') }}
       - name: Cache diarization models (URLs + sha256 are pinned, assets immutable)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
@@ -87,6 +132,16 @@ jobs:
       - run: uv sync --frozen --extra diarization
       - run: uv run ruff check
       - run: uv run pytest tests/unit -q
+      - name: Generated launcher in PowerShell
+        shell: pwsh
+        run: |
+          uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]" --help
+          if (Test-Path '=3.11,') { throw 'launcher created a redirection artifact' }
+      - name: Generated launcher in cmd.exe
+        shell: cmd
+        run: |
+          uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]" --help
+          if exist "=3.11," exit /b 1
       - name: CLI smoke on the committed fixture
         run: uv run talkthrough-mcp process tests/fixtures/talkthrough-demo.mp4
       - name: Idempotent re-run returns instantly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,9 @@ jobs:
       - name: Extract release notes from CHANGELOG
         shell: bash
         run: |
+          PROJECT_VERSION="$(uv version --short)"
           uv run python scripts/extract_release_notes.py \
-            --version "${GITHUB_REF_NAME#v}" \
+            --version "$PROJECT_VERSION" \
             --tag "$GITHUB_REF_NAME" \
             --output release-notes.md
       - run: uv build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Extract release notes from CHANGELOG
+        shell: bash
+        run: |
+          uv run python scripts/extract_release_notes.py \
+            --version "${GITHUB_REF_NAME#v}" \
+            --tag "$GITHUB_REF_NAME" \
+            --output release-notes.md
       - run: uv build
 
       - name: Generate signed build provenance
@@ -57,6 +64,10 @@ jobs:
         with:
           name: provenance
           path: dist/*.intoto.jsonl
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-notes
+          path: release-notes.md
 
   publish-pypi:
     needs: build
@@ -86,6 +97,11 @@ jobs:
         with:
           name: provenance
           path: provenance/
-      - run: gh release create "$GITHUB_REF_NAME" dist/* provenance/* --generate-notes
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-notes
+      - run: >-
+          gh release create "$GITHUB_REF_NAME" dist/* provenance/*
+          --notes-file release-notes.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,73 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [SemVer](https://semver.org/).
 
+## [0.3.2] — 2026-09-03
+
+A data-safety and portability patch from externally reproduced reports. No
+tools, prompts, dependencies, or manifest schema versions were added.
+
+### Fixed
+
+- **Pending speaker identities are lossless across repeated relabels.** Active
+  and already-pending names now merge deterministically instead of replacing
+  each other. Every retained item carries bounded old-roster context; current
+  labels can be confirmed, replaced, or removed, stale labels can be removed
+  explicitly, and superseded collisions are reported once instead of being
+  silently discarded.
+- **Full forced reprocessing is transactional and identity-safe.** A job is
+  rebuilt in a hidden same-filesystem staging directory, validated, and
+  committed manifest-last; STT, diarization, OCR, validation, or commit
+  failures keep the previous manifest and frames intact. A named job refuses
+  a full rebuild unless diarization is resolved on, and successful rebuilds
+  move every previous identity to pending review against the new roster.
+- **Legacy OCR limitations are explicit.** Video jobs produced before 0.3.1
+  with flat OCR remain readable without migration and now explain why name
+  candidates may be absent and how to regenerate safely. The candidate filter
+  accepts broader real-world names, particles, apostrophes, lowercase scripts,
+  and trailing role metadata while rejecting known UI chrome; hints remain
+  capped, deduplicated, and never become identities automatically.
+- **Every agent-facing `uvx` launcher selects supported Python portably.** The
+  canonical argv is `--python`, `>=3.11,<3.14`, and the package spec. Shell
+  prose uses portable double quotes, while JSON, TOML, deeplinks, and plugin
+  arguments retain raw argv values. A generator-owned quoting allowlist and
+  repository-wide semantic audit prevent shell redirection regressions.
+- **Supported interpreters are continuously exercised.** CI now runs frozen
+  unit/import/CLI/MCP inventory checks on Python 3.11, 3.12, and 3.13 in
+  addition to the existing Linux, macOS, and Windows gates. Native bash, sh,
+  zsh, PowerShell, and cmd launcher smokes verify the same 8-tool/6-prompt
+  server contract.
+- **Cold-start, TLS, and cache recovery instructions name the actual stages.**
+  Documentation separates uv environment resolution, managed Python, media
+  assets, and warm offline processing; covers `SSL_CERT_FILE`,
+  `UV_SYSTEM_CERTS`, `UV_PYTHON_INSTALL_MIRROR`, targeted prune/clean commands,
+  and the distinct Talkthrough job GC scope.
+- **GitHub Release notes are deterministic.** The release workflow extracts
+  this exact changelog section and fails before publishing on a missing,
+  duplicate, empty, or tag-mismatched section. Documentation tests now assert
+  operational facts instead of pinning incidental marketing prose.
+- **Cross-segment evidence no longer renders a doubled crop marker.** Two
+  independently cropped quote windows share one `…` at their boundary while
+  preserving search semantics and the 240-character cap.
+
+### Compatibility
+
+- Existing 0.1.x–0.3.1 manifests load in place without migration or rewrite;
+  pre-0.3.1 flat OCR remains unchanged and is described by a response-only
+  compatibility note.
+- Full force reprocessing of a job with saved or pending speaker identities now
+  requires diarization and changes those identities from active claims to
+  pending-review evidence. Unnamed jobs retain the previous force behavior.
+- OCR text produced by current versions keeps embedded newlines between
+  detected boxes; search whitespace behavior and bounded response shapes are
+  unchanged.
+- Progress remains the first MCP notification and no deprecated logging
+  capability is reintroduced. A failed diarization amend or full force returns
+  an error and preserves the old stored job rather than persisting an
+  `available=false` replacement.
+- The root development `.mcp.json` remains a local `uv run --directory`
+  configuration. Generated distribution launchers and the released Claude
+  plugin use the supported Python selector; tool and prompt counts remain 8/6.
+
 ## [0.3.1] — 2026-09-02
 
 A compatibility-and-honesty patch from six externally reproduced findings.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ system. Choose this for a minimal setup, or when you manage MCP servers
 yourself across several clients:
 
 ```bash
-claude mcp add -s user talkthrough -- uvx --python '>=3.11,<3.14' 'talkthrough-mcp[diarization]'
+claude mcp add -s user talkthrough -- uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"
 ```
 
 **Full plugin** — the same server, plus native slash commands
@@ -344,7 +344,7 @@ More: [`integrations/zed/`](integrations/zed/)
 
 </details>
 
-Any other MCP stdio client uses the same server command: `uvx --python '>=3.11,<3.14' 'talkthrough-mcp[diarization]'`.
+Any other MCP stdio client uses the same server command: `uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"`.
 Per-engine folders with exactly these snippets plus verification steps live
 in [`integrations/`](integrations/); agents can self-install via
 [`llms-install.md`](llms-install.md).
@@ -361,7 +361,7 @@ works — diarization itself still runs only when requested per call
 and its models download once on first use.
 
 Prefer the minimal server without the diarization engine? Use
-`uvx talkthrough-mcp` as the command instead (the MCP registry entry also
+`uvx --python ">=3.11,<3.14" talkthrough-mcp` as the command instead (the MCP registry entry also
 resolves to this lean form) — an explicit `diarize=true` will then answer
 with the one-line install fix. Details in
 [Speakers](#speakers-optional-diarization).
@@ -460,6 +460,11 @@ torch, no accounts, no GPU):
   it re-runs *only* diarization — whisper is not re-run, and labels land in
   the existing job. Same for changing `num_speakers`. The diarization stage
   itself still re-scans the full audio: minutes on long recordings.
+- **Full rebuilds keep named jobs safe.** If a job has active or pending names,
+  `force=true` also requires `diarize=true`; otherwise the call refuses before
+  changing stored data. A successful force rebuilds in staging and moves every
+  previous identity to pending review against the fresh roster. Any processing
+  or commit failure leaves the prior manifest and frames intact.
 - Labels start anonymous. After checking self-introductions, vocatives, or
   video evidence, call `label_speakers` to preserve a verified mapping such
   as `S1` → "Alice" across sessions. The roster can expose bounded OCR
@@ -469,6 +474,10 @@ torch, no accounts, no GPU):
   active and move to bounded `speaker_names_pending_review` evidence instead
   of being silently lost. Re-check the current roster and explicitly confirm
   or remove each affected label with `label_speakers`.
+- Video jobs produced before 0.3.1 keep their original flat OCR and can return
+  `name_candidates_note` to explain why hints are absent. They remain fully
+  readable without migration; `force=true, diarize=true` regenerates line-aware
+  OCR while preserving saved identities for review.
 
 Models download once (~47 MB total) from pinned, checksum-verified URLs into
 `~/.talkthrough/models/`; warm runs are zero-network like the rest of the

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -97,6 +97,17 @@ the second call on the same bytes returns the stored summary in milliseconds.
                                     "speaker_name_evidence_pending_review"?: {
                                       "S1": "frame proof"
                                     },
+                                    "speaker_names_pending_review_context"?: {
+                                      "S1": {
+                                        "source_detected_num_speakers": 2,
+                                        "source_requested_num_speakers": 2,
+                                        "source_produced_by": "0.3.2",
+                                        "talk_time_ms": 18342,
+                                        "turn_count": 4,
+                                        "longest_turn_at_ms": 5210,
+                                        "longest_turn_duration_ms": 7040
+                                      }
+                                    },
                                     "turns": [[t0_ms, t1_ms, "S1"], …] } },
   "frames": { "count", "unique_count", "cap_hit",
               "items": [{ "ms", "file", "duplicate_of"?, "ocr_text"? }] },
@@ -144,6 +155,10 @@ The whole tool surface is built to keep responses small:
   each ≤80 characters. The deterministic filter rejects obvious UI chrome,
   digits, URLs/paths, and long copy; candidates remain unverified hints and
   never become active names without `label_speakers`.
+- Pending speaker identities are capped on response surfaces and stay
+  separate from active names. Each served entry may carry a bounded anchor
+  to its source roster; stale labels can only be removed with an explicit
+  null patch and never become active automatically.
 - Tool descriptions themselves are budgeted: one-line examples, ≤120 chars
   each (gated by `tests/unit/test_guidance.py`).
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -5,9 +5,16 @@ Short answers to the failure modes people actually hit. If yours isn't here,
 
 ## First run is slow / downloads a lot
 
-There are two separate cold-start stages. First, `uvx` resolves a compatible
-Python and creates an environment for the requested package version. Then the
-first `process_media` downloads media/model assets that are still missing:
+Cold setup has four separate stages; identify the failing stage before
+changing caches or certificates:
+
+1. `uvx` resolves the package and creates its isolated environment.
+2. If no compatible interpreter exists, uv downloads a managed Python.
+3. The first `process_media` downloads media/model assets that are still missing.
+4. Warm processing uses the installed environment and local caches without
+   runtime network access.
+
+First-media assets can include:
 
 - no system ffmpeg → `static-ffmpeg` fetches a bundled build (~80 MB);
 - first transcription → whisper model download into `~/.cache/huggingface`
@@ -20,9 +27,9 @@ environment. After a plugin update, a machine without system ffmpeg may
 therefore fetch the ~80 MB static build again; one external cold run took
 about 50 seconds, but that is an observation, not a timing promise. The
 Whisper, OCR, and diarization model caches are shared across those tool
-environments. Set `SSL_CERT_FILE` in the MCP server environment before the
-first media processing on a TLS-inspecting corporate network, because the
-static-ffmpeg download needs the same trusted CA as model downloads.
+environments. Set `SSL_CERT_FILE` before either uv setup or the first media
+processing on a TLS-inspecting corporate network: managed Python, package,
+static-ffmpeg, and model downloads all need the trusted CA.
 
 A second run in the same warm environment does not redownload dependencies.
 Warm processing is network-free and reuses model caches; re-processing the
@@ -32,8 +39,21 @@ typically around 3× faster than real time (a 2-minute clip ≈ 40 s).
 
 ## Corporate networks: model downloads stall or fail TLS
 
-Two env vars fix the one-time downloads on locked-down networks (warm runs
+The settings below fix one-time downloads on locked-down networks (warm runs
 are offline and unaffected):
+
+- **uv environment or managed Python download fails TLS** — use the OS trust
+  store with `UV_SYSTEM_CERTS=true`, or point `SSL_CERT_FILE` at a PEM bundle
+  containing the corporate CA. A diagnostic/preseed command isolates this
+  stage before launching the server:
+
+  ```bash
+  uv python install 3.12
+  ```
+
+  `UV_PYTHON_INSTALL_MIRROR` is supported for an organization mirror of
+  `python-build-standalone`; use it only when that mirror preserves uv's
+  expected release path layout. It does not disable certificate validation.
 
 - **Whisper download hangs / stalls at 0%** — some proxies break Hugging
   Face's Xet transfer protocol. Disable it; downloads fall back to plain
@@ -72,7 +92,7 @@ diarization integration tests download models on first run, so a fresh
 
 Your Python is older than 3.11 (macOS ships 3.9 as `/usr/bin/python3`), so
 pip filters out every release and prints the confusing "from versions: none".
-Fixes: use `uvx talkthrough-mcp` (uv picks a compatible Python by itself), or
+Fixes: use `uvx --python ">=3.11,<3.14" talkthrough-mcp`, or
 create the venv from a modern interpreter, e.g. `python3.12 -m venv`.
 
 ## `uvx` selects managed Python 3.10 and cannot resolve Talkthrough
@@ -84,14 +104,14 @@ No solution found ... current Python version (3.10.x) does not satisfy Python>=3
 ```
 
 Inspect the selected interpreter with `uv python find`. If no compatible
-managed Python is available, install one with `uv python install 3.12`; a
-manual launch can select it explicitly:
+managed Python is available, install one with `uv python install 3.12`; this
+diagnostic manual launch pins 3.12 explicitly:
 
 ```bash
-uvx --python 3.12 "talkthrough-mcp[diarization]"
+uvx --python "3.12" "talkthrough-mcp[diarization]"
 ```
 
-Generated Talkthrough v0.3.1 client configs and the Claude plugin already
+Generated Talkthrough v0.3.2 client configs and the Claude plugin
 pass the canonical `>=3.11,<3.14` range from `pyproject.toml`, so uv selects
 or downloads a compatible interpreter instead of inheriting Python 3.10.
 
@@ -113,7 +133,7 @@ constraint rather than overriding the package metadata, so using it with
 0.3.0 fails resolution as unsatisfiable. Refresh the tool environment instead:
 
 ```bash
-uvx --refresh "talkthrough-mcp[diarization]" --help
+uvx --refresh --python ">=3.11,<3.14" "talkthrough-mcp[diarization]" --help
 ```
 
 The history below applies only to older Talkthrough releases.
@@ -130,7 +150,7 @@ Fixed for the 0.2.x line in **0.2.5** (`mcp>=1.28.1,<2`). Unpinned `uvx`
 setups picked that bound up on their next resolve; the historical refresh was:
 
 ```bash
-uvx --refresh "talkthrough-mcp[diarization]" --help
+uvx --refresh --python ">=3.11,<3.14" "talkthrough-mcp[diarization]" --help
 ```
 
 then reconnect (`/mcp`). The interim `"--with", "mcp<2"` launch argument is
@@ -158,7 +178,8 @@ plugin list` prints the id to use.
 ## The plugin says 0.2.3 but the server reports a newer version
 
 Also expected, and the reverse of the case above. The plugin launches the
-server unpinned (`uvx talkthrough-mcp[diarization]`), so a session started
+server unpinned (`uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"`),
+so a session started
 after a PyPI release resolves the NEWEST server even while the plugin — the
 slash commands, the skill, the triage agent — is still on your installed
 version. Sessions started before the release keep serving the older one in
@@ -229,8 +250,9 @@ same file is an instant re-call, and `list_jobs()` finds the job.
 ## `diarize=true` fails with "[diarization]" in the error
 
 The optional engine isn't installed. Use
-`uvx "talkthrough-mcp[diarization]"` as the server command (JSON configs:
-`"args": ["talkthrough-mcp[diarization]"]`), restart the client, retry.
+`uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"` as the server
+command (JSON configs: `"args": ["--python", ">=3.11,<3.14",
+"talkthrough-mcp[diarization]"]`), restart the client, retry.
 
 If you installed into your own uv **project** (`uv add
 "talkthrough-mcp[diarization]"`) and `import sherpa_onnx` fails with a
@@ -272,6 +294,22 @@ the engine (a mistyped `TALKTHROUGH_DIARIZATION_*_MODEL`, a dead model
 download); 0.3.1 extends the same fail-safe contract to failures inside the
 diarization run. Correct the environment and retry the amend.
 
+The same atomic contract covers a full `force=true` rebuild. If the stored job
+has active or pending speaker identities, the rebuild must explicitly resolve
+`diarize=true`; omitting or disabling diarization is rejected before probing or
+staging. On success every previous identity becomes pending-review evidence
+against the fresh roster. A transcription, diarization, frame/OCR, validation,
+or commit failure leaves the previous manifest and frames readable.
+
+## A legacy video has no OCR name candidates
+
+Video jobs produced before 0.3.1 stored OCR as a flat line, so current name
+candidate heuristics may have no useful line boundaries. The job is not corrupt
+and is served without migration; transcript and saved identities remain intact.
+The response-only `name_candidates_note` explains this case. Regenerate only if
+the hints matter, using `force=true, diarize=true`; line-aware OCR is rebuilt and
+all previous identities move to pending review rather than disappearing.
+
 ## `t_wall` is null or looks wrong
 
 - The recorder wrote no usable metadata — pass
@@ -289,8 +327,13 @@ Everything lives under `~/.talkthrough` (override with `TALKTHROUGH_HOME`):
 
 - `talkthrough-mcp gc --keep-days 30` prunes old jobs; deleting the whole
   directory removes every job.
-- Whisper models cache in `~/.cache/huggingface`; uvx environments are
-  cleared with `uv cache clean`.
+- Whisper models cache in `~/.cache/huggingface`; `uv cache prune` is the
+  ordinary cleanup for unused uv entries and cached tool environments.
+- `uv cache clean talkthrough-mcp` removes that package's uv cache entries;
+  bare `uv cache clean` clears the entire uv cache. Both can force package or
+  tool-environment downloads again, so use them only for deliberate repair.
+- `talkthrough-mcp gc --keep-days 30` cleans Talkthrough jobs and abandoned
+  job staging; it does not clean uv environments, Python installs, or models.
 
 Nothing is written anywhere else, and there is no telemetry to opt out of.
 

--- a/examples/prompts/meeting-actions.md
+++ b/examples/prompts/meeting-actions.md
@@ -28,8 +28,9 @@ them, and that is fine.
    OCR/frames over the transcript for names. State the mapping first (e.g.
    `S1 = Vera, S2 = Tom, S3 = unidentified`) — never guess beyond the
    evidence. If the header carries speaker_names_pending_review, those names
-   came from an older roster and are NOT active identities: re-check each one
-   against the current roster before confirming or removing it.
+   came from an older roster and are NOT active identities: use their stored
+   context anchors to re-check each one. Confirm/replace only labels that are
+   still current; remove stale labels with an explicit null patch.
 5. Persist every defensible mapping with label_speakers(job_id="<job_id>",
    labels={"S1":"<name>"}, evidence={"S1":"<intro, frame, or attendee proof>"}).
    Never save OCR name_candidates directly: they are raw hints that may be UI

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -3,7 +3,7 @@
 The talkthrough MCP server is engine-agnostic (stdio MCP). Server command:
 
 ```
-uvx --python '>=3.11,<3.14' 'talkthrough-mcp[diarization]'
+uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"
 ```
 
 One folder per engine with the exact config to paste:

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "talkthrough",
   "description": "Turn screen recordings into transcript, exact frames, OCR and wall-clock evidence — then into ready-to-file bug drafts, specs, backlogs and meeting actions. Bundles the talkthrough MCP server, six workflow commands, a triage agent, and an agent skill.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": {
     "name": "korovin-aa97",
     "url": "https://github.com/korovin-aa97"

--- a/integrations/claude-code/.mcp.json
+++ b/integrations/claude-code/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--python",
         ">=3.11,<3.14",
-        "talkthrough-mcp[diarization]==0.3.1"
+        "talkthrough-mcp[diarization]==0.3.2"
       ]
     }
   }

--- a/integrations/claude-code/commands/meeting-actions.md
+++ b/integrations/claude-code/commands/meeting-actions.md
@@ -34,8 +34,9 @@ them, and that is fine.
    OCR/frames over the transcript for names. State the mapping first (e.g.
    `S1 = Vera, S2 = Tom, S3 = unidentified`) — never guess beyond the
    evidence. If the header carries speaker_names_pending_review, those names
-   came from an older roster and are NOT active identities: re-check each one
-   against the current roster before confirming or removing it.
+   came from an older roster and are NOT active identities: use their stored
+   context anchors to re-check each one. Confirm/replace only labels that are
+   still current; remove stale labels with an explicit null patch.
 5. Persist every defensible mapping with label_speakers(job_id="$ARGUMENTS",
    labels={"S1":"<name>"}, evidence={"S1":"<intro, frame, or attendee proof>"}).
    Never save OCR name_candidates directly: they are raw hints that may be UI

--- a/integrations/claude-code/skills/talkthrough/SKILL.md
+++ b/integrations/claude-code/skills/talkthrough/SKILL.md
@@ -19,7 +19,7 @@ never ask for more than the moment you are analyzing.
 
 The `talkthrough` MCP server must be connected (tools like
 `process_media` / `get_transcript` are visible). If not, tell the user to
-install it: `claude mcp add -s user talkthrough -- uvx talkthrough-mcp`
+install it: `claude mcp add -s user talkthrough -- uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"`
 (see the repository README for other clients).
 
 ## Core workflow
@@ -56,7 +56,10 @@ install it: `claude mcp add -s user talkthrough -- uvx talkthrough-mcp`
    old-roster context anchors to re-check them. A pending label still in the
    roster can be confirmed, replaced, or removed; a stale pending label can
    only be removed with `labels={"Sx":null}`. Never use a pending name in
-   minutes or search as though it were active.
+   minutes or search as though it were active. A full `force=true` rebuild of
+   a job with active or pending names must also use `diarize=true`; it rebuilds
+   safely and moves every old identity to pending review, while omitting
+   diarization is refused without changing the stored job.
 6. **Recall across sessions**: `list_jobs()` — the store persists; a file
    processed yesterday (even via CLI) is queryable by `job_id` today.
 
@@ -69,7 +72,8 @@ VERBATIM from the payload — never compute it from `t_ms` yourself
 correlate remarks with server/app logs (±30 s grep window). If
 `wall_clock` is null or low-confidence, ask the user when the recording
 started and re-anchor: `process_media(path, recorded_at="<ISO 8601>",
-force=true)`.
+force=true)`; when the job already has speaker identities, include
+`diarize=true` as required by the safe-rebuild contract.
 
 ## Packaged workflows (server prompts)
 
@@ -97,6 +101,10 @@ friendly), `correlate-with-logs`.
   UI text, a job title, or somebody else's name. Inspect the cited frame and
   persist only defensible mappings with `label_speakers`; never auto-save a
   candidate.
+  A `name_candidates_note` on a pre-0.3.1 video job explains that its legacy
+  flat OCR may not yield hints. The job remains readable; regenerate only when
+  useful, with `force=true, diarize=true`, so old identities become pending
+  review instead of being lost.
   `diarize=true` needs the `[diarization]` extra — its absence produces an
   actionable install-hint error.
 - Findings/quotes must cite the narrator's exact words + `t_ms` (+ `t_wall`

--- a/integrations/claude-code/skills/talkthrough/SKILL.md
+++ b/integrations/claude-code/skills/talkthrough/SKILL.md
@@ -52,9 +52,11 @@ install it: `claude mcp add -s user talkthrough -- uvx talkthrough-mcp`
    evidence={"S1":"intro or frame proof"})`. Saved names appear in later
    transcript, moment, and search calls while raw `S1`/`S2` labels remain.
    If a diarization amend changes labels, those names move to
-   `speaker_names_pending_review` and stop being identities. Re-check the
-   current roster, then explicitly confirm or remove each affected label;
-   never use a pending name in minutes or search as though it were active.
+   `speaker_names_pending_review` and stop being identities. Use the stored
+   old-roster context anchors to re-check them. A pending label still in the
+   roster can be confirmed, replaced, or removed; a stale pending label can
+   only be removed with `labels={"Sx":null}`. Never use a pending name in
+   minutes or search as though it were active.
 6. **Recall across sessions**: `list_jobs()` — the store persists; a file
    processed yesterday (even via CLI) is queryable by `job_id` today.
 

--- a/integrations/claude-desktop/manifest.json
+++ b/integrations/claude-desktop/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "talkthrough",
   "display_name": "Talkthrough — narrated recordings for your agent",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Turn narrated screen recordings into structured evidence: local Whisper transcript, scene keyframes, OCR, wall-clock anchoring. Record, talk — Claude writes the bug report.",
   "author": {
     "name": "korovin-aa97",

--- a/integrations/cline/README.md
+++ b/integrations/cline/README.md
@@ -1,6 +1,6 @@
 # Cline / Roo Code
 
-Server command (stdio): `uvx --python '>=3.11,<3.14' 'talkthrough-mcp[diarization]'`
+Server command (stdio): `uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"`
 
 Config: `cline_mcp_settings.json (via MCP Servers UI)`
 
@@ -21,7 +21,7 @@ Config: `cline_mcp_settings.json (via MCP Servers UI)`
 
 Fastest path: ask Cline to install it — point it at [`llms-install.md`](../../llms-install.md).
 
-Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx talkthrough-mcp`.
+Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx --python ">=3.11,<3.14" talkthrough-mcp`.
 
 Verify: the client should list 8 tools (process_media, get_transcript, get_frames, get_moment, search, label_speakers, extract_frame, list_jobs). A `list_jobs` call returning an empty list is a healthy first run.
 

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,6 +1,6 @@
 # OpenAI Codex CLI
 
-Server command (stdio): `uvx --python '>=3.11,<3.14' 'talkthrough-mcp[diarization]'`
+Server command (stdio): `uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"`
 
 Config: `~/.codex/config.toml (or project-scoped .codex/config.toml in trusted projects)`
 
@@ -12,7 +12,7 @@ args = ["--python", ">=3.11,<3.14", "talkthrough-mcp[diarization]"]
 
 Skills: this repo ships the talkthrough skill at `.agents/skills/talkthrough/` — Codex discovers it automatically inside a checkout; for global use copy it to `~/.agents/skills/` and invoke with `$talkthrough`.
 
-Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx talkthrough-mcp`.
+Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx --python ">=3.11,<3.14" talkthrough-mcp`.
 
 Verify: the client should list 8 tools (process_media, get_transcript, get_frames, get_moment, search, label_speakers, extract_frame, list_jobs). A `list_jobs` call returning an empty list is a healthy first run.
 

--- a/integrations/copilot-cli/README.md
+++ b/integrations/copilot-cli/README.md
@@ -1,6 +1,6 @@
 # GitHub Copilot CLI
 
-Server command (stdio): `uvx --python '>=3.11,<3.14' 'talkthrough-mcp[diarization]'`
+Server command (stdio): `uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"`
 
 Config: `~/.copilot/mcp-config.json`
 
@@ -19,7 +19,7 @@ Config: `~/.copilot/mcp-config.json`
 }
 ```
 
-Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx talkthrough-mcp`.
+Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx --python ">=3.11,<3.14" talkthrough-mcp`.
 
 Verify: the client should list 8 tools (process_media, get_transcript, get_frames, get_moment, search, label_speakers, extract_frame, list_jobs). A `list_jobs` call returning an empty list is a healthy first run.
 

--- a/integrations/cursor/README.md
+++ b/integrations/cursor/README.md
@@ -1,6 +1,6 @@
 # Cursor
 
-Server command (stdio): `uvx --python '>=3.11,<3.14' 'talkthrough-mcp[diarization]'`
+Server command (stdio): `uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"`
 
 Config: `~/.cursor/mcp.json (or project .cursor/mcp.json)`
 
@@ -19,7 +19,7 @@ Config: `~/.cursor/mcp.json (or project .cursor/mcp.json)`
 }
 ```
 
-Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx talkthrough-mcp`.
+Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx --python ">=3.11,<3.14" talkthrough-mcp`.
 
 Verify: the client should list 8 tools (process_media, get_transcript, get_frames, get_moment, search, label_speakers, extract_frame, list_jobs). A `list_jobs` call returning an empty list is a healthy first run.
 

--- a/integrations/gemini-cli/README.md
+++ b/integrations/gemini-cli/README.md
@@ -1,6 +1,6 @@
 # Gemini CLI
 
-Server command (stdio): `uvx --python '>=3.11,<3.14' 'talkthrough-mcp[diarization]'`
+Server command (stdio): `uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"`
 
 Config: `~/.gemini/settings.json`
 
@@ -19,7 +19,7 @@ Config: `~/.gemini/settings.json`
 }
 ```
 
-Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx talkthrough-mcp`.
+Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx --python ">=3.11,<3.14" talkthrough-mcp`.
 
 Verify: the client should list 8 tools (process_media, get_transcript, get_frames, get_moment, search, label_speakers, extract_frame, list_jobs). A `list_jobs` call returning an empty list is a healthy first run.
 

--- a/integrations/goose/README.md
+++ b/integrations/goose/README.md
@@ -1,6 +1,6 @@
 # Goose
 
-Server command (stdio): `uvx --python '>=3.11,<3.14' 'talkthrough-mcp[diarization]'`
+Server command (stdio): `uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"`
 
 Config: `~/.config/goose/config.yaml`
 
@@ -13,7 +13,7 @@ extensions:
     args: ["--python", ">=3.11,<3.14", "talkthrough-mcp[diarization]"]
 ```
 
-Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx talkthrough-mcp`.
+Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx --python ">=3.11,<3.14" talkthrough-mcp`.
 
 Verify: the client should list 8 tools (process_media, get_transcript, get_frames, get_moment, search, label_speakers, extract_frame, list_jobs). A `list_jobs` call returning an empty list is a healthy first run.
 

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -1,6 +1,6 @@
 # OpenClaw
 
-Server command (stdio): `uvx --python '>=3.11,<3.14' 'talkthrough-mcp[diarization]'`
+Server command (stdio): `uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"`
 
 Config: `~/.openclaw/openclaw.json`
 
@@ -24,12 +24,12 @@ Config: `~/.openclaw/openclaw.json`
 Or via CLI:
 
 ```bash
-openclaw mcp add talkthrough --command uvx --arg --python --arg '>=3.11,<3.14' --arg 'talkthrough-mcp[diarization]'
+openclaw mcp add talkthrough --command uvx --arg --python --arg ">=3.11,<3.14" --arg "talkthrough-mcp[diarization]"
 ```
 
 ClawHub: a publish-ready skill wrapper lives in [`clawhub/`](clawhub/) (submit after the repo is public).
 
-Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx talkthrough-mcp`.
+Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx --python ">=3.11,<3.14" talkthrough-mcp`.
 
 Verify: the client should list 8 tools (process_media, get_transcript, get_frames, get_moment, search, label_speakers, extract_frame, list_jobs). A `list_jobs` call returning an empty list is a healthy first run.
 

--- a/integrations/openclaw/clawhub/SKILL.md
+++ b/integrations/openclaw/clawhub/SKILL.md
@@ -13,7 +13,7 @@ workflow. Everything runs locally: recordings never leave the machine.
 Add the MCP server:
 
 ```bash
-openclaw mcp add talkthrough --command uvx --arg --python --arg '>=3.11,<3.14' --arg 'talkthrough-mcp[diarization]'
+openclaw mcp add talkthrough --command uvx --arg --python --arg ">=3.11,<3.14" --arg "talkthrough-mcp[diarization]"
 ```
 
 Requires `uv` (https://astral.sh/uv). First processing downloads a whisper

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -1,6 +1,6 @@
 # OpenCode
 
-Server command (stdio): `uvx --python '>=3.11,<3.14' 'talkthrough-mcp[diarization]'`
+Server command (stdio): `uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"`
 
 Config: `opencode.json (project) or ~/.config/opencode/opencode.json`
 
@@ -21,7 +21,7 @@ Config: `opencode.json (project) or ~/.config/opencode/opencode.json`
 }
 ```
 
-Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx talkthrough-mcp`.
+Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx --python ">=3.11,<3.14" talkthrough-mcp`.
 
 Verify: the client should list 8 tools (process_media, get_transcript, get_frames, get_moment, search, label_speakers, extract_frame, list_jobs). A `list_jobs` call returning an empty list is a healthy first run.
 

--- a/integrations/windsurf/README.md
+++ b/integrations/windsurf/README.md
@@ -1,6 +1,6 @@
 # Windsurf
 
-Server command (stdio): `uvx --python '>=3.11,<3.14' 'talkthrough-mcp[diarization]'`
+Server command (stdio): `uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"`
 
 Config: `~/.codeium/windsurf/mcp_config.json`
 
@@ -19,7 +19,7 @@ Config: `~/.codeium/windsurf/mcp_config.json`
 }
 ```
 
-Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx talkthrough-mcp`.
+Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx --python ">=3.11,<3.14" talkthrough-mcp`.
 
 Verify: the client should list 8 tools (process_media, get_transcript, get_frames, get_moment, search, label_speakers, extract_frame, list_jobs). A `list_jobs` call returning an empty list is a healthy first run.
 

--- a/integrations/zed/README.md
+++ b/integrations/zed/README.md
@@ -1,6 +1,6 @@
 # Zed
 
-Server command (stdio): `uvx --python '>=3.11,<3.14' 'talkthrough-mcp[diarization]'`
+Server command (stdio): `uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"`
 
 Config: `settings.json (Zed)`
 
@@ -22,7 +22,7 @@ Config: `settings.json (Zed)`
 }
 ```
 
-Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx talkthrough-mcp`.
+Optional env vars: TALKTHROUGH_WHISPER_MODEL (default `small`; use `large-v3-turbo` for non-English narration — agents can also pass `model=` per call), TALKTHROUGH_OCR (`off` to disable), TALKTHROUGH_OCR_LANG (on-screen-text script, e.g. `ru`, `ja`, `ko`), TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). Speaker diarization is included but off per call — agents pass `diarize=true` (plus `num_speakers` when known); the minimal server without the diarization engine is `uvx --python ">=3.11,<3.14" talkthrough-mcp`.
 
 Verify: the client should list 8 tools (process_media, get_transcript, get_frames, get_moment, search, label_speakers, extract_frame, list_jobs). A `list_jobs` call returning an empty list is a healthy first run.
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -16,21 +16,23 @@ turns narrated screen recordings / audio files into queryable structured data
 ## Server command (stdio)
 
 ```
-uvx "talkthrough-mcp[diarization]"
+uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"
 ```
 
 This is the batteries-included form (adds local who-said-what speaker
 labeling; ~20 MB extra wheels, models download only on first use). The
-minimal server without the diarization engine is `uvx talkthrough-mcp`.
-(Latest unreleased main instead: `uvx --from "talkthrough-mcp[diarization] @
-git+https://github.com/korovin-aa97/talkthrough-mcp" talkthrough-mcp`)
+minimal server without the diarization engine is
+`uvx --python ">=3.11,<3.14" talkthrough-mcp`.
+(Latest unreleased main instead: `uvx --python ">=3.11,<3.14" --from
+"talkthrough-mcp[diarization] @ git+https://github.com/korovin-aa97/talkthrough-mcp"
+talkthrough-mcp`.)
 
 ## Client configuration
 
 ### Claude Code
 
 ```bash
-claude mcp add -s user talkthrough -- uvx talkthrough-mcp
+claude mcp add -s user talkthrough -- uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"
 ```
 
 ### Claude Desktop / Cursor / Cline / any JSON-config client
@@ -43,7 +45,7 @@ Add to the client's MCP servers config (`claude_desktop_config.json`,
   "mcpServers": {
     "talkthrough": {
       "command": "uvx",
-      "args": ["talkthrough-mcp"]
+      "args": ["--python", ">=3.11,<3.14", "talkthrough-mcp[diarization]"]
     }
   }
 }
@@ -64,7 +66,7 @@ participant count is known — it is the main accuracy lever. Calling
 `diarize=true` on an already-processed job adds speakers without
 re-transcribing. Diarization models (~47 MB) download once, pinned and
 checksum-verified. If the user explicitly wants the minimal install
-(`uvx talkthrough-mcp`, no diarization engine), an explicit `diarize=true`
+(`uvx --python ">=3.11,<3.14" talkthrough-mcp`, no diarization engine), an explicit `diarize=true`
 will answer with the one-line reinstall hint — relay it verbatim.
 
 ## Verify the installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "talkthrough-mcp"
-version = "0.3.1"
+version = "0.3.2"
 description = "Local MCP server: turn screen recordings into transcript, exact frames, OCR and wall-clock evidence for coding agents."
 readme = "README.md"
 authors = [

--- a/scripts/check_mcp_inventory.py
+++ b/scripts/check_mcp_inventory.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Initialize the local stdio server and verify its public inventory."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from talkthrough_mcp import __version__, guidance
+
+
+async def check() -> None:
+    with tempfile.TemporaryDirectory(prefix="talkthrough-inventory-") as home:
+        params = StdioServerParameters(
+            command=sys.executable,
+            args=["-m", "talkthrough_mcp.cli", "serve"],
+            env={**os.environ, "TALKTHROUGH_HOME": home},
+            cwd=str(Path(__file__).resolve().parents[1]),
+        )
+        async with (
+            stdio_client(params) as (read, write),
+            ClientSession(read, write) as session,
+        ):
+            initialized = await session.initialize()
+            tools = await session.list_tools()
+            prompts = await session.list_prompts()
+            assert initialized.server_info.version == __version__
+            assert sorted(tool.name for tool in tools.tools) == sorted(guidance.TOOL_NAMES)
+            assert sorted(prompt.name for prompt in prompts.prompts) == sorted(
+                guidance.PROMPT_NAMES
+            )
+            print(
+                f"talkthrough-mcp {__version__}: "
+                f"{len(tools.tools)} tools, {len(prompts.prompts)} prompts"
+            )
+
+
+if __name__ == "__main__":
+    asyncio.run(check())

--- a/scripts/check_mcp_inventory.py
+++ b/scripts/check_mcp_inventory.py
@@ -19,7 +19,10 @@ async def check() -> None:
     with tempfile.TemporaryDirectory(prefix="talkthrough-inventory-") as home:
         params = StdioServerParameters(
             command=sys.executable,
-            args=["-m", "talkthrough_mcp.cli", "serve"],
+            args=[
+                "-c",
+                "from talkthrough_mcp.cli import main; main(['serve'])",
+            ],
             env={**os.environ, "TALKTHROUGH_HOME": home},
             cwd=str(Path(__file__).resolve().parents[1]),
         )

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Extract one exact Keep-a-Changelog release section for publishing."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+VERSION_RE = re.compile(r"\d+\.\d+\.\d+")
+
+
+class ReleaseNotesError(ValueError):
+    """The requested changelog section is not safe to publish."""
+
+
+def normalized_version(value: str, *, field: str) -> str:
+    version = value.removeprefix("v")
+    if VERSION_RE.fullmatch(version) is None:
+        raise ReleaseNotesError(f"invalid {field}: {value!r}")
+    return version
+
+
+def extract_release_notes(changelog: str, version: str, *, tag: str | None = None) -> str:
+    """Return exactly one non-empty ``## [version]`` section."""
+    requested = normalized_version(version, field="version")
+    if tag is not None:
+        tagged = normalized_version(tag, field="tag")
+        if not tag.startswith("v"):
+            raise ReleaseNotesError(f"release tag must start with 'v': {tag!r}")
+        if tagged != requested:
+            raise ReleaseNotesError(
+                f"release tag/version mismatch: tag={tag!r}, version={requested!r}"
+            )
+
+    heading = re.compile(rf"^## \[{re.escape(requested)}\](?:\s+[^\n]*)?$", re.MULTILINE)
+    matches = list(heading.finditer(changelog))
+    if len(matches) != 1:
+        qualifier = "missing" if not matches else "duplicate"
+        raise ReleaseNotesError(f"{qualifier} changelog section for {requested}")
+
+    start = matches[0].start()
+    next_heading = re.search(r"^## \[", changelog[matches[0].end() :], re.MULTILINE)
+    end = (
+        matches[0].end() + next_heading.start()
+        if next_heading is not None
+        else len(changelog)
+    )
+    section = changelog[start:end].strip()
+    body = section.split("\n", 1)[1].strip() if "\n" in section else ""
+    if not body:
+        raise ReleaseNotesError(f"empty changelog section for {requested}")
+    return section + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="release version, e.g. 0.3.2")
+    parser.add_argument("--tag", help="optional matching v-prefixed tag, e.g. v0.3.2")
+    parser.add_argument(
+        "--changelog", type=Path, default=Path("CHANGELOG.md"), help="changelog path"
+    )
+    parser.add_argument("--output", type=Path, help="write notes here instead of stdout")
+    args = parser.parse_args(argv)
+
+    try:
+        notes = extract_release_notes(
+            args.changelog.read_text(encoding="utf-8"), args.version, tag=args.tag
+        )
+    except (OSError, ReleaseNotesError) as exc:
+        parser.error(str(exc))
+
+    if args.output is None:
+        sys.stdout.write(notes)
+    else:
+        args.output.write_text(notes, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gen_integrations.py
+++ b/scripts/gen_integrations.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import base64
 import json
-import shlex
 import sys
 import tomllib
 import urllib.parse
@@ -56,14 +55,34 @@ _UVX_ARGS = {
     "pypi": [*UVX_PYTHON_ARGS, _PYPI_SPEC],
 }
 UVX_ARGS: list[str] = _UVX_ARGS[INSTALL_PHASE]
+MINIMAL_UVX_ARGS = [*UVX_PYTHON_ARGS, "talkthrough-mcp"]
 
 
-def _shell_quoted(arg: str) -> str:
-    """Quote a single argv item for POSIX shell snippets and one-liners."""
-    return shlex.quote(arg)
+_SHELL_OWNED_ARGS = frozenset(
+    {
+        "--from",
+        "--python",
+        PROJECT_REQUIRES_PYTHON,
+        _GIT_SPEC,
+        _PYPI_SPEC,
+        "talkthrough-mcp",
+    }
+)
 
 
-UVX_CMDLINE = "uvx " + " ".join(_shell_quoted(arg) for arg in UVX_ARGS)
+def _shell_owned_arg(arg: str) -> str:
+    """Render one generator-owned argv item portably for human shell snippets."""
+    if arg not in _SHELL_OWNED_ARGS:
+        raise ValueError(f"refusing to quote non-generator argv item: {arg!r}")
+    if any(character in arg for character in ('"', "$", "`", "\r", "\n")):
+        raise ValueError(f"unsafe generator argv item: {arg!r}")
+    return arg if arg.startswith("--") or arg == "talkthrough-mcp" else f'"{arg}"'
+
+
+UVX_CMDLINE = "uvx " + " ".join(_shell_owned_arg(arg) for arg in UVX_ARGS)
+MINIMAL_UVX_CMDLINE = "uvx " + " ".join(
+    _shell_owned_arg(arg) for arg in MINIMAL_UVX_ARGS
+)
 
 # A released Claude Code plugin pack must always start its matching server.
 # User-facing install snippets intentionally remain unpinned latest via
@@ -82,7 +101,7 @@ ENV_DOC = (
     "TALKTHROUGH_HOME (job store root, default `~/.talkthrough`). "
     "Speaker diarization is included but off per call — agents pass "
     "`diarize=true` (plus `num_speakers` when known); the minimal server "
-    "without the diarization engine is `uvx talkthrough-mcp`."
+    f"without the diarization engine is `{MINIMAL_UVX_CMDLINE}`."
 )
 
 VERIFY_DOC = (
@@ -162,7 +181,7 @@ ENGINE_SPECS: list[dict[str, str]] = [
         ),
         "extra": (
             "Or via CLI:\n\n```bash\nopenclaw mcp add talkthrough --command uvx "
-            + " ".join(f"--arg {_shell_quoted(arg)}" for arg in UVX_ARGS)
+            + " ".join(f"--arg {_shell_owned_arg(arg)}" for arg in UVX_ARGS)
             + "\n```\n\nClawHub: a publish-ready skill wrapper lives in "
             "[`clawhub/`](clawhub/) (submit after the repo is public)."
         ),
@@ -629,7 +648,7 @@ workflow. Everything runs locally: recordings never leave the machine.
 Add the MCP server:
 
 ```bash
-openclaw mcp add talkthrough --command uvx {" ".join(f"--arg {_shell_quoted(arg)}" for arg in UVX_ARGS)}
+openclaw mcp add talkthrough --command uvx {" ".join(f"--arg {_shell_owned_arg(arg)}" for arg in UVX_ARGS)}
 ```
 
 Requires `uv` (https://astral.sh/uv). First processing downloads a whisper

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/korovin-aa97/talkthrough-mcp",
     "source": "github"
   },
-  "version": "0.3.1",
+  "version": "0.3.2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "talkthrough-mcp",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/talkthrough_mcp/cli.py
+++ b/src/talkthrough_mcp/cli.py
@@ -143,7 +143,10 @@ def _cmd_gc(args: argparse.Namespace) -> int:
     if result.removed:
         print(f"removed {len(result.removed)} job(s): {', '.join(result.removed)}")
     if result.swept:
-        print(f"swept {len(result.swept)} partial dir(s): {', '.join(result.swept)}")
+        print(
+            f"swept {len(result.swept)} partial/staging dir(s): "
+            f"{', '.join(result.swept)}"
+        )
     if not result.removed and not result.swept:
         print(f"nothing to remove (keep-days={args.keep_days})")
     return 0

--- a/src/talkthrough_mcp/core/diarize.py
+++ b/src/talkthrough_mcp/core/diarize.py
@@ -130,6 +130,85 @@ class SpeakerStat:
     last_ms: int
 
 
+@dataclass(frozen=True)
+class PendingSpeakerReviewContext:
+    """Bounded anchor back to the diarization generation an identity came from.
+
+    The context is evidence location only. It never claims that an old ``S1``
+    and the current ``S1`` describe the same voice.
+    """
+
+    source_detected_num_speakers: int | None = None
+    source_requested_num_speakers: int | None = None
+    source_produced_by: str | None = None
+    talk_time_ms: int | None = None
+    turn_count: int | None = None
+    longest_turn_at_ms: int | None = None
+    longest_turn_duration_ms: int | None = None
+
+    def to_dict(self) -> dict[str, int | str]:
+        return {
+            key: value
+            for key, value in (
+                ("source_detected_num_speakers", self.source_detected_num_speakers),
+                ("source_requested_num_speakers", self.source_requested_num_speakers),
+                ("source_produced_by", self.source_produced_by),
+                ("talk_time_ms", self.talk_time_ms),
+                ("turn_count", self.turn_count),
+                ("longest_turn_at_ms", self.longest_turn_at_ms),
+                ("longest_turn_duration_ms", self.longest_turn_duration_ms),
+            )
+            if value is not None
+        }
+
+    @staticmethod
+    def from_dict(payload: object) -> PendingSpeakerReviewContext | None:
+        """Parse one future-tolerant entry; malformed entries are skipped."""
+        if not isinstance(payload, dict):
+            return None
+
+        def nonnegative_int(key: str) -> int | None:
+            value = payload.get(key)
+            if value is None:
+                return None
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(key)
+            return value
+
+        try:
+            produced_by = payload.get("source_produced_by")
+            if produced_by is not None and (
+                not isinstance(produced_by, str) or not produced_by.strip()
+            ):
+                return None
+            context = PendingSpeakerReviewContext(
+                source_detected_num_speakers=nonnegative_int(
+                    "source_detected_num_speakers"
+                ),
+                source_requested_num_speakers=nonnegative_int(
+                    "source_requested_num_speakers"
+                ),
+                source_produced_by=produced_by,
+                talk_time_ms=nonnegative_int("talk_time_ms"),
+                turn_count=nonnegative_int("turn_count"),
+                longest_turn_at_ms=nonnegative_int("longest_turn_at_ms"),
+                longest_turn_duration_ms=nonnegative_int(
+                    "longest_turn_duration_ms"
+                ),
+            )
+        except ValueError:
+            return None
+        return context if context.to_dict() else None
+
+
+@dataclass(frozen=True)
+class PendingSpeakerIdentityMerge:
+    names: dict[str, str]
+    evidence: dict[str, str]
+    context: dict[str, PendingSpeakerReviewContext]
+    dropped: dict[str, str]
+
+
 @dataclass
 class Diarization:
     """Additive manifest block under ``transcript`` (schema stays v1).
@@ -154,10 +233,13 @@ class Diarization:
     speaker_name_evidence: dict[str, str] | None = None
     # A label-changing amend must deactivate human-verified identities (the
     # new S<n> roster may describe different voices), but it must never erase
-    # the user's work. Keep exactly the latest unreviewed mapping as bounded
-    # evidence until label_speakers explicitly confirms/removes each label.
+    # the user's work. Persist every disjoint pending label; response surfaces
+    # apply their own cap until label_speakers reviews or removes each entry.
     speaker_names_pending_review: dict[str, str] | None = None
     speaker_name_evidence_pending_review: dict[str, str] | None = None
+    speaker_names_pending_review_context: (
+        dict[str, PendingSpeakerReviewContext] | None
+    ) = None
     # Amend outcome metadata; each field stays absent on legacy manifests.
     # ``labels_changed``: set only by the amend path — did the re-run actually
     # relabel anything? ``amend_reason``: which explicit input invalidated the
@@ -206,6 +288,16 @@ class Diarization:
             }
             if pending_evidence:
                 payload["speaker_name_evidence_pending_review"] = pending_evidence
+            pending_context = {
+                label: context.to_dict()
+                for label, context in sorted(
+                    (self.speaker_names_pending_review_context or {}).items(),
+                    key=lambda item: speaker_label_sort_key(item[0]),
+                )
+                if label in self.speaker_names_pending_review and context.to_dict()
+            }
+            if pending_context:
+                payload["speaker_names_pending_review_context"] = pending_context
         if self.labels_changed is not None:
             payload["labels_changed"] = self.labels_changed
         if self.amend_reason is not None:
@@ -255,6 +347,19 @@ class Diarization:
             else {}
         )
         known["speaker_name_evidence_pending_review"] = pending_evidence_clean or None
+        pending_context = payload.get("speaker_names_pending_review_context")
+        pending_context_clean: dict[str, PendingSpeakerReviewContext] = {}
+        if isinstance(pending_context, dict) and known["speaker_names_pending_review"]:
+            for label in sorted(
+                pending_context, key=lambda value: speaker_label_sort_key(str(value))
+            ):
+                normalized_label = str(label)
+                if normalized_label not in known["speaker_names_pending_review"]:
+                    continue
+                parsed = PendingSpeakerReviewContext.from_dict(pending_context[label])
+                if parsed is not None:
+                    pending_context_clean[normalized_label] = parsed
+        known["speaker_names_pending_review_context"] = pending_context_clean or None
         amend_reason = payload.get("amend_reason")
         known["amend_reason"] = amend_reason if amend_reason in AMEND_REASONS else None
         return Diarization(**known)
@@ -274,6 +379,147 @@ def _label_number(label: str) -> int:
         return int(label.lstrip("S"))
     except ValueError:
         return 1 << 30
+
+
+def speaker_label_sort_key(label: str) -> tuple[int, int, str]:
+    """Numeric ``S<n>`` labels first, then deterministic lexical fallback."""
+    if label.startswith("S") and label[1:].isdigit():
+        return 0, int(label[1:]), ""
+    return 1, 0, label
+
+
+def _source_review_context(
+    diarization: Diarization, label: str
+) -> PendingSpeakerReviewContext | None:
+    stat = next((item for item in diarization.speakers if item.label == label), None)
+    valid_turns = [
+        turn
+        for turn in diarization.turns
+        if turn.speaker == label and turn.t0_ms >= 0 and turn.t1_ms >= turn.t0_ms
+    ]
+    longest = (
+        max(valid_turns, key=lambda turn: (turn.t1_ms - turn.t0_ms, -turn.t0_ms))
+        if valid_turns
+        else None
+    )
+
+    def nonnegative(value: int | None) -> int | None:
+        return value if value is not None and value >= 0 else None
+
+    context = PendingSpeakerReviewContext(
+        source_detected_num_speakers=nonnegative(
+            diarization.detected_num_speakers
+        ),
+        source_requested_num_speakers=nonnegative(
+            diarization.requested_num_speakers
+        ),
+        source_produced_by=diarization.produced_by or None,
+        talk_time_ms=nonnegative(stat.talk_time_ms) if stat is not None else None,
+        turn_count=nonnegative(stat.turn_count) if stat is not None else None,
+        longest_turn_at_ms=longest.t0_ms if longest is not None else None,
+        longest_turn_duration_ms=(
+            longest.t1_ms - longest.t0_ms if longest is not None else None
+        ),
+    )
+    return context if context.to_dict() else None
+
+
+def _combine_same_identity_context(
+    older: PendingSpeakerReviewContext | None,
+    newer: PendingSpeakerReviewContext | None,
+) -> PendingSpeakerReviewContext | None:
+    if older is None:
+        return newer
+    if newer is None:
+        return older
+    return PendingSpeakerReviewContext(
+        source_detected_num_speakers=(
+            newer.source_detected_num_speakers
+            if newer.source_detected_num_speakers is not None
+            else older.source_detected_num_speakers
+        ),
+        source_requested_num_speakers=(
+            newer.source_requested_num_speakers
+            if newer.source_requested_num_speakers is not None
+            else older.source_requested_num_speakers
+        ),
+        source_produced_by=newer.source_produced_by or older.source_produced_by,
+        talk_time_ms=(
+            newer.talk_time_ms
+            if newer.talk_time_ms is not None
+            else older.talk_time_ms
+        ),
+        turn_count=(
+            newer.turn_count if newer.turn_count is not None else older.turn_count
+        ),
+        longest_turn_at_ms=(
+            newer.longest_turn_at_ms
+            if newer.longest_turn_at_ms is not None
+            else older.longest_turn_at_ms
+        ),
+        longest_turn_duration_ms=(
+            newer.longest_turn_duration_ms
+            if newer.longest_turn_duration_ms is not None
+            else older.longest_turn_duration_ms
+        ),
+    )
+
+
+def merge_pending_speaker_identities(
+    previous: Diarization,
+) -> PendingSpeakerIdentityMerge:
+    """Merge pending identities with the previous active generation.
+
+    Active values are the latest human-verified data. They supersede a
+    conflicting pending value for the same label, while disjoint pending
+    labels remain actionable. The returned ``dropped`` map is response-only.
+    """
+    names = dict(previous.speaker_names_pending_review or {})
+    evidence = {
+        label: value
+        for label, value in (previous.speaker_name_evidence_pending_review or {}).items()
+        if label in names
+    }
+    context = {
+        label: value
+        for label, value in (previous.speaker_names_pending_review_context or {}).items()
+        if label in names
+    }
+    dropped: dict[str, str] = {}
+    for label in sorted(previous.speaker_names or {}, key=speaker_label_sort_key):
+        name = (previous.speaker_names or {})[label]
+        pending_name = names.get(label)
+        same_identity = pending_name == name
+        if pending_name is not None and not same_identity:
+            dropped[label] = pending_name
+        names[label] = name
+
+        active_evidence = (previous.speaker_name_evidence or {}).get(label)
+        if active_evidence is not None:
+            evidence[label] = active_evidence
+        elif not same_identity:
+            evidence.pop(label, None)
+
+        active_context = _source_review_context(previous, label)
+        if same_identity:
+            combined = _combine_same_identity_context(context.get(label), active_context)
+            if combined is not None:
+                context[label] = combined
+        elif active_context is not None:
+            context[label] = active_context
+        else:
+            context.pop(label, None)
+
+    ordered_labels = sorted(names, key=speaker_label_sort_key)
+    return PendingSpeakerIdentityMerge(
+        names={label: names[label] for label in ordered_labels},
+        evidence={label: evidence[label] for label in ordered_labels if label in evidence},
+        context={label: context[label] for label in ordered_labels if label in context},
+        dropped={
+            label: dropped[label]
+            for label in sorted(dropped, key=speaker_label_sort_key)
+        },
+    )
 
 
 def relabel_turns(raw_turns: Sequence[tuple[int, int, int]]) -> list[Turn]:

--- a/src/talkthrough_mcp/core/diarize.py
+++ b/src/talkthrough_mcp/core/diarize.py
@@ -56,7 +56,8 @@ MAX_DEFAULT_THREADS = 4
 
 MISSING_EXTRA_REASON = (
     "speaker diarization needs the optional sherpa-onnx engine — reinstall with the "
-    "[diarization] extra, e.g. uvx \"talkthrough-mcp[diarization]\""
+    "[diarization] extra, e.g. uvx --python \">=3.11,<3.14\" "
+    "\"talkthrough-mcp[diarization]\""
 )
 
 

--- a/src/talkthrough_mcp/core/jobs.py
+++ b/src/talkthrough_mcp/core/jobs.py
@@ -12,6 +12,7 @@ import hashlib
 import logging
 import os
 import shutil
+import tempfile
 import threading
 import time
 from collections.abc import Iterator
@@ -21,7 +22,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from .errors import ToolFailureError, UnknownJobError
-from .manifest import FRAMES_DIR_NAME, MANIFEST_NAME, Manifest, load_manifest
+from .manifest import FRAMES_DIR_NAME, MANIFEST_NAME, SCHEMA, Manifest, load_manifest
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,9 @@ _HASH_CHUNK_BYTES = 1 << 20
 # A manifest-less job dir this old cannot be a live run (processing is capped
 # at 2 h by default) — it is litter from a failure before cleanup existed.
 PARTIAL_SWEEP_MIN_AGE_S = 24 * 3600.0
+REPROCESS_PREFIX = ".reprocess-"
+REPROCESS_BACKUP_FRAMES = "previous-frames"
+REPROCESS_FAILED_FRAMES = "failed-new-frames"
 _PROCESS_LOCKS_GUARD = threading.Lock()
 _PROCESS_LOCKS: dict[str, threading.RLock] = {}
 
@@ -68,6 +72,136 @@ def load_job(job_id: str) -> Manifest:
     if not job_exists(job_id):
         raise UnknownJobError(job_id)
     return load_manifest(job_dir(job_id))
+
+
+def has_identity_state(manifest: Manifest) -> bool:
+    """Whether a full rebuild could discard human-reviewed speaker data."""
+    diarization = manifest.transcript.diarization
+    if diarization is None:
+        return False
+    return any(
+        (
+            diarization.speaker_names,
+            diarization.speaker_name_evidence,
+            diarization.speaker_names_pending_review,
+            diarization.speaker_name_evidence_pending_review,
+            diarization.speaker_names_pending_review_context,
+        )
+    )
+
+
+@contextmanager
+def reprocess_workspace(job_id: str) -> Iterator[Path]:
+    """Yield a hidden same-filesystem staging directory for a full rebuild.
+
+    The caller holds :func:`job_lock`. Keeping staging inside the live job
+    directory makes directory renames atomic while ensuring ``list_jobs``
+    never mistakes an incomplete rebuild for a separate job.
+    """
+    directory = job_dir(job_id)
+    directory.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=REPROCESS_PREFIX, dir=directory))
+    try:
+        yield staging
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def _validate_staged_job(job_id: str, staging: Path) -> Manifest:
+    """Reload and validate the bounded invariants needed before commit."""
+    try:
+        manifest = load_manifest(staging)
+    except Exception as exc:
+        raise ToolFailureError(f"staged reprocess manifest is unreadable: {exc}") from exc
+    if manifest.job_id != job_id:
+        raise ToolFailureError(
+            f"staged reprocess job_id {manifest.job_id!r} does not match {job_id!r}"
+        )
+    if manifest.schema != SCHEMA:
+        raise ToolFailureError(
+            f"staged reprocess schema {manifest.schema!r} does not match {SCHEMA!r}"
+        )
+    if manifest.frames.count != len(manifest.frames.items):
+        raise ToolFailureError("staged reprocess frame count does not match its index")
+    unique_count = sum(frame.is_unique for frame in manifest.frames.items)
+    if manifest.frames.unique_count != unique_count:
+        raise ToolFailureError("staged reprocess unique frame count does not match its index")
+    staged_frames = staging / FRAMES_DIR_NAME
+    for frame in manifest.frames.items:
+        relative = Path(frame.file)
+        if relative.is_absolute() or relative.name != frame.file:
+            raise ToolFailureError(
+                f"staged reprocess frame path is not a safe filename: {frame.file!r}"
+            )
+        if not (staged_frames / relative).is_file():
+            raise ToolFailureError(
+                f"staged reprocess frame is missing from its index: {frame.file!r}"
+            )
+
+    diarization = manifest.transcript.diarization
+    if diarization is not None:
+        active_names = diarization.speaker_names or {}
+        pending_names = diarization.speaker_names_pending_review or {}
+        if not set(diarization.speaker_name_evidence or {}) <= set(active_names):
+            raise ToolFailureError("staged active speaker evidence has no matching name")
+        if not set(diarization.speaker_name_evidence_pending_review or {}) <= set(
+            pending_names
+        ):
+            raise ToolFailureError("staged pending speaker evidence has no matching name")
+        if not set(diarization.speaker_names_pending_review_context or {}) <= set(
+            pending_names
+        ):
+            raise ToolFailureError("staged pending speaker context has no matching name")
+    return manifest
+
+
+def commit_reprocessed_job(job_id: str, staging: Path) -> Manifest:
+    """Atomically publish a validated staged rebuild, rolling frames back on error.
+
+    The caller must hold :func:`job_lock`. The old manifest remains present
+    until the last ``os.replace``; catchable failures before that point restore
+    the old frames and leave the old manifest authoritative.
+    """
+    manifest = _validate_staged_job(job_id, staging)
+    directory = job_dir(job_id)
+    live_manifest = directory / MANIFEST_NAME
+    staged_manifest = staging / MANIFEST_NAME
+    live_frames = directory / FRAMES_DIR_NAME
+    staged_frames = staging / FRAMES_DIR_NAME
+    backup_frames = staging / REPROCESS_BACKUP_FRAMES
+    failed_frames = staging / REPROCESS_FAILED_FRAMES
+    old_frames_moved = False
+    new_frames_moved = False
+    manifest_replaced = False
+    try:
+        if live_frames.exists():
+            os.replace(live_frames, backup_frames)
+            old_frames_moved = True
+        if staged_frames.exists():
+            os.replace(staged_frames, live_frames)
+            new_frames_moved = True
+        os.replace(staged_manifest, live_manifest)
+        manifest_replaced = True
+    except BaseException as exc:
+        if not manifest_replaced:
+            try:
+                if new_frames_moved and live_frames.exists():
+                    os.replace(live_frames, failed_frames)
+                if old_frames_moved and backup_frames.exists():
+                    os.replace(backup_frames, live_frames)
+                shutil.rmtree(failed_frames, ignore_errors=True)
+            except Exception as rollback_exc:
+                raise ToolFailureError(
+                    "reprocess commit failed and frame rollback also failed: "
+                    f"{rollback_exc}"
+                ) from rollback_exc
+        if isinstance(exc, Exception):
+            raise ToolFailureError(
+                "reprocess commit failed before manifest publication; the previous "
+                "job was restored — retry the operation"
+            ) from exc
+        raise
+    return manifest
 
 
 @contextmanager
@@ -280,6 +414,44 @@ def _sweep_partial_dirs(min_age_s: float = PARTIAL_SWEEP_MIN_AGE_S) -> list[str]
     return swept
 
 
+def _sweep_reprocess_dirs(min_age_s: float = PARTIAL_SWEEP_MIN_AGE_S) -> list[str]:
+    """Remove abandoned hidden rebuild workspaces without touching live runs."""
+    root = jobs_root()
+    if not root.is_dir():
+        return []
+    now = time.time()
+    swept: list[str] = []
+    for directory in root.iterdir():
+        if not directory.is_dir():
+            continue
+        for staging in directory.glob(f"{REPROCESS_PREFIX}*"):
+            if not staging.is_dir():
+                continue
+            try:
+                if now - staging.stat().st_mtime < min_age_s:
+                    continue
+            except OSError:
+                continue
+            try:
+                with job_lock(directory.name, wait_seconds=0):
+                    if not staging.is_dir():
+                        continue
+                    try:
+                        if now - staging.stat().st_mtime < min_age_s:
+                            continue
+                    except OSError:
+                        continue
+                    shutil.rmtree(staging)
+                    swept.append(f"{directory.name}/{staging.name}")
+            except ToolFailureError:
+                logger.info(
+                    "found stale reprocess dir %s/%s, left in place (job lock is held)",
+                    directory.name,
+                    staging.name,
+                )
+    return swept
+
+
 def gc(keep_days: int) -> GcResult:
     """Delete jobs older than ``keep_days`` and sweep stale partial dirs."""
     cutoff = datetime.now(UTC) - timedelta(days=keep_days)
@@ -297,4 +469,7 @@ def gc(keep_days: int) -> GcResult:
         if created < cutoff:
             delete_job(manifest.job_id)
             removed.append(manifest.job_id)
-    return GcResult(removed=removed, swept=_sweep_partial_dirs())
+    return GcResult(
+        removed=removed,
+        swept=[*_sweep_partial_dirs(), *_sweep_reprocess_dirs()],
+    )

--- a/src/talkthrough_mcp/core/manifest.py
+++ b/src/talkthrough_mcp/core/manifest.py
@@ -457,7 +457,12 @@ def _straddle_quote(first_text: str, second_text: str, tokens: list[str]) -> tup
     second_anchors = second_anchors or [0]
     first_window = _word_window(first_words, first_anchors)
     second_window = _word_window(second_words, second_anchors)
-    quote = f"{first_window} {second_window}"
+    if first_window.endswith(" …") and second_window.startswith("… "):
+        # Both independently cropped windows mark the same segment boundary.
+        # Render that boundary once instead of the noisy ``… …`` join.
+        quote = f"{first_window[:-2]} … {second_window[2:]}"
+    else:
+        quote = f"{first_window} {second_window}"
     if len(quote) <= STRADDLE_QUOTE_MAX_CHARS:
         folded_quote = _fold_for_search(quote)
         return quote, all(token in folded_quote for token in tokens)

--- a/src/talkthrough_mcp/core/pipeline.py
+++ b/src/talkthrough_mcp/core/pipeline.py
@@ -98,6 +98,9 @@ class ProcessResult:
     # Response-only collision report. The superseded pending value is not
     # persisted because the latest human-verified active value wins.
     speaker_names_pending_review_dropped: dict[str, str] | None = None
+    # Response-only explanation for a successful full rebuild that moved
+    # durable identities to pending review.
+    reprocessed_identity_review: bool = False
 
 
 def _env_int(name: str, default: int) -> int:
@@ -468,6 +471,171 @@ def _amend_diarization(
     return manifest, pending_merge.dropped if diarization.labels_changed else {}
 
 
+def _preserve_reprocessed_identities(
+    manifest: Manifest, previous: Manifest | None
+) -> tuple[dict[str, str], bool]:
+    """Move every durable identity from a prior full job into pending review."""
+    if previous is None or not jobs.has_identity_state(previous):
+        return {}, False
+    previous_diarization = previous.transcript.diarization
+    if previous_diarization is None:  # guarded by has_identity_state
+        return {}, False
+    current = manifest.transcript.diarization
+    if current is None or not current.available:
+        reason = current.reason if current is not None else "no diarization result"
+        raise ToolFailureError(
+            "forced reprocess could not rebuild speaker labels; the stored job and "
+            f"speaker identities were kept unchanged: {reason}"
+        )
+    merged = diarize.merge_pending_speaker_identities(previous_diarization)
+    current.speaker_names = None
+    current.speaker_name_evidence = None
+    current.speaker_names_pending_review = merged.names or None
+    current.speaker_name_evidence_pending_review = merged.evidence or None
+    current.speaker_names_pending_review_context = merged.context or None
+    return merged.dropped, True
+
+
+def _build_manifest(
+    media: Path,
+    job_id: str,
+    directory: Path,
+    info: MediaInfo,
+    diarize_request: _DiarizeRequest,
+    *,
+    recorded_at: str | None,
+    vocabulary: str | None,
+    language: str | None,
+    model_name: str,
+    previous: Manifest | None,
+    report: ProgressFn,
+) -> tuple[Manifest, int, dict[str, str], bool]:
+    """Build one complete manifest and its artifacts inside ``directory``."""
+    wall_clock = resolve_wall_clock(
+        recorded_at=recorded_at,
+        format_tags=info.format_tags,
+        mtime_epoch=info.mtime_epoch,
+        duration_s=info.duration_s,
+    )
+    tool_timeout = max(600, int(info.duration_s * 4) + 120)
+    duration_ms = max(1, int(info.duration_s * 1000))
+
+    transcript = Transcript(
+        available=False, reason="no audio stream in recording", language=None, model=None
+    )
+    echo_trimmed = 0
+    if info.has_audio:
+        report("extracting audio", 0.10)
+        wav_path = directory / "audio.wav"
+        try:
+            audio.extract_wav(media, wav_path, timeout=tool_timeout)
+            report("transcribing (local whisper)", 0.15)
+            # Diarization (when on) takes the 0.56→0.70 window; whisper
+            # keeps its full 0.15→0.70 span otherwise.
+            stt_span = (DIARIZE_PROGRESS_START - 0.15) if diarize_request.run else 0.55
+
+            def on_segment(t1_ms: int) -> None:
+                report("transcribing (local whisper)", 0.15 + stt_span * (t1_ms / duration_ms))
+
+            stt_result = stt.transcribe(
+                wav_path,
+                model_name=model_name,
+                language=language,
+                vocabulary=vocabulary,
+                word_timestamps=diarize_request.run,
+                on_segment=on_segment,
+            )
+            transcript = Transcript(
+                available=True,
+                reason="",
+                language=stt_result.language,
+                model=stt_result.model,
+                language_probability=stt_result.language_probability,
+                segments=list(stt_result.segments),
+                words=(list(stt_result.words) or None) if diarize_request.run else None,
+            )
+            echo_trimmed = stt_result.vocabulary_echo_trimmed
+            if diarize_request.run:
+                # The stage eats the same WAV — it must run before unlink.
+                _run_diarization(wav_path, transcript, diarize_request, report)
+            elif diarize_request.engine_missing:
+                transcript.diarization = Diarization(
+                    available=False,
+                    reason=diarize.MISSING_EXTRA_REASON,
+                    produced_by=__version__,
+                )
+        finally:
+            wav_path.unlink(missing_ok=True)
+
+    frames_directory = directory / FRAMES_DIR_NAME
+    frame_index = FrameIndex(count=0, unique_count=0, cap_hit=False)
+    ocr_ran = False
+    if info.has_video:
+        report("extracting keyframes", 0.72)
+        extracted, cap_hit = frames.extract_keyframes(
+            media,
+            frames_directory,
+            max_frames=max_frames_cap(),
+            timeout=tool_timeout,
+            duration_s=info.duration_s,
+        )
+        report("deduplicating frames", 0.82)
+        dedup.mark_duplicates(extracted, frames_directory)
+        unique = [frame for frame in extracted if frame.is_unique]
+
+        # STT ran first (pipeline order), so the detected narration language
+        # can pick the OCR script pack when no env is set.
+        engine = ocr.create_engine(language_hint=transcript.language)
+        if engine is not None:
+            ocr_ran = True
+            for index, frame in enumerate(unique):
+                fraction = 0.86 + 0.12 * (index / max(1, len(unique)))
+                report("reading text on frames (OCR)", fraction)
+                text = ocr.ocr_image(engine, frames_directory / frame.file)
+                frame.ocr_text = text or None
+
+        frame_index = FrameIndex(
+            count=len(extracted),
+            unique_count=len(unique),
+            cap_hit=cap_hit,
+            items=extracted,
+        )
+
+    manifest = Manifest(
+        schema="talkthrough-manifest/v1",
+        job_id=job_id,
+        created_at=datetime.now(UTC).isoformat(timespec="seconds"),
+        media=MediaMeta(
+            path=info.path,
+            filename=info.filename,
+            kind="video" if info.has_video else "audio",
+            duration_s=info.duration_s,
+            size_bytes=info.size_bytes,
+            width=info.width,
+            height=info.height,
+            video_codec=info.video_codec,
+            has_audio=info.has_audio,
+            has_video=info.has_video,
+        ),
+        wall_clock=wall_clock,
+        transcript=transcript,
+        frames=frame_index,
+        caps=Caps(
+            max_seconds=max_seconds_cap(),
+            max_frames=max_frames_cap(),
+            scene_threshold=frames.DEFAULT_SCENE_THRESHOLD,
+            ocr=ocr_ran,
+        ),
+        tool_versions=_tool_versions(),
+    )
+    dropped, identities_preserved = _preserve_reprocessed_identities(
+        manifest, previous
+    )
+    report("writing manifest", 0.99)
+    save_manifest(manifest, directory)
+    return manifest, echo_trimmed, dropped, identities_preserved
+
+
 def process_media(
     path: str,
     *,
@@ -543,9 +711,9 @@ def process_media(
                     manifest=amended,
                     reused=True,
                     elapsed_s=time.monotonic() - started,
-                    # the flag reflects the OUTCOME: a failed amend keeps the
-                    # transcript, records available=false + reason, and must
-                    # not be reported as an applied amend
+                    # The flag reflects the outcome. A failed amend keeps the
+                    # old manifest unchanged and raises instead of returning
+                    # an ``available=false`` replacement.
                     amended=diarization is not None and diarization.available,
                     speaker_names_pending_review_dropped=dropped or None,
                 )
@@ -553,134 +721,52 @@ def process_media(
                 manifest=manifest_hit, reused=True, elapsed_s=time.monotonic() - started
             )
 
+        directory = jobs.job_dir(job_id)
+        previous = jobs.load_job(job_id) if jobs.job_exists(job_id) else None
+        if (
+            previous is not None
+            and jobs.has_identity_state(previous)
+            and not diarize_request.run
+        ):
+            raise ValidationError(
+                "full reprocessing a job with saved speaker identities requires "
+                "force=true, diarize=true so the old identities can be preserved for "
+                "review; otherwise remove them explicitly with label_speakers first"
+            )
+
         report("probing media", 0.05)
         info = probe_media(media)
-        directory = jobs.job_dir(job_id)
         _validate_caps(info, directory)
-        wall_clock = resolve_wall_clock(
-            recorded_at=recorded_at,
-            format_tags=info.format_tags,
-            mtime_epoch=info.mtime_epoch,
-            duration_s=info.duration_s,
-        )
-
-        frames_directory = directory / FRAMES_DIR_NAME
-        if force:
-            shutil.rmtree(frames_directory, ignore_errors=True)
-            (directory / "manifest.json").unlink(missing_ok=True)
-
-        tool_timeout = max(600, int(info.duration_s * 4) + 120)
-        duration_ms = max(1, int(info.duration_s * 1000))
-
-        transcript = Transcript(
-            available=False, reason="no audio stream in recording", language=None, model=None
-        )
-        echo_trimmed = 0
-        if info.has_audio:
-            report("extracting audio", 0.10)
-            wav_path = directory / "audio.wav"
-            try:
-                audio.extract_wav(media, wav_path, timeout=tool_timeout)
-                report("transcribing (local whisper)", 0.15)
-                # Diarization (when on) takes the 0.56→0.70 window; whisper
-                # keeps its full 0.15→0.70 span otherwise.
-                stt_span = (DIARIZE_PROGRESS_START - 0.15) if diarize_request.run else 0.55
-
-                def on_segment(t1_ms: int) -> None:
-                    report("transcribing (local whisper)", 0.15 + stt_span * (t1_ms / duration_ms))
-
-                stt_result = stt.transcribe(
-                    wav_path,
-                    model_name=model_name,
-                    language=language,
-                    vocabulary=vocabulary,
-                    word_timestamps=diarize_request.run,
-                    on_segment=on_segment,
-                )
-                transcript = Transcript(
-                    available=True,
-                    reason="",
-                    language=stt_result.language,
-                    model=stt_result.model,
-                    language_probability=stt_result.language_probability,
-                    segments=list(stt_result.segments),
-                    words=(list(stt_result.words) or None) if diarize_request.run else None,
-                )
-                echo_trimmed = stt_result.vocabulary_echo_trimmed
-                if diarize_request.run:
-                    # The stage eats the same WAV — it must run before unlink.
-                    _run_diarization(wav_path, transcript, diarize_request, report)
-                elif diarize_request.engine_missing:
-                    transcript.diarization = Diarization(
-                        available=False,
-                        reason=diarize.MISSING_EXTRA_REASON,
-                        produced_by=__version__,
-                    )
-            finally:
-                wav_path.unlink(missing_ok=True)
-
-        frame_index = FrameIndex(count=0, unique_count=0, cap_hit=False)
-        ocr_ran = False
-        if info.has_video:
-            report("extracting keyframes", 0.72)
-            extracted, cap_hit = frames.extract_keyframes(
+        if previous is None:
+            manifest, echo_trimmed, dropped, identities_preserved = _build_manifest(
                 media,
-                frames_directory,
-                max_frames=max_frames_cap(),
-                timeout=tool_timeout,
-                duration_s=info.duration_s,
+                job_id,
+                directory,
+                info,
+                diarize_request,
+                recorded_at=recorded_at,
+                vocabulary=vocabulary,
+                language=language,
+                model_name=model_name,
+                previous=None,
+                report=report,
             )
-            report("deduplicating frames", 0.82)
-            dedup.mark_duplicates(extracted, frames_directory)
-            unique = [frame for frame in extracted if frame.is_unique]
-
-            # STT ran first (pipeline order), so the detected narration
-            # language can pick the OCR script pack when no env is set.
-            engine = ocr.create_engine(language_hint=transcript.language)
-            if engine is not None:
-                ocr_ran = True
-                for index, frame in enumerate(unique):
-                    fraction = 0.86 + 0.12 * (index / max(1, len(unique)))
-                    report("reading text on frames (OCR)", fraction)
-                    text = ocr.ocr_image(engine, frames_directory / frame.file)
-                    frame.ocr_text = text or None
-
-            frame_index = FrameIndex(
-                count=len(extracted),
-                unique_count=len(unique),
-                cap_hit=cap_hit,
-                items=extracted,
-            )
-
-        manifest = Manifest(
-            schema="talkthrough-manifest/v1",
-            job_id=job_id,
-            created_at=datetime.now(UTC).isoformat(timespec="seconds"),
-            media=MediaMeta(
-                path=info.path,
-                filename=info.filename,
-                kind="video" if info.has_video else "audio",
-                duration_s=info.duration_s,
-                size_bytes=info.size_bytes,
-                width=info.width,
-                height=info.height,
-                video_codec=info.video_codec,
-                has_audio=info.has_audio,
-                has_video=info.has_video,
-            ),
-            wall_clock=wall_clock,
-            transcript=transcript,
-            frames=frame_index,
-            caps=Caps(
-                max_seconds=max_seconds_cap(),
-                max_frames=max_frames_cap(),
-                scene_threshold=frames.DEFAULT_SCENE_THRESHOLD,
-                ocr=ocr_ran,
-            ),
-            tool_versions=_tool_versions(),
-        )
-        report("writing manifest", 0.99)
-        save_manifest(manifest, directory)
+        else:
+            with jobs.reprocess_workspace(job_id) as staging:
+                manifest, echo_trimmed, dropped, identities_preserved = _build_manifest(
+                    media,
+                    job_id,
+                    staging,
+                    info,
+                    diarize_request,
+                    recorded_at=recorded_at,
+                    vocabulary=vocabulary,
+                    language=language,
+                    model_name=model_name,
+                    previous=previous,
+                    report=report,
+                )
+                manifest = jobs.commit_reprocessed_job(job_id, staging)
 
     report("done", 1.0)
     return ProcessResult(
@@ -688,6 +774,8 @@ def process_media(
         reused=False,
         elapsed_s=time.monotonic() - started,
         vocabulary_echo_trimmed=echo_trimmed,
+        speaker_names_pending_review_dropped=dropped or None,
+        reprocessed_identity_review=identities_preserved,
     )
 
 
@@ -697,7 +785,31 @@ NAME_CANDIDATE_WINDOW_MS = 30_000
 NAME_CANDIDATE_FRAME_LIMIT = 3
 NAME_CANDIDATE_LIMIT = 3
 NAME_CANDIDATE_MAX_CHARS = 80
-_NAME_PARTICLES = frozenset({"al", "bin", "da", "de", "del", "la", "van", "von"})
+_NAME_PARTICLES = frozenset(
+    {
+        "abu",
+        "af",
+        "al",
+        "bin",
+        "d",
+        "da",
+        "de",
+        "del",
+        "den",
+        "der",
+        "di",
+        "du",
+        "e",
+        "ibn",
+        "la",
+        "le",
+        "ter",
+        "van",
+        "von",
+        "y",
+        "zu",
+    }
+)
 _UI_CHROME_WORDS = frozenset(
     {
         "build",
@@ -732,6 +844,24 @@ _UI_CHROME_WORDS = frozenset(
 _URL_OR_PATH = re.compile(
     r"(?:https?://|www\.|[A-Za-z]:\\|[/\\]|\b[^\s]+\.(?:com|org|net|io|dev|py|js|ts|java)\b)",
     re.IGNORECASE,
+)
+_TRAILING_NAME_METADATA = re.compile(r"\s*\([^()\n]{1,40}\)\s*$")
+_APOSTROPHE_PARTICLE = re.compile(r"^([^\W\d_]+)['\u2019](.+)$", re.UNICODE)
+_EXACT_UI_PHRASES = frozenset(
+    {
+        "copy paste delete",
+        "everyone",
+        "loading",
+        "meeting chat",
+        "prophet",
+        "stop recording",
+        "terminal",
+        "unknown caller",
+        "waiting room",
+        "zoom meeting",
+        "продажи отчет",
+        "参会者",
+    }
 )
 # Above this, an unconstrained cluster count stops being merely unreliable
 # and becomes implausible for one recording (tester report, 2026-07-27: a
@@ -968,6 +1098,101 @@ def speaker_name(diarization: Diarization | None, label: str | None) -> str | No
     return diarization.speaker_names.get(label)
 
 
+def _candidate_key(line: str) -> str:
+    folded = unicodedata.normalize("NFKC", line).casefold()
+    return " ".join(
+        "".join(character if character.isalnum() else " " for character in folded).split()
+    )
+
+
+def _candidate_parts(line: str) -> tuple[str, str, str]:
+    """Return bounded raw display, validation base, and dedupe key."""
+    raw = " ".join(line.split()).strip()
+    base = _TRAILING_NAME_METADATA.sub("", raw).strip()
+    return raw, base, _candidate_key(base)
+
+
+def _name_candidate_rejection_reason(line: str) -> str | None:
+    """Explain why one OCR line is not a conservative name-like hint."""
+    raw, base, key = _candidate_parts(line)
+    if not raw or not base:
+        return "empty"
+    if len(raw) > NAME_CANDIDATE_MAX_CHARS:
+        return "too_long"
+    if any(char.isdigit() for char in base):
+        return "digit"
+    if _URL_OR_PATH.search(base):
+        return "url_or_path"
+    words = base.split()
+    if not 1 <= len(words) <= 7:
+        return "word_count"
+    alpha_count = sum(char.isalpha() for char in base)
+    punctuation_count = sum(
+        unicodedata.category(char).startswith("P") for char in base
+    )
+    if not alpha_count:
+        return "no_letters"
+    if punctuation_count > max(2, alpha_count // 3):
+        return "punctuation"
+    if key in _EXACT_UI_PHRASES:
+        return "ui_phrase"
+    key_words = key.split()
+    chrome_count = sum(word in _UI_CHROME_WORDS for word in key_words)
+    if chrome_count == len(key_words) or chrome_count >= 2:
+        return "ui_chrome"
+
+    cased_words = [
+        word
+        for word in words
+        if any(char.isalpha() and char.lower() != char.upper() for char in word)
+    ]
+    if not cased_words:
+        return None  # Arabic/CJK and other scripts without letter case.
+    cased_letters = [
+        char for char in base if char.isalpha() and char.lower() != char.upper()
+    ]
+    if all(char.isupper() for char in cased_letters):
+        return None
+    if (
+        2 <= len(words) <= 4
+        and cased_letters
+        and all(char.islower() for char in cased_letters)
+    ):
+        return None
+    for word in cased_words:
+        letters = [char for char in word if char.isalpha()]
+        if not letters:
+            continue
+        word_key = _candidate_key(word)
+        if word_key in _NAME_PARTICLES:
+            continue
+        apostrophe = _APOSTROPHE_PARTICLE.match(word)
+        if apostrophe is not None and apostrophe.group(1).casefold() in _NAME_PARTICLES:
+            suffix_letters = [char for char in apostrophe.group(2) if char.isalpha()]
+            if suffix_letters and suffix_letters[0].isupper():
+                continue
+        if not letters[0].isupper():
+            return "casing"
+    return None
+
+
+def legacy_name_candidates_note(manifest: Manifest) -> str | None:
+    """Explain a known pre-0.3.1 flat-OCR limitation without rewriting it."""
+    if not manifest.media.has_video or not manifest.caps.ocr:
+        return None
+    if not any(frame.ocr_text for frame in manifest.frames.items):
+        return None
+    producer = manifest.tool_versions.get("talkthrough-mcp")
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)", producer or "")
+    if match is None or tuple(int(part) for part in match.groups()) >= (0, 3, 1):
+        return None
+    return (
+        "This job stores legacy single-line OCR, so name candidates may be absent. "
+        "Re-run with force=true and diarize=true to regenerate line-aware OCR; saved "
+        "names will move to pending review instead of being discarded."
+    )
+
+
 def _name_candidates(manifest: Manifest, at_ms: int) -> list[dict[str, Any]]:
     """Bounded name-like OCR hints near a longest turn; never identities."""
     if not manifest.media.has_video or not manifest.caps.ocr:
@@ -981,59 +1206,11 @@ def _name_candidates(manifest: Manifest, at_ms: int) -> list[dict[str, Any]]:
     candidates: list[dict[str, Any]] = []
     seen: set[str] = set()
 
-    def candidate_key(line: str) -> str:
-        folded = unicodedata.normalize("NFKC", line).casefold()
-        return " ".join(
-            "".join(character if character.isalnum() else " " for character in folded).split()
-        )
-
-    def name_like(line: str) -> bool:
-        if len(line) > NAME_CANDIDATE_MAX_CHARS or any(char.isdigit() for char in line):
-            return False
-        if _URL_OR_PATH.search(line):
-            return False
-        words = line.split()
-        if not 1 <= len(words) <= 5:
-            return False
-        alpha_count = sum(char.isalpha() for char in line)
-        punctuation_count = sum(unicodedata.category(char).startswith("P") for char in line)
-        if not alpha_count or punctuation_count > max(2, alpha_count // 3):
-            return False
-        key_words = candidate_key(line).split()
-        chrome_count = sum(word in _UI_CHROME_WORDS for word in key_words)
-        if chrome_count == len(key_words) or chrome_count >= 2:
-            return False
-
-        cased_words = [
-            word
-            for word in words
-            if any(char.isalpha() and char.lower() != char.upper() for char in word)
-        ]
-        if not cased_words:
-            return True  # Arabic/CJK and other scripts without letter case.
-        cased_letters = [
-            char
-            for char in line
-            if char.isalpha() and char.lower() != char.upper()
-        ]
-        if all(char.isupper() for char in cased_letters):
-            return True
-        for word in cased_words:
-            letters = [char for char in word if char.isalpha()]
-            if not letters:
-                continue
-            if candidate_key(word) in _NAME_PARTICLES:
-                continue
-            if not letters[0].isupper():
-                return False
-        return True
-
     for frame in nearby[:NAME_CANDIDATE_FRAME_LIMIT]:
         for raw_line in (frame.ocr_text or "").splitlines():
-            line = " ".join(raw_line.split()).strip()
-            if not line or not name_like(line):
+            line, _base, folded = _candidate_parts(raw_line)
+            if not line or _name_candidate_rejection_reason(line) is not None:
                 continue
-            folded = candidate_key(line)
             if folded in seen:
                 continue
             seen.add(folded)
@@ -1114,6 +1291,10 @@ def _summarize_diarization(
             attribution_precision(transcript) if transcript is not None else "segment"
         ),
     }
+    if manifest is not None:
+        legacy_note = legacy_name_candidates_note(manifest)
+        if legacy_note is not None:
+            payload["name_candidates_note"] = legacy_note
     if transcript is not None and attribution_precision(transcript) == "segment":
         payload["attribution_note"] = (
             "speaker boundaries use segment-level timestamps; exact word splitting "
@@ -1209,6 +1390,13 @@ def summarize(result: ProcessResult) -> dict[str, Any]:
                 result.speaker_names_pending_review_dropped
             )
         )
+        if result.reprocessed_identity_review:
+            diarization_summary["force_identity_review_note"] = (
+                "Full reprocessing rebuilt the transcript and speaker labels. Every "
+                "saved identity from the previous job was preserved as pending review, "
+                "not as an active identity; re-check the new roster before confirming "
+                "current labels or removing stale ones."
+            )
     return {
         "job_id": manifest.job_id,
         "reused": result.reused,

--- a/src/talkthrough_mcp/core/pipeline.py
+++ b/src/talkthrough_mcp/core/pipeline.py
@@ -95,6 +95,9 @@ class ProcessResult:
     # the outcome either way.
     amended: bool = False
     vocabulary_echo_trimmed: int = 0  # opening initial_prompt echoes dropped
+    # Response-only collision report. The superseded pending value is not
+    # persisted because the latest human-verified active value wins.
+    speaker_names_pending_review_dropped: dict[str, str] | None = None
 
 
 def _env_int(name: str, default: int) -> int:
@@ -357,7 +360,7 @@ def _labels_snapshot(
 
 def _amend_diarization(
     media: Path, manifest: Manifest, request: _DiarizeRequest, report: ProgressFn
-) -> Manifest:
+) -> tuple[Manifest, dict[str, str]]:
     """Re-extract the WAV and run ONLY diarization on an existing job.
 
     Whisper is not re-run; stored segments are re-attributed in place and the
@@ -405,6 +408,16 @@ def _amend_diarization(
         if previous_diarization
         else {}
     )
+    previous_pending_context = (
+        dict(previous_diarization.speaker_names_pending_review_context or {})
+        if previous_diarization
+        else {}
+    )
+    pending_merge = (
+        diarize.merge_pending_speaker_identities(previous_diarization)
+        if previous_diarization is not None
+        else diarize.PendingSpeakerIdentityMerge({}, {}, {}, {})
+    )
     report("extracting audio", 0.10)
     try:
         audio.extract_wav(media, wav_path, timeout=tool_timeout)
@@ -435,22 +448,24 @@ def _amend_diarization(
             diarization.speaker_name_evidence_pending_review = (
                 previous_pending_evidence or None
             )
-        elif previous_names:
-            # Keep only the most recent unreviewed mapping. Active identities
-            # are deliberately not carried onto changed labels.
-            diarization.speaker_names_pending_review = previous_names
-            diarization.speaker_name_evidence_pending_review = previous_evidence or None
+            diarization.speaker_names_pending_review_context = (
+                previous_pending_context or None
+            )
         else:
-            # A second amend before review must not erase the saved mapping
-            # merely because there are no active names left to move.
-            diarization.speaker_names_pending_review = previous_pending_names or None
+            # Labels changed: no previous identity is safe to activate on the
+            # new roster. Merge every disjoint pending generation with the
+            # latest active values and anchor the latter to the old roster.
+            diarization.speaker_names_pending_review = pending_merge.names or None
             diarization.speaker_name_evidence_pending_review = (
-                previous_pending_evidence or None
+                pending_merge.evidence or None
+            )
+            diarization.speaker_names_pending_review_context = (
+                pending_merge.context or None
             )
     report("writing manifest", 0.99)
     save_manifest(manifest, directory)
     report("done", 1.0)
-    return manifest
+    return manifest, pending_merge.dropped if diarization.labels_changed else {}
 
 
 def process_media(
@@ -520,7 +535,9 @@ def process_media(
                 logger.info(
                     "job %s exists — amending diarization only, whisper is not re-run", job_id
                 )
-                amended = _amend_diarization(media, manifest_hit, diarize_request, report)
+                amended, dropped = _amend_diarization(
+                    media, manifest_hit, diarize_request, report
+                )
                 diarization = amended.transcript.diarization
                 return ProcessResult(
                     manifest=amended,
@@ -530,6 +547,7 @@ def process_media(
                     # transcript, records available=false + reason, and must
                     # not be reported as an applied amend
                     amended=diarization is not None and diarization.available,
+                    speaker_names_pending_review_dropped=dropped or None,
                 )
             return ProcessResult(
                 manifest=manifest_hit, reused=True, elapsed_s=time.monotonic() - started
@@ -736,10 +754,18 @@ def pending_review_note(diarization: Diarization) -> str | None:
     count = len(diarization.speaker_names_pending_review or {})
     if not count:
         return None
+    current_labels = {speaker.label for speaker in diarization.speakers}
+    stale_count = sum(
+        label not in current_labels
+        for label in (diarization.speaker_names_pending_review or {})
+    )
     return (
-        f"{count} saved speaker name(s) moved to pending review because diarization "
-        "changed the labels; they are not active identities. Re-check the current "
-        "roster and confirm or remove them with label_speakers."
+        f"{count} saved speaker name(s) are pending review because diarization changed "
+        "the labels; they are not active identities. Re-check the current roster. "
+        "Current pending labels can be confirmed, replaced, or removed with "
+        "label_speakers; stale pending labels"
+        + (f" ({stale_count})" if stale_count else "")
+        + " can only be removed with labels={\"Sx\": null}."
     )
 
 
@@ -749,11 +775,20 @@ def pending_review_payload(diarization: Diarization) -> dict[str, Any]:
     if not names:
         return {}
     roster_order = [speaker.label for speaker in diarization.speakers]
+    current_labels = set(roster_order)
     ordered_labels = [label for label in roster_order if label in names]
-    ordered_labels.extend(sorted(label for label in names if label not in ordered_labels))
+    ordered_labels.extend(
+        sorted(
+            (label for label in names if label not in current_labels),
+            key=diarize.speaker_label_sort_key,
+        )
+    )
     served_labels = ordered_labels[:SUMMARY_ROSTER_CAP]
     hidden = len(ordered_labels) - len(served_labels)
     evidence = diarization.speaker_name_evidence_pending_review or {}
+    context = diarization.speaker_names_pending_review_context or {}
+    stale_labels = [label for label in served_labels if label not in current_labels]
+    stale_total = sum(label not in current_labels for label in ordered_labels)
     note = pending_review_note(diarization)
     assert note is not None
     return {
@@ -767,9 +802,59 @@ def pending_review_payload(diarization: Diarization) -> dict[str, Any]:
             if any(label in evidence for label in served_labels)
             else {}
         ),
+        **(
+            {
+                "speaker_names_pending_review_context": {
+                    label: context[label].to_dict()
+                    for label in served_labels
+                    if label in context and context[label].to_dict()
+                }
+            }
+            if any(label in context and context[label].to_dict() for label in served_labels)
+            else {}
+        ),
+        **(
+            {"speaker_names_pending_review_stale_labels": stale_labels}
+            if stale_labels
+            else {}
+        ),
+        **(
+            {"speaker_names_pending_review_stale_total": stale_total}
+            if stale_total
+            else {}
+        ),
+        **(
+            {
+                "speaker_names_pending_review_stale_truncated": (
+                    stale_total - len(stale_labels)
+                )
+            }
+            if stale_total > len(stale_labels)
+            else {}
+        ),
         "speaker_names_pending_review_total": len(ordered_labels),
         **({"speaker_names_pending_review_truncated": hidden} if hidden else {}),
         "speaker_names_pending_review_note": note,
+    }
+
+
+def pending_review_dropped_payload(dropped: dict[str, str] | None) -> dict[str, Any]:
+    """Bounded one-shot collision report for the amend response only."""
+    if not dropped:
+        return {}
+    ordered = sorted(dropped, key=diarize.speaker_label_sort_key)
+    served = ordered[:SUMMARY_ROSTER_CAP]
+    hidden = len(ordered) - len(served)
+    return {
+        "speaker_names_pending_review_dropped": {
+            label: dropped[label] for label in served
+        },
+        "speaker_names_pending_review_dropped_total": len(ordered),
+        **({"speaker_names_pending_review_dropped_truncated": hidden} if hidden else {}),
+        "speaker_names_pending_review_dropped_note": (
+            "A newer human-verified active name superseded each conflicting pending "
+            "value for the same raw label; the listed older values are no longer stored."
+        ),
     }
 
 
@@ -1114,6 +1199,16 @@ def summarize(result: ProcessResult) -> dict[str, Any]:
         for segment in segments[:TRANSCRIPT_PREVIEW_SEGMENTS]
     ]
     frames_with_text = sum(1 for frame in manifest.frames.items if frame.ocr_text)
+    diarization_summary: dict[str, Any] | None = None
+    if diarization is not None:
+        diarization_summary = _summarize_diarization(
+            diarization, manifest.transcript, manifest
+        )
+        diarization_summary.update(
+            pending_review_dropped_payload(
+                result.speaker_names_pending_review_dropped
+            )
+        )
     return {
         "job_id": manifest.job_id,
         "reused": result.reused,
@@ -1144,15 +1239,7 @@ def summarize(result: ProcessResult) -> dict[str, Any]:
             "preview_segments": preview,
             "preview_truncated": len(segments) > len(preview),
         },
-        **(
-            {
-                "diarization": _summarize_diarization(
-                    diarization, manifest.transcript, manifest
-                )
-            }
-            if diarization
-            else {}
-        ),
+        **({"diarization": diarization_summary} if diarization_summary else {}),
         "frames": _summarize_frames(manifest),
         "ocr": {"enabled": manifest.caps.ocr, "unique_frames_with_text": frames_with_text},
         "next_steps": (

--- a/src/talkthrough_mcp/core/speaker_labels.py
+++ b/src/talkthrough_mcp/core/speaker_labels.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import unicodedata
 from collections.abc import Mapping
 
-from .diarize import Diarization
+from .diarize import Diarization, speaker_label_sort_key
 from .errors import ValidationError
 
 MAX_SPEAKER_NAME_CHARS = 100
@@ -17,7 +17,12 @@ def _has_control_characters(value: str) -> bool:
 
 
 def _normalize_patch_keys(
-    values: Mapping[str, object], valid_labels: list[str], field: str
+    values: Mapping[str, object],
+    valid_labels: list[str],
+    field: str,
+    *,
+    current_labels: list[str],
+    pending_labels: list[str],
 ) -> dict[str, object]:
     normalized: dict[str, object] = {}
     for raw_label, value in values.items():
@@ -26,6 +31,8 @@ def _normalize_patch_keys(
             raise ValidationError(
                 f"unknown speaker label {raw_label!r} in {field}; valid labels: "
                 + ", ".join(valid_labels)
+                + f" (current roster labels: {', '.join(current_labels) or 'none'}; "
+                f"pending-review labels: {', '.join(pending_labels) or 'none'})"
             )
         if label in normalized:
             raise ValidationError(
@@ -42,16 +49,50 @@ def apply_speaker_label_patch(
     evidence: Mapping[str, str] | None = None,
 ) -> None:
     """Validate and atomically-in-memory apply one names/evidence patch."""
-    valid_labels = [speaker.label for speaker in diarization.speakers]
+    current_labels = [speaker.label for speaker in diarization.speakers]
+    current_set = set(current_labels)
+    pending_labels = sorted(
+        diarization.speaker_names_pending_review or {}, key=speaker_label_sort_key
+    )
+    valid_labels = [*current_labels]
+    valid_labels.extend(label for label in pending_labels if label not in current_set)
     if not valid_labels:
-        raise ValidationError("this diarized job has an empty speaker roster")
-    label_patch = _normalize_patch_keys(labels, valid_labels, "labels")
-    evidence_patch = _normalize_patch_keys(evidence or {}, valid_labels, "evidence")
+        raise ValidationError(
+            "this diarized job has an empty speaker roster and no pending-review labels"
+        )
+    label_patch = _normalize_patch_keys(
+        labels,
+        valid_labels,
+        "labels",
+        current_labels=current_labels,
+        pending_labels=pending_labels,
+    )
+    evidence_patch = _normalize_patch_keys(
+        evidence or {},
+        valid_labels,
+        "evidence",
+        current_labels=current_labels,
+        pending_labels=pending_labels,
+    )
+    pending_only = set(pending_labels) - current_set
+    for label, raw_value in label_patch.items():
+        if label in pending_only and raw_value is not None:
+            raise ValidationError(
+                f"inactive pending-review label {label} cannot be confirmed or replaced; "
+                "remove it with an explicit null value"
+            )
+    for label in evidence_patch:
+        if label in pending_only:
+            raise ValidationError(
+                f"evidence for inactive pending-review label {label} is not accepted; "
+                "remove the identity with labels={...: null}"
+            )
 
     names = dict(diarization.speaker_names or {})
     saved_evidence = dict(diarization.speaker_name_evidence or {})
     pending_names = dict(diarization.speaker_names_pending_review or {})
     pending_evidence = dict(diarization.speaker_name_evidence_pending_review or {})
+    pending_context = dict(diarization.speaker_names_pending_review_context or {})
     validated_names: dict[str, str | None] = {}
     for label, raw_value in label_patch.items():
         if raw_value is not None and not isinstance(raw_value, str):
@@ -91,6 +132,8 @@ def apply_speaker_label_patch(
         validated_evidence[label] = value or None
 
     for label, stored_name in validated_names.items():
+        if label in pending_only:
+            continue  # validated above: explicit null only, handled as pending review
         if stored_name is None:
             names.pop(label, None)
             saved_evidence.pop(label, None)
@@ -111,10 +154,15 @@ def apply_speaker_label_patch(
     for label in label_patch:
         pending_names.pop(label, None)
         pending_evidence.pop(label, None)
+        pending_context.pop(label, None)
     pending_evidence = {
         label: value for label, value in pending_evidence.items() if label in pending_names
+    }
+    pending_context = {
+        label: value for label, value in pending_context.items() if label in pending_names
     }
     diarization.speaker_names = names or None
     diarization.speaker_name_evidence = saved_evidence or None
     diarization.speaker_names_pending_review = pending_names or None
     diarization.speaker_name_evidence_pending_review = pending_evidence or None
+    diarization.speaker_names_pending_review_context = pending_context or None

--- a/src/talkthrough_mcp/guidance.py
+++ b/src/talkthrough_mcp/guidance.py
@@ -29,7 +29,7 @@ speech locally (whisper), extracts scene-change keyframes, OCRs on-screen text, 
 the wall-clock start time, and (opt-in) labels who said what via local speaker diarization. \
 Returns a compact summary (job_id, media info, wall_clock, transcript preview, speaker \
 roster when diarized) — full data stays on disk and is served lazily by the other tools. \
-Idempotent by content hash: re-calling on an already-processed file returns instantly. For MULTI-PERSON recordings (meetings, interviews, calls) diarize=true is part of a proper analysis — pass it even when the user only asks for a summary. num_speakers is a target the clusterer may not reach, not a constraint — the payload says when a re-run changed nothing (labels_changed). If an amend changes the labels, verified names become bounded pending-review evidence rather than active identities; re-check the new roster and confirm or remove them with label_speakers.
+Idempotent by content hash: re-calling on an already-processed file returns instantly. For MULTI-PERSON recordings (meetings, interviews, calls) diarize=true is part of a proper analysis — pass it even when the user only asks for a summary. num_speakers is a target the clusterer may not reach, not a constraint — the payload says when a re-run changed nothing (labels_changed). If an amend changes the labels, verified names become pending-review evidence rather than active identities, with old-roster anchors for re-checking. Current pending labels can be confirmed/replaced/removed; stale labels can only be removed with an explicit null patch.
 When NOT to use: to re-fetch data you already processed (use the retrieval tools), or for \
 URLs — local file paths only.
 Examples:
@@ -37,7 +37,7 @@ Examples:
 - meetings: model="large-v3-turbo" + vocabulary=<attendees, terms> + num_speakers=N — turbo's extra cost is trivial
 - process_media(path="/tmp/standup.m4a") — audio-only: transcript tools work, frame tools will error
 - process_media(path="/rec/panel.mov", diarize=true, num_speakers=4) — headcount known? ALWAYS pass it: best accuracy
-- relabel amend → saved names move to pending review; re-check the roster before confirming them
+- relabel amend → names become pending with old anchors; stale labels are removable only with null
 - error mentions [diarization] → the extra is missing: install via uvx "talkthrough-mcp[diarization]"
 - know the attendees? process_media(path=..., vocabulary="Anastasia, Evgenii, OKR") — names+jargon survive STT
 - user: "analyze/summarize this meeting" → include diarize=true — speaker structure is not optional extra credit
@@ -54,8 +54,9 @@ Retrieve the transcript of a processed job, lazily and paginated. Formats: "segm
 (default — seq, t_ms, t_wall when known, speaker when diarized, text), "text" (plain \
 prose; "S1:" prefixes at speaker changes), "srt" (subtitles, speaker-prefixed cues). \
 Diarized jobs also return the roster, attribution_precision, saved speaker_name values, \
-raw OCR name_candidates, and bounded pending-review names after a relabel. Pending names \
-are evidence to re-check, never active identities. Raw S<n> labels remain canonical. Responses \
+raw OCR name_candidates, and bounded pending-review names plus old-roster context after a relabel. \
+Pending names are evidence to re-check, never active identities. A stale pending label can only be \
+removed with label_speakers(..., labels={"Sx":null}). Raw S<n> labels remain canonical. Responses \
 are capped (~8k tokens): when truncated=true, continue from the returned next_start_ms.
 When NOT to use: to find one keyword (use search) or to inspect one moment with visuals \
 (use get_moment).
@@ -72,7 +73,7 @@ Examples:
 - correlate speech with logs: each segment's t_wall lines up with your log timestamps
 - no speaker fields on a meeting job → re-run process_media with diarize=true (adds them without re-transcribing)
 - attribution_precision="segment" → force=true+diarize=true is required for exact word boundaries
-- pending-review names are inactive after relabel; verify the current roster before confirming them
+- pending context points to old evidence; stale labels accept null removal, never a new name
 - anti-example: "where did they mention checkout?" → search(job_id, "checkout"), not full paging
 - anti-example: screenshots around a remark → get_moment(job_id, start_ms, end_ms)
 """,
@@ -152,8 +153,9 @@ Persist VERIFIED human-readable names for anonymous S1/S2/… labels on one diar
 `evidence` (max 500 characters per label) records why the mapping is trusted. Raw labels \
 remain canonical in JSON; names appear separately and in text/SRT display. The write is \
 atomic, locked, local, and idempotent. OCR name_candidates are raw hints only and are never \
-saved automatically. A relabelled job can carry pending-review names; an explicit labels patch \
-confirms, replaces, or removes only the touched pending entries.
+saved automatically. A relabelled job can carry pending-review names with source-roster anchors. \
+For a label still in the roster, an explicit patch confirms, replaces, or removes only that entry. \
+For a stale pending label, only an explicit null removes its name, evidence, and context.
 When NOT to use: before diarization, or when a name is only a guess without human/screen evidence.
 Examples:
 - label_speakers(job_id="...", labels={"S1":"Vera"}) — save one verified mapping
@@ -168,7 +170,7 @@ Examples:
 - name_candidates may be UI text or another person's name → inspect frames before deciding
 - unknown label or a name over 100 characters → error lists the valid roster labels
 - fresh session: get_transcript returns saved names; do not infer the mapping again
-- pending-review S1 after relabel → inspect the current S1, then confirm or remove it explicitly
+- stale pending S3 → labels={"S3":null}; never assign a name while S3 is outside the roster
 - anti-example: uncertain identity → keep S<n> anonymous until evidence verifies the name
 """,
     "extract_frame": """\
@@ -460,8 +462,9 @@ them, and that is fine.
    OCR/frames over the transcript for names. State the mapping first (e.g.
    `S1 = Vera, S2 = Tom, S3 = unidentified`) — never guess beyond the
    evidence. If the header carries speaker_names_pending_review, those names
-   came from an older roster and are NOT active identities: re-check each one
-   against the current roster before confirming or removing it.
+   came from an older roster and are NOT active identities: use their stored
+   context anchors to re-check each one. Confirm/replace only labels that are
+   still current; remove stale labels with an explicit null patch.
 5. Persist every defensible mapping with label_speakers(job_id="{job_id}",
    labels={{"S1":"<name>"}}, evidence={{"S1":"<intro, frame, or attendee proof>"}}).
    Never save OCR name_candidates directly: they are raw hints that may be UI

--- a/src/talkthrough_mcp/guidance.py
+++ b/src/talkthrough_mcp/guidance.py
@@ -29,7 +29,7 @@ speech locally (whisper), extracts scene-change keyframes, OCRs on-screen text, 
 the wall-clock start time, and (opt-in) labels who said what via local speaker diarization. \
 Returns a compact summary (job_id, media info, wall_clock, transcript preview, speaker \
 roster when diarized) — full data stays on disk and is served lazily by the other tools. \
-Idempotent by content hash: re-calling on an already-processed file returns instantly. For MULTI-PERSON recordings (meetings, interviews, calls) diarize=true is part of a proper analysis — pass it even when the user only asks for a summary. num_speakers is a target the clusterer may not reach, not a constraint — the payload says when a re-run changed nothing (labels_changed). If an amend changes the labels, verified names become pending-review evidence rather than active identities, with old-roster anchors for re-checking. Current pending labels can be confirmed/replaced/removed; stale labels can only be removed with an explicit null patch.
+Idempotent by content hash: re-calling on an already-processed file returns instantly. For MULTI-PERSON recordings (meetings, interviews, calls) diarize=true is part of a proper analysis — pass it even when the user only asks for a summary. num_speakers is a target the clusterer may not reach, not a constraint — the payload says when a re-run changed nothing (labels_changed). If an amend changes the labels, verified names become pending-review evidence rather than active identities, with old-roster anchors for re-checking. Current pending labels can be confirmed/replaced/removed; stale labels can only be removed with an explicit null patch. Full force reprocessing of a job with saved or pending identities requires diarize=true and preserves every old identity as pending review against the rebuilt roster; without diarization it refuses before changing the stored job.
 When NOT to use: to re-fetch data you already processed (use the retrieval tools), or for \
 URLs — local file paths only.
 Examples:
@@ -38,7 +38,7 @@ Examples:
 - process_media(path="/tmp/standup.m4a") — audio-only: transcript tools work, frame tools will error
 - process_media(path="/rec/panel.mov", diarize=true, num_speakers=4) — headcount known? ALWAYS pass it: best accuracy
 - relabel amend → names become pending with old anchors; stale labels are removable only with null
-- error mentions [diarization] → the extra is missing: install via uvx "talkthrough-mcp[diarization]"
+- error mentions [diarization] → run uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization]"
 - know the attendees? process_media(path=..., vocabulary="Anastasia, Evgenii, OKR") — names+jargon survive STT
 - user: "analyze/summarize this meeting" → include diarize=true — speaker structure is not optional extra credit
 - noisy threshold roster (clusters ≫ people)? ASK your user for the real headcount, then re-run with num_speakers=N
@@ -47,7 +47,7 @@ Examples:
 - transcript garbled or language_probability low → re-call with model="large-v3-turbo" (or language="ru") + force=true
 - after success, do NOT dump everything — continue with get_transcript / get_moment / search on the job_id
 - anti-example: frames from an already-processed job → get_frames(job_id=...), never process_media again
-- anti-example: YouTube/URL input → unsupported in v1; have the user download the file first
+- named job + force=true → include diarize=true; old identities return as pending review, never silently vanish
 """,
     "get_transcript": """\
 Retrieve the transcript of a processed job, lazily and paginated. Formats: "segments" \
@@ -55,6 +55,7 @@ Retrieve the transcript of a processed job, lazily and paginated. Formats: "segm
 prose; "S1:" prefixes at speaker changes), "srt" (subtitles, speaker-prefixed cues). \
 Diarized jobs also return the roster, attribution_precision, saved speaker_name values, \
 raw OCR name_candidates, and bounded pending-review names plus old-roster context after a relabel. \
+Pre-0.3.1 video jobs may return name_candidates_note because their flat OCR is readable but less useful for hints. \
 Pending names are evidence to re-check, never active identities. A stale pending label can only be \
 removed with label_speakers(..., labels={"Sx":null}). Raw S<n> labels remain canonical. Responses \
 are capped (~8k tokens): when truncated=true, continue from the returned next_start_ms.
@@ -69,7 +70,7 @@ Examples:
 - "what did S2 say?" → format="segments", collect entries with speaker=="S2" (labels are in order of first voice)
 - got truncated=true with next_start_ms=421500 → get_transcript(job_id="...", start_ms=421500)
 - user: "what was said between 5:00 and 6:30?" → start_ms=300000, end_ms=390000
-- meeting recording (audio-only job): this tool is the main surface — frames don't exist there
+- legacy video name_candidates_note → explain the limitation; safe regeneration uses force=true+diarize=true
 - correlate speech with logs: each segment's t_wall lines up with your log timestamps
 - no speaker fields on a meeting job → re-run process_media with diarize=true (adds them without re-transcribing)
 - attribution_precision="segment" → force=true+diarize=true is required for exact word boundaries

--- a/src/talkthrough_mcp/server.py
+++ b/src/talkthrough_mcp/server.py
@@ -279,6 +279,9 @@ def get_transcript(
     if diarization is not None and diarization.available:
         payload["diarized"] = True
         payload["speakers"], hidden = pipeline.roster_payload(diarization, manifest)
+        legacy_note = pipeline.legacy_name_candidates_note(manifest)
+        if legacy_note is not None:
+            payload["name_candidates_note"] = legacy_note
         payload["attribution_precision"] = pipeline.attribution_precision(manifest.transcript)
         if payload["attribution_precision"] == "segment":
             payload["attribution_note"] = (
@@ -626,11 +629,13 @@ def label_speakers(
         save_manifest(manifest, jobs.job_dir(job_id))
 
     speakers, hidden = pipeline.roster_payload(diarization, manifest)
+    legacy_note = pipeline.legacy_name_candidates_note(manifest)
     return {
         "job_id": job_id,
         "mapping_count": len(diarization.speaker_names or {}),
         "speakers": speakers,
         **({"speakers_truncated": hidden} if hidden else {}),
+        **({"name_candidates_note": legacy_note} if legacy_note else {}),
         **pipeline.pending_review_payload(diarization),
         "note": (
             "names are user/agent-verified labels; raw S<n> identifiers remain canonical "

--- a/src/talkthrough_mcp/server.py
+++ b/src/talkthrough_mcp/server.py
@@ -503,11 +503,11 @@ def search(
                     name.casefold() == folded for name in pending_names.values()
                 )
                 if pending_match:
+                    pending_note = pipeline.pending_review_note(diarization)
+                    assert pending_note is not None
                     note = (
-                        f"speaker name {speaker_query!r} is saved in pending review because "
-                        "diarization changed the labels; it is not an active identity and is "
-                        "not used for search. Re-check the current roster and confirm or "
-                        "remove it with label_speakers"
+                        f"speaker name {speaker_query!r} is saved in pending review; it is "
+                        f"not an active identity and is not used for search. {pending_note}"
                     )
                 else:
                     note = (

--- a/tests/e2e/test_mcp_client.py
+++ b/tests/e2e/test_mcp_client.py
@@ -25,7 +25,13 @@ from tests.integration.fixture_facts import DEMO_MP4, TWO_VOICE_M4A, TWO_VOICE_N
 from talkthrough_mcp import __version__ as package_version
 from talkthrough_mcp import guidance
 from talkthrough_mcp.core import diarize
-from talkthrough_mcp.core.diarize import Diarization, Turn, attribute_segments, speaker_roster
+from talkthrough_mcp.core.diarize import (
+    Diarization,
+    PendingSpeakerReviewContext,
+    Turn,
+    attribute_segments,
+    speaker_roster,
+)
 from talkthrough_mcp.core.manifest import save_manifest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -429,10 +435,23 @@ async def _run_pending_review_session(home: Path) -> None:
         detected_num_speakers=2,
         speakers=speaker_roster(turns),
         turns=turns,
-        speaker_names_pending_review={"S1": "Samantha", "S2": "Daniel"},
+        speaker_names_pending_review={
+            "S1": "Samantha",
+            "S2": "Daniel",
+            "S3": "Ghost",
+        },
         speaker_name_evidence_pending_review={
             "S1": "old fixture order",
             "S2": "old fixture order",
+            "S3": "old third cluster",
+        },
+        speaker_names_pending_review_context={
+            "S1": PendingSpeakerReviewContext(longest_turn_at_ms=0),
+            "S2": PendingSpeakerReviewContext(longest_turn_at_ms=5000),
+            "S3": PendingSpeakerReviewContext(
+                source_detected_num_speakers=3,
+                longest_turn_at_ms=9000,
+            ),
         },
         labels_changed=True,
     )
@@ -449,6 +468,12 @@ async def _run_pending_review_session(home: Path) -> None:
         assert transcript["speaker_names_pending_review"] == {
             "S1": "Samantha",
             "S2": "Daniel",
+            "S3": "Ghost",
+        }
+        assert transcript["speaker_names_pending_review_stale_labels"] == ["S3"]
+        assert transcript["speaker_names_pending_review_context"]["S3"] == {
+            "source_detected_num_speakers": 3,
+            "longest_turn_at_ms": 9000,
         }
         assert "not active identities" in transcript["speaker_names_pending_review_note"]
         assert all("speaker_name" not in segment for segment in transcript["segments"])
@@ -462,7 +487,35 @@ async def _run_pending_review_session(home: Path) -> None:
         assert "saved in pending review" in pending_search["note"]
         jobs_payload = _payload(await session.call_tool("list_jobs", {}))
         entry = next(job for job in jobs_payload["jobs"] if job["job_id"] == manifest.job_id)
-        assert entry["speaker_names_pending_review_count"] == 2
+        assert entry["speaker_names_pending_review_count"] == 3
+        removed = _payload(
+            await session.call_tool(
+                "label_speakers",
+                {"job_id": manifest.job_id, "labels": {"S3": None}},
+            )
+        )
+        assert removed["speaker_names_pending_review"] == {
+            "S1": "Samantha",
+            "S2": "Daniel",
+        }
+        assert "speaker_names_pending_review_stale_labels" not in removed
+
+    # A new server process proves stale cleanup and the remaining context are
+    # durable rather than cached in one SDK session.
+    async with (
+        stdio_client(_server_params(home)) as (read, write),
+        ClientSession(read, write) as session,
+    ):
+        await session.initialize()
+        transcript = _payload(
+            await session.call_tool("get_transcript", {"job_id": manifest.job_id})
+        )
+        assert transcript["speaker_names_pending_review"] == {
+            "S1": "Samantha",
+            "S2": "Daniel",
+        }
+        assert set(transcript["speaker_names_pending_review_context"]) == {"S1", "S2"}
+        assert "speaker_names_pending_review_stale_labels" not in transcript
 
 
 @pytest.mark.timeout(900)

--- a/tests/e2e/test_mcp_client.py
+++ b/tests/e2e/test_mcp_client.py
@@ -405,12 +405,66 @@ async def _run_session(home: Path) -> None:
             )
             assert named_hits["hits"]
             assert all(hit["speaker_name"] == "Samantha" for hit in named_hits["hits"])
+
+            unsafe_force = await session.call_tool(
+                "process_media",
+                {
+                    "path": str(TWO_VOICE_M4A),
+                    "force": True,
+                    "diarize": False,
+                },
+                read_timeout_seconds=PROCESS_TIMEOUT,
+            )
+            assert unsafe_force.is_error
+            unsafe_error = unsafe_force.content[0]
+            assert isinstance(unsafe_error, types.TextContent)
+            assert "force=true, diarize=true" in unsafe_error.text
+            survivor = _payload(
+                await session.call_tool("get_transcript", {"job_id": diarized_job_id})
+            )
+            assert {entry["speaker_name"] for entry in survivor["speakers"]} == {
+                "Samantha",
+                "Daniel",
+            }
+
+            forced = _payload(
+                await session.call_tool(
+                    "process_media",
+                    {
+                        "path": str(TWO_VOICE_M4A),
+                        "force": True,
+                        "diarize": True,
+                        "num_speakers": TWO_VOICE_NUM_SPEAKERS,
+                    },
+                    read_timeout_seconds=PROCESS_TIMEOUT,
+                )
+            )
+            assert forced["reused"] is False
+            assert "force_identity_review_note" in forced["diarization"]
+            assert forced["diarization"]["speaker_names_pending_review"] == {
+                "S1": "Samantha",
+                "S2": "Daniel",
+            }
             removed = _payload(
                 await session.call_tool(
                     "label_speakers", {"job_id": diarized_job_id, "labels": {"S1": None}}
                 )
             )
-            assert removed["mapping_count"] == 1
+            assert removed["mapping_count"] == 0
+            assert removed["speaker_names_pending_review"] == {"S2": "Daniel"}
+
+        # The successful force and pending cleanup must survive another MCP
+        # process rather than living only in the prior server's Python state.
+        async with (
+            stdio_client(_server_params(home)) as (read, write),
+            ClientSession(read, write) as session,
+        ):
+            await session.initialize()
+            persisted = _payload(
+                await session.call_tool("get_transcript", {"job_id": diarized_job_id})
+            )
+            assert "speaker_name" not in persisted["speakers"][0]
+            assert persisted["speaker_names_pending_review"] == {"S2": "Daniel"}
 
     errlog.flush()
     errlog.seek(0)

--- a/tests/integration/test_diarization_integration.py
+++ b/tests/integration/test_diarization_integration.py
@@ -370,7 +370,9 @@ def test_label_changing_amend_persists_names_for_review_across_reload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """External v0.3.0 repro: k=2 → verified names → k=3 → fresh session."""
-    from talkthrough_mcp.server import get_transcript, label_speakers
+    import json
+
+    from talkthrough_mcp.server import get_moment, get_transcript, label_speakers
 
     monkeypatch.setenv("TALKTHROUGH_HOME", str(tmp_path / "pending-review-home"))
     first = pipeline.process_media(
@@ -401,6 +403,12 @@ def test_label_changing_amend_persists_names_for_review_across_reload(
         "S1": "fixture first voice",
         "S2": "fixture second voice",
     }
+    assert current.speaker_names_pending_review_context is not None
+    assert set(current.speaker_names_pending_review_context) == {"S1", "S2"}
+    assert all(
+        context.longest_turn_at_ms is not None
+        for context in current.speaker_names_pending_review_context.values()
+    )
 
     reloaded = jobs.load_job(first.manifest.job_id).transcript.diarization
     assert reloaded is not None
@@ -411,14 +419,48 @@ def test_label_changing_amend_persists_names_for_review_across_reload(
         "speaker_names_pending_review_note"
     ]
 
-    # Returning to k=2 must not erase the unreviewed snapshot. Re-verifying
-    # one current label activates only that identity and leaves the other one
-    # pending for a later decision.
+    # F1/F3 exact lifecycle: label a voice that exists only in the k=3
+    # generation, then shrink back to k=2. All three identities survive and
+    # S3 remains publicly removable even though it is no longer in the roster.
+    assert any(stat.label == "S3" for stat in current.speakers)
+    label_speakers(
+        first.manifest.job_id,
+        {"S3": "Ghost"},
+        {"S3": "third cluster in the k=3 generation"},
+    )
     pipeline.process_media(
         str(INTERRUPT_M4A),
         diarize_speakers=True,
         num_speakers=2,
     )
+    shrunk = jobs.load_job(first.manifest.job_id).transcript.diarization
+    assert shrunk is not None
+    assert shrunk.speaker_names_pending_review == {
+        "S1": "Samantha",
+        "S2": "Daniel",
+        "S3": "Ghost",
+    }
+    assert shrunk.speaker_names_pending_review_context is not None
+    old_s3_anchor = shrunk.speaker_names_pending_review_context[
+        "S3"
+    ].longest_turn_at_ms
+    assert old_s3_anchor is not None
+    moment = json.loads(
+        get_moment(
+            first.manifest.job_id,
+            old_s3_anchor,
+            old_s3_anchor + 500,
+        )[0]
+    )
+    assert moment["range"]["start_ms"] == old_s3_anchor
+    assert "audio-only" in moment["note"]
+
+    stale_removed = label_speakers(first.manifest.job_id, {"S3": None})
+    assert "S3" not in stale_removed["speaker_names_pending_review"]
+    assert "speaker_names_pending_review_stale_labels" not in stale_removed
+
+    # Re-verifying one current label activates only that identity and leaves
+    # the other one pending for a later decision.
     reviewed = label_speakers(
         first.manifest.job_id,
         {"S1": "Samantha"},
@@ -429,6 +471,9 @@ def test_label_changing_amend_persists_names_for_review_across_reload(
     assert final is not None
     assert final.speaker_names == {"S1": "Samantha"}
     assert final.speaker_names_pending_review == {"S2": "Daniel"}
+    final_cleanup = label_speakers(first.manifest.job_id, {"S2": None})
+    assert "speaker_names_pending_review" not in final_cleanup
+    assert final_cleanup["mapping_count"] == 1
 
 
 def test_explicit_diarize_amends_on_embedding_model_change(

--- a/tests/integration/test_diarization_integration.py
+++ b/tests/integration/test_diarization_integration.py
@@ -34,7 +34,7 @@ from tests.integration.fixture_facts import (
 )
 
 from talkthrough_mcp.core import diarize, jobs, pipeline
-from talkthrough_mcp.core.errors import ValidationError
+from talkthrough_mcp.core.errors import ToolFailureError, ValidationError
 from talkthrough_mcp.core.pipeline import ProcessResult
 
 pytestmark = [
@@ -474,6 +474,88 @@ def test_label_changing_amend_persists_names_for_review_across_reload(
     final_cleanup = label_speakers(first.manifest.job_id, {"S2": None})
     assert "speaker_names_pending_review" not in final_cleanup
     assert final_cleanup["mapping_count"] == 1
+
+
+def test_full_force_preserves_active_and_pending_names_transactionally(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from talkthrough_mcp.core.diarize import Diarization
+    from talkthrough_mcp.server import label_speakers
+
+    monkeypatch.setenv("TALKTHROUGH_HOME", str(tmp_path / "force-home"))
+    first = pipeline.process_media(
+        str(INTERRUPT_M4A), diarize_speakers=True, num_speakers=2
+    )
+    label_speakers(
+        first.manifest.job_id,
+        {"S1": "Samantha"},
+        {"S1": "verified on the original two-speaker roster"},
+    )
+    pipeline.process_media(
+        str(INTERRUPT_M4A), diarize_speakers=True, num_speakers=3
+    )
+    label_speakers(
+        first.manifest.job_id,
+        {"S2": "Daniel"},
+        {"S2": "verified on the current three-speaker roster"},
+    )
+    directory = jobs.job_dir(first.manifest.job_id)
+
+    def snapshot() -> dict[str, bytes]:
+        return {
+            path.relative_to(directory).as_posix(): path.read_bytes()
+            for path in directory.rglob("*")
+            if path.is_file()
+            and path.name != jobs.LOCK_NAME
+            and jobs.REPROCESS_PREFIX not in path.parts
+        }
+
+    before_failure = snapshot()
+
+    def failed_diarization(
+        _wav: Path,
+        transcript: object,
+        _request: object,
+        _report: object,
+        _diarizer: object = None,
+    ) -> None:
+        transcript.diarization = Diarization(  # type: ignore[attr-defined]
+            available=False, reason="controlled engine failure"
+        )
+
+    with monkeypatch.context() as failure:
+        failure.setattr(pipeline, "_run_diarization", failed_diarization)
+        with pytest.raises(ToolFailureError, match="could not rebuild speaker labels"):
+            pipeline.process_media(
+                str(INTERRUPT_M4A),
+                force=True,
+                diarize_speakers=True,
+                num_speakers=2,
+            )
+    assert snapshot() == before_failure
+    assert not list(directory.glob(f"{jobs.REPROCESS_PREFIX}*"))
+
+    rebuilt = pipeline.process_media(
+        str(INTERRUPT_M4A),
+        force=True,
+        diarize_speakers=True,
+        num_speakers=2,
+    )
+    current = rebuilt.manifest.transcript.diarization
+    assert current is not None and current.available
+    assert current.speaker_names is None
+    assert current.speaker_names_pending_review == {
+        "S1": "Samantha",
+        "S2": "Daniel",
+    }
+    assert current.speaker_names_pending_review_context is not None
+    assert set(current.speaker_names_pending_review_context) == {"S1", "S2"}
+    assert rebuilt.manifest.transcript.words
+    assert any(segment.speaker for segment in rebuilt.manifest.transcript.segments)
+    summary = pipeline.summarize(rebuilt)["diarization"]
+    assert "force_identity_review_note" in summary
+    assert jobs.load_job(first.manifest.job_id).transcript.diarization == current
+    assert not list(directory.glob(f"{jobs.REPROCESS_PREFIX}*"))
 
 
 def test_explicit_diarize_amends_on_embedding_model_change(

--- a/tests/integration/test_pipeline_integration.py
+++ b/tests/integration/test_pipeline_integration.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import itertools
 import json
 import os
+import shutil
 import subprocess
 from collections.abc import Iterator
 from pathlib import Path
@@ -28,7 +29,7 @@ from tests.integration.fixture_facts import (
 
 from talkthrough_mcp.core import jobs, pipeline
 from talkthrough_mcp.core.errors import ValidationError
-from talkthrough_mcp.core.manifest import search_manifest
+from talkthrough_mcp.core.manifest import save_manifest, search_manifest
 from talkthrough_mcp.core.pipeline import ProcessResult
 
 pytestmark = pytest.mark.timeout(900)
@@ -385,6 +386,48 @@ def test_japanese_narration_autoselects_the_japan_ocr_pack(integration_home: Pat
         f"katakana heading not OCR-indexed — japan pack not engaged? "
         f"frame texts: {[frame.ocr_text for frame in result.manifest.unique_frames()]}"
     )
+
+
+def test_copied_legacy_manifest_is_served_with_read_only_ocr_note(
+    demo: ProcessResult, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A private real-store specimen is unavailable; reproduce its flat OCR
+    shape on a copy of the committed video fixture without migrating it."""
+    copied_home = tmp_path / "legacy-home"
+    copied_job = copied_home / "jobs" / demo.manifest.job_id
+    shutil.copytree(jobs.job_dir(demo.manifest.job_id), copied_job)
+    monkeypatch.setenv("TALKTHROUGH_HOME", str(copied_home))
+    manifest = jobs.load_job(demo.manifest.job_id)
+    manifest.tool_versions["talkthrough-mcp"] = "0.3.0"
+    for frame in manifest.frames.items:
+        if frame.ocr_text:
+            frame.ocr_text = " ".join(frame.ocr_text.splitlines())
+    from talkthrough_mcp.core.diarize import (
+        Diarization,
+        Turn,
+        attribute_segments,
+        speaker_roster,
+    )
+
+    turns = [Turn(0, round(manifest.media.duration_s * 1000), "S1")]
+    manifest.transcript.segments = attribute_segments(
+        manifest.transcript.segments, turns
+    )
+    manifest.transcript.diarization = Diarization(
+        available=True,
+        reason="",
+        detected_num_speakers=1,
+        speakers=speaker_roster(turns),
+        turns=turns,
+    )
+    save_manifest(manifest, copied_job)
+    before = (copied_job / "manifest.json").read_bytes()
+
+    from talkthrough_mcp.server import get_transcript
+
+    payload = get_transcript(manifest.job_id)
+    assert "legacy single-line OCR" in payload["name_candidates_note"]
+    assert (copied_job / "manifest.json").read_bytes() == before
 
 
 # --- mutating tests: keep these LAST -----------------------------------------

--- a/tests/unit/test_diarize.py
+++ b/tests/unit/test_diarize.py
@@ -19,6 +19,7 @@ from talkthrough_mcp.core.diarize import (
     SEGMENTATION_MODELS,
     Diarization,
     ModelSpec,
+    PendingSpeakerReviewContext,
     SpeakerStat,
     Turn,
     attribute_segments,
@@ -28,6 +29,7 @@ from talkthrough_mcp.core.diarize import (
     diarize_default,
     ensure_model_file,
     load_wav_float32,
+    merge_pending_speaker_identities,
     models_root,
     relabel_turns,
     resolve_model,
@@ -207,6 +209,100 @@ def test_diarization_round_trips_pending_review_names_and_omits_empty_maps() -> 
     serialized = empty.to_dict()
     assert "speaker_names_pending_review" not in serialized
     assert "speaker_name_evidence_pending_review" not in serialized
+
+
+def test_pending_review_context_round_trips_and_filters_orphans() -> None:
+    diarization = make_diarization()
+    diarization.speaker_names_pending_review = {"S1": "Alice"}
+    diarization.speaker_names_pending_review_context = {
+        "S1": PendingSpeakerReviewContext(
+            source_detected_num_speakers=2,
+            source_requested_num_speakers=3,
+            source_produced_by="0.3.1",
+            talk_time_ms=5000,
+            turn_count=1,
+            longest_turn_at_ms=0,
+            longest_turn_duration_ms=5000,
+        ),
+        "S9": PendingSpeakerReviewContext(talk_time_ms=1),
+    }
+    payload = diarization.to_dict()
+    assert payload["speaker_names_pending_review_context"] == {
+        "S1": {
+            "source_detected_num_speakers": 2,
+            "source_requested_num_speakers": 3,
+            "source_produced_by": "0.3.1",
+            "talk_time_ms": 5000,
+            "turn_count": 1,
+            "longest_turn_at_ms": 0,
+            "longest_turn_duration_ms": 5000,
+        }
+    }
+    assert Diarization.from_dict(payload).speaker_names_pending_review_context == {
+        "S1": diarization.speaker_names_pending_review_context["S1"]
+    }
+
+    diarization.speaker_names_pending_review_context = {
+        "S9": PendingSpeakerReviewContext(talk_time_ms=1)
+    }
+    assert "speaker_names_pending_review_context" not in diarization.to_dict()
+
+
+def test_pending_review_context_tolerates_unknown_and_skips_malformed_entries() -> None:
+    payload = make_diarization().to_dict()
+    payload["speaker_names_pending_review"] = {
+        "S1": "Alice",
+        "S2": "Bob",
+        "S3": "Ghost",
+    }
+    payload["speaker_names_pending_review_context"] = {
+        "S1": {"talk_time_ms": 5000, "future_anchor": "ignored"},
+        "S2": {"talk_time_ms": -1},
+        "S3": "not an object",
+        "S9": {"talk_time_ms": 1},
+    }
+    rebuilt = Diarization.from_dict(payload)
+    assert rebuilt.speaker_names_pending_review_context == {
+        "S1": PendingSpeakerReviewContext(talk_time_ms=5000)
+    }
+
+
+def test_merge_pending_identities_keeps_disjoint_labels_and_reports_collision() -> None:
+    diarization = make_diarization()
+    diarization.speaker_names = {"S1": "Current Alice", "S3": "Carol"}
+    diarization.speaker_name_evidence = {"S1": "fresh intro", "S3": "fresh plate"}
+    diarization.speaker_names_pending_review = {"S1": "Older Alice", "S2": "Bob"}
+    diarization.speaker_name_evidence_pending_review = {
+        "S1": "old intro",
+        "S2": "old plate",
+    }
+    diarization.speaker_names_pending_review_context = {
+        "S2": PendingSpeakerReviewContext(longest_turn_at_ms=5000)
+    }
+
+    merged = merge_pending_speaker_identities(diarization)
+    assert merged.names == {"S1": "Current Alice", "S2": "Bob", "S3": "Carol"}
+    assert merged.evidence == {
+        "S1": "fresh intro",
+        "S2": "old plate",
+        "S3": "fresh plate",
+    }
+    assert merged.dropped == {"S1": "Older Alice"}
+    assert merged.context["S1"].talk_time_ms == 5000
+    assert merged.context["S1"].longest_turn_at_ms == 0
+    assert merged.context["S2"].longest_turn_at_ms == 5000
+    assert list(merged.names) == ["S1", "S2", "S3"]
+
+
+def test_merge_same_label_and_name_is_not_a_drop() -> None:
+    diarization = make_diarization()
+    diarization.speaker_names = {"S1": "Alice"}
+    diarization.speaker_names_pending_review = {"S1": "Alice"}
+    diarization.speaker_name_evidence_pending_review = {"S1": "older proof"}
+    merged = merge_pending_speaker_identities(diarization)
+    assert merged.names == {"S1": "Alice"}
+    assert merged.evidence == {"S1": "older proof"}
+    assert merged.dropped == {}
 
 
 def test_diarization_round_trips_amend_outcome_fields() -> None:

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -4,7 +4,43 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _troubleshooting_contract(path: Path) -> dict[str, bool]:
+    text = path.read_text(encoding="utf-8")
+    normalized = " ".join(text.split())
+    return {
+        "four_cold_stages": all(
+            fact in normalized
+            for fact in (
+                "four separate stages",
+                "isolated environment",
+                "managed Python",
+                "media/model assets",
+                "Warm processing",
+            )
+        ),
+        "tls_before_setup": (
+            "Set `SSL_CERT_FILE` before either uv setup or the first media processing"
+            in normalized
+        ),
+        "uv_trust_and_mirror": all(
+            fact in normalized
+            for fact in ("`UV_SYSTEM_CERTS=true`", "`UV_PYTHON_INSTALL_MIRROR`")
+        ),
+        "cache_scopes": all(
+            fact in normalized
+            for fact in (
+                "`uv cache prune`",
+                "`uv cache clean talkthrough-mcp`",
+                "bare `uv cache clean` clears the entire uv cache",
+                "`talkthrough-mcp gc --keep-days 30` cleans Talkthrough jobs",
+            )
+        ),
+    }
 
 
 def test_corporate_tls_docs_cover_the_first_static_ffmpeg_download() -> None:
@@ -13,3 +49,40 @@ def test_corporate_tls_docs_cover_the_first_static_ffmpeg_download() -> None:
     assert "third-party `static-ffmpeg` package" in normalized
     assert "same `SSL_CERT_FILE` setting" in normalized
     assert "one-time ffmpeg download" in normalized
+
+
+def test_troubleshooting_keeps_operational_semantics() -> None:
+    contract = _troubleshooting_contract(REPO_ROOT / "docs" / "TROUBLESHOOTING.md")
+    assert all(contract.values()), contract
+
+
+def test_copy_edit_does_not_pin_marketing_prose(tmp_path: Path) -> None:
+    source = (REPO_ROOT / "docs" / "TROUBLESHOOTING.md").read_text(encoding="utf-8")
+    copy = tmp_path / "TROUBLESHOOTING.md"
+    copy.write_text(
+        source.replace(
+            "Short answers to the failure modes people actually hit.",
+            "Practical answers for common operational failures.",
+        ),
+        encoding="utf-8",
+    )
+    assert all(_troubleshooting_contract(copy).values())
+
+
+@pytest.mark.parametrize("removed_fact", _troubleshooting_contract(
+    REPO_ROOT / "docs" / "TROUBLESHOOTING.md"
+))
+def test_removing_an_operational_fact_breaks_its_contract(
+    tmp_path: Path, removed_fact: str
+) -> None:
+    source = (REPO_ROOT / "docs" / "TROUBLESHOOTING.md").read_text(encoding="utf-8")
+    replacements = {
+        "four_cold_stages": ("four separate stages", "several setup stages"),
+        "tls_before_setup": ("Set `SSL_CERT_FILE` before", "Configure certificates before"),
+        "uv_trust_and_mirror": ("`UV_PYTHON_INSTALL_MIRROR`", "the organization mirror"),
+        "cache_scopes": ("`uv cache clean talkthrough-mcp`", "the package cache command"),
+    }
+    old, new = replacements[removed_fact]
+    copy = tmp_path / "TROUBLESHOOTING.md"
+    copy.write_text(source.replace(old, new), encoding="utf-8")
+    assert _troubleshooting_contract(copy)[removed_fact] is False

--- a/tests/unit/test_guidance.py
+++ b/tests/unit/test_guidance.py
@@ -228,9 +228,11 @@ def test_distribution_arg_order_and_shell_quoting_are_safe() -> None:
         _GIT_SPEC,
         _PYPI_SPEC,
         _UVX_ARGS,
+        MINIMAL_UVX_ARGS,
+        MINIMAL_UVX_CMDLINE,
         PROJECT_REQUIRES_PYTHON,
         UVX_CMDLINE,
-        _shell_quoted,
+        _shell_owned_arg,
     )
 
     assert _UVX_ARGS["git"] == [
@@ -241,11 +243,18 @@ def test_distribution_arg_order_and_shell_quoting_are_safe() -> None:
         "talkthrough-mcp",
     ]
     assert _UVX_ARGS["pypi"] == ["--python", PROJECT_REQUIRES_PYTHON, _PYPI_SPEC]
-    assert _shell_quoted(PROJECT_REQUIRES_PYTHON) == f"'{PROJECT_REQUIRES_PYTHON}'"
-    assert _shell_quoted(_PYPI_SPEC) == f"'{_PYPI_SPEC}'"
+    assert MINIMAL_UVX_ARGS == ["--python", PROJECT_REQUIRES_PYTHON, "talkthrough-mcp"]
+    assert _shell_owned_arg(PROJECT_REQUIRES_PYTHON) == f'"{PROJECT_REQUIRES_PYTHON}"'
+    assert _shell_owned_arg(_PYPI_SPEC) == f'"{_PYPI_SPEC}"'
     assert (
-        f"uvx --python '{PROJECT_REQUIRES_PYTHON}' '{_PYPI_SPEC}'"
+        f'uvx --python "{PROJECT_REQUIRES_PYTHON}" "{_PYPI_SPEC}"'
     ) == UVX_CMDLINE
+    assert (
+        f'uvx --python "{PROJECT_REQUIRES_PYTHON}" talkthrough-mcp'
+    ) == MINIMAL_UVX_CMDLINE
+    for unsafe in ('evil"arg', "evil$arg", "evil`arg", "evil\narg", "unowned"):
+        with pytest.raises(ValueError):
+            _shell_owned_arg(unsafe)
 
 
 def test_cold_start_documentation_contract() -> None:
@@ -253,22 +262,54 @@ def test_cold_start_documentation_contract() -> None:
     troubleshooting = (REPO_ROOT / "docs/TROUBLESHOOTING.md").read_text(encoding="utf-8")
     normalized = " ".join(troubleshooting.split())
 
-    assert "two separate stages" in readme
-    assert "~80 MB bundled ffmpeg again" in readme
-    assert "warm, network-free jobs" in readme
+    assert "cold setup" in readme.casefold()
+    assert "bundled ffmpeg" in readme
+    assert "network-free" in readme
     for fact in (
         "distinct `uvx` environment",
-        "~80 MB static build again",
-        "observation, not a timing promise",
-        "model caches are shared",
-        "Set `SSL_CERT_FILE`",
-        "Warm processing is network-free",
+        "managed Python",
+        "static-ffmpeg",
+        "model caches",
+        "`SSL_CERT_FILE`",
+        "Warm processing",
         "uv python find",
         "uv python install 3.12",
-        "uvx --python 3.12",
+        "UV_SYSTEM_CERTS",
+        "UV_PYTHON_INSTALL_MIRROR",
+        "uv cache prune",
+        "uv cache clean talkthrough-mcp",
         "`>=3.11,<3.14` range from `pyproject.toml`",
     ):
         assert fact in normalized
+
+
+def test_agent_facing_uvx_launchers_use_the_project_python_range() -> None:
+    project = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))[
+        "project"
+    ]
+    required = f'--python "{project["requires-python"]}"'
+    openclaw_required = f'--arg --python --arg "{project["requires-python"]}"'
+    files = [
+        REPO_ROOT / "README.md",
+        REPO_ROOT / "llms-install.md",
+        REPO_ROOT / ".agents/skills/talkthrough/SKILL.md",
+        REPO_ROOT / "docs/TROUBLESHOOTING.md",
+        *(REPO_ROOT / "integrations").rglob("*.md"),
+    ]
+    offenders: list[str] = []
+    launcher = re.compile(r"uvx[^\n`]*talkthrough-mcp[^\n`]*")
+    for path in files:
+        for match in launcher.finditer(path.read_text(encoding="utf-8")):
+            command = match.group(0)
+            context = path.read_text(encoding="utf-8")[max(0, match.start() - 160) : match.start()]
+            diagnostic = "diagnostic" in context.casefold()
+            encoded_config = "uvx%22" in command
+            portable = required in command or openclaw_required in command
+            if "..." not in command and not diagnostic and not encoded_config and not portable:
+                offenders.append(f"{path.relative_to(REPO_ROOT)}: {command}")
+    assert not offenders, "agent-facing uvx launchers missing Python range:\n" + "\n".join(
+        offenders
+    )
 
 
 def test_claude_plugin_agent_uses_plugin_mcp_tool_namespace() -> None:

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -47,6 +47,15 @@ def _store_job(job_id: str, created_at: str) -> None:
     save_manifest(make_manifest(job_id=job_id, created_at=created_at), directory)
 
 
+def _materialize_job(job_id: str, directory: Path, *, marker: bytes, created_at: str) -> None:
+    manifest = make_manifest(job_id=job_id, created_at=created_at)
+    frame_directory = directory / "frames"
+    frame_directory.mkdir(parents=True, exist_ok=True)
+    for frame in manifest.frames.items:
+        (frame_directory / frame.file).write_bytes(marker + frame.file.encode())
+    save_manifest(manifest, directory)
+
+
 def test_list_jobs_newest_first_and_skips_broken(isolated_home: Path) -> None:
     _store_job("aaaaaaaaaaaaaaaa", "2026-07-01T10:00:00+00:00")
     _store_job("bbbbbbbbbbbbbbbb", "2026-07-09T10:00:00+00:00")
@@ -121,6 +130,92 @@ def test_partial_job_cleanup_context_removes_only_manifestless_dirs(
     ):
         raise RuntimeError("amend failed after the manifest existed")
     assert jobs.job_exists(completed)
+
+
+def test_reprocess_workspace_is_nested_hidden_and_commit_replaces_complete_job(
+    isolated_home: Path,
+) -> None:
+    job_id = "a1" * 8
+    directory = jobs.job_dir(job_id)
+    _materialize_job(
+        job_id,
+        directory,
+        marker=b"old:",
+        created_at="2026-07-01T10:00:00+00:00",
+    )
+    with jobs.job_lock(job_id), jobs.reprocess_workspace(job_id) as staging:
+        assert staging.parent == directory
+        assert staging.name.startswith(jobs.REPROCESS_PREFIX)
+        assert [manifest.job_id for manifest in jobs.list_jobs()] == [job_id]
+        _materialize_job(
+            job_id,
+            staging,
+            marker=b"new:",
+            created_at="2026-07-02T10:00:00+00:00",
+        )
+        committed = jobs.commit_reprocessed_job(job_id, staging)
+        assert committed.created_at == "2026-07-02T10:00:00+00:00"
+        assert (directory / "manifest.json").is_file()
+        assert all(
+            (directory / "frames" / frame.file).read_bytes().startswith(b"new:")
+            for frame in committed.frames.items
+        )
+    assert not list(directory.glob(f"{jobs.REPROCESS_PREFIX}*"))
+
+
+def test_reprocess_commit_failure_restores_old_manifest_and_frames(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    job_id = "b2" * 8
+    directory = jobs.job_dir(job_id)
+    _materialize_job(
+        job_id,
+        directory,
+        marker=b"old:",
+        created_at="2026-07-01T10:00:00+00:00",
+    )
+    old_manifest = (directory / "manifest.json").read_bytes()
+    old_frames = {
+        path.name: path.read_bytes() for path in (directory / "frames").iterdir()
+    }
+    with jobs.job_lock(job_id), jobs.reprocess_workspace(job_id) as staging:
+        _materialize_job(
+            job_id,
+            staging,
+            marker=b"new:",
+            created_at="2026-07-02T10:00:00+00:00",
+        )
+        real_replace = jobs.os.replace
+
+        def fail_manifest_replace(source: object, destination: object) -> None:
+            if Path(source) == staging / "manifest.json":
+                raise OSError("injected manifest commit failure")
+            real_replace(source, destination)
+
+        monkeypatch.setattr(jobs.os, "replace", fail_manifest_replace)
+        with pytest.raises(ToolFailureError, match="previous job was restored"):
+            jobs.commit_reprocessed_job(job_id, staging)
+
+    assert (directory / "manifest.json").read_bytes() == old_manifest
+    assert {
+        path.name: path.read_bytes() for path in (directory / "frames").iterdir()
+    } == old_frames
+    assert jobs.load_job(job_id).created_at == "2026-07-01T10:00:00+00:00"
+
+
+def test_gc_sweeps_stale_nested_reprocess_workspace(isolated_home: Path) -> None:
+    job_id = "c3" * 8
+    _store_job(job_id, datetime.now(UTC).isoformat(timespec="seconds"))
+    staging = jobs.job_dir(job_id) / f"{jobs.REPROCESS_PREFIX}abandoned"
+    staging.mkdir()
+    (staging / "audio.wav").write_bytes(b"partial")
+    stamp = time.time() - 3 * 86_400
+    os.utime(staging, (stamp, stamp))
+
+    result = jobs.gc(keep_days=30)
+    assert result.swept == [f"{job_id}/{staging.name}"]
+    assert jobs.job_exists(job_id)
+    assert not staging.exists()
 
 
 # --- v0.2.6 F6: gc sweeps manifest-less partial dirs ---------------------------

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -262,6 +262,7 @@ def test_straddle_hint_keeps_unique_tokens_from_two_long_segments() -> None:
     assert len(hint.quote) <= STRADDLE_QUOTE_MAX_CHARS
     assert "alpha" in hint.quote and "omega" in hint.quote
     assert hint.quote.startswith("… ") and hint.quote.endswith(" …")
+    assert "… …" not in hint.quote
     assert hint.all_tokens_shown is True
 
 

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -12,6 +12,7 @@ from tests.conftest import make_manifest
 
 from talkthrough_mcp.core.diarize import (
     Diarization,
+    PendingSpeakerReviewContext,
     Turn,
     attribute_segments,
     speaker_roster,
@@ -446,6 +447,44 @@ def test_diarized_round_trip(tmp_path: Path) -> None:
     assert diarization is not None
     assert diarization.turns == [Turn(0, 5000, "S1"), Turn(5000, 8000, "S2")]
     assert [stat.label for stat in diarization.speakers] == ["S1", "S2"]
+
+
+def test_manifest_round_trips_additive_pending_context_without_changing_old_maps(
+    tmp_path: Path,
+) -> None:
+    manifest = _diarized_manifest()
+    diarization = manifest.transcript.diarization
+    assert diarization is not None
+    diarization.speaker_names_pending_review = {"S1": "Alice"}
+    diarization.speaker_name_evidence_pending_review = {"S1": "old intro"}
+    diarization.speaker_names_pending_review_context = {
+        "S1": PendingSpeakerReviewContext(
+            source_detected_num_speakers=2,
+            longest_turn_at_ms=0,
+        )
+    }
+    save_manifest(manifest, tmp_path)
+    loaded = load_manifest(tmp_path)
+    loaded_diarization = loaded.transcript.diarization
+    assert loaded_diarization is not None
+    assert loaded_diarization.speaker_names_pending_review == {"S1": "Alice"}
+    assert loaded_diarization.speaker_name_evidence_pending_review == {
+        "S1": "old intro"
+    }
+    assert loaded_diarization.speaker_names_pending_review_context == {
+        "S1": PendingSpeakerReviewContext(
+            source_detected_num_speakers=2,
+            longest_turn_at_ms=0,
+        )
+    }
+
+    old_reader_payload = manifest.to_dict()
+    old_diarization = old_reader_payload["transcript"]["diarization"]
+    old_diarization.pop("speaker_names_pending_review_context")
+    old_compatible = Manifest.from_dict(old_reader_payload).transcript.diarization
+    assert old_compatible is not None
+    assert old_compatible.speaker_names_pending_review == {"S1": "Alice"}
+    assert old_compatible.speaker_name_evidence_pending_review == {"S1": "old intro"}
 
 
 def test_srt_prefixes_every_diarized_cue() -> None:

--- a/tests/unit/test_pipeline_config.py
+++ b/tests/unit/test_pipeline_config.py
@@ -751,6 +751,124 @@ def _amend_through_fake_engine(media, monkeypatch: pytest.MonkeyPatch, *, turns,
     return pipeline.process_media(str(media), diarize_speakers=True, num_speakers=k)
 
 
+def _stored_force_identity_job(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    video: bool = False,
+):
+    from talkthrough_mcp.core import jobs
+    from talkthrough_mcp.core.diarize import Turn, attribute_segments, speaker_roster
+    from talkthrough_mcp.core.manifest import save_manifest
+
+    monkeypatch.setenv("TALKTHROUGH_HOME", str(tmp_path / "force-home"))
+    media = tmp_path / ("force.mp4" if video else "force.m4a")
+    media.write_bytes(b"force fixture bytes")
+    job_id = jobs.compute_job_id(media)
+    turns = [Turn(0, 4000, "S1"), Turn(4000, 8000, "S2")]
+    manifest = make_manifest(job_id=job_id, kind="video" if video else "audio")
+    manifest.media = type(manifest.media)(
+        **{
+            **manifest.media.__dict__,
+            "path": str(media),
+            "filename": media.name,
+            "size_bytes": media.stat().st_size,
+        }
+    )
+    manifest.transcript.segments = attribute_segments(
+        manifest.transcript.segments, turns
+    )
+    manifest.transcript.diarization = Diarization(
+        available=True,
+        reason="",
+        requested_num_speakers=2,
+        detected_num_speakers=2,
+        speakers=speaker_roster(turns),
+        turns=turns,
+        speaker_names={"S1": "Alice"},
+        speaker_name_evidence={"S1": "old introduction"},
+        speaker_names_pending_review={"S3": "Carol"},
+        speaker_name_evidence_pending_review={"S3": "older roster"},
+        speaker_names_pending_review_context={
+            "S3": PendingSpeakerReviewContext(longest_turn_at_ms=7000)
+        },
+    )
+    directory = jobs.job_dir(job_id)
+    directory.mkdir(parents=True)
+    if video:
+        frame_directory = directory / "frames"
+        frame_directory.mkdir()
+        for frame in manifest.frames.items:
+            (frame_directory / frame.file).write_bytes(b"old:" + frame.file.encode())
+    save_manifest(manifest, directory)
+    return media, manifest
+
+
+def _stub_successful_force(
+    media: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    video: bool = False,
+) -> None:
+    from tests.conftest import make_manifest as _make_manifest
+
+    from talkthrough_mcp.core import audio, dedup, frames, ocr, pipeline, stt
+    from talkthrough_mcp.core.diarize import Turn
+    from talkthrough_mcp.core.probe import MediaInfo
+
+    stat = media.stat()
+    monkeypatch.setattr(
+        pipeline,
+        "probe_media",
+        lambda path: MediaInfo(
+            path=str(media),
+            filename=media.name,
+            size_bytes=stat.st_size,
+            duration_s=8.0,
+            has_video=video,
+            has_audio=True,
+            width=1280 if video else 0,
+            height=720 if video else 0,
+            video_codec="h264" if video else "",
+            mtime_epoch=stat.st_mtime,
+        ),
+    )
+    monkeypatch.setattr(audio, "extract_wav", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        stt,
+        "transcribe",
+        lambda *args, **kwargs: stt.SttResult(
+            language="en",
+            model="tiny",
+            segments=tuple(_make_manifest(kind="audio").transcript.segments[:2]),
+            latency_ms=1,
+            words=(
+                stt.SttWord(0, 2000, "Hello"),
+                stt.SttWord(4000, 6000, "There"),
+            ),
+        ),
+    )
+    engine(monkeypatch, available=True)
+    monkeypatch.setattr(
+        diarize,
+        "create_diarizer",
+        lambda: _FakeDiarizer([Turn(0, 4000, "S1"), Turn(4000, 8000, "S2")]),
+    )
+    monkeypatch.setattr(diarize, "load_wav_float32", lambda path: ([], 16000))
+    monkeypatch.setattr(pipeline, "_tool_versions", lambda: {"talkthrough-mcp": "test"})
+    if video:
+        def extract_frames(media_path, frame_directory, **kwargs):  # type: ignore[no-untyped-def]
+            frame_directory.mkdir(parents=True)
+            frame = frames.Frame(ms=0, file="t00000000.jpg")
+            (frame_directory / frame.file).write_bytes(b"new frame")
+            return [frame], False
+
+        monkeypatch.setattr(frames, "extract_keyframes", extract_frames)
+        monkeypatch.setattr(dedup, "mark_duplicates", lambda *args, **kwargs: None)
+        monkeypatch.setattr(ocr, "create_engine", lambda **kwargs: object())
+        monkeypatch.setattr(ocr, "ocr_image", lambda *args, **kwargs: "Alice")
+
+
 def test_noop_amend_reports_labels_unchanged_and_keeps_provenance(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1015,6 +1133,201 @@ def test_same_label_and_name_does_not_report_a_drop(
     summary = pipeline.summarize(result)["diarization"]
     assert summary["speaker_names_pending_review"] == {"S1": "Alice"}
     assert "speaker_names_pending_review_dropped" not in summary
+
+
+@pytest.mark.parametrize("diarize_flag", [False, None])
+def test_force_on_named_job_without_resolved_diarization_fails_before_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    diarize_flag: bool | None,
+) -> None:
+    from talkthrough_mcp.core import jobs, pipeline
+
+    media, stored = _stored_force_identity_job(tmp_path, monkeypatch)
+    engine(monkeypatch, available=True)
+    monkeypatch.delenv("TALKTHROUGH_DIARIZE", raising=False)
+    before = (jobs.job_dir(stored.job_id) / "manifest.json").read_bytes()
+
+    def no_probe(path: Path):  # type: ignore[no-untyped-def]
+        raise AssertionError("unsafe force must fail before probing or staging")
+
+    monkeypatch.setattr(pipeline, "probe_media", no_probe)
+    with pytest.raises(ValidationError, match=r"force=true, diarize=true"):
+        pipeline.process_media(
+            str(media),
+            force=True,
+            diarize_speakers=diarize_flag,
+        )
+    assert (jobs.job_dir(stored.job_id) / "manifest.json").read_bytes() == before
+    assert not list(jobs.job_dir(stored.job_id).glob(f"{jobs.REPROCESS_PREFIX}*"))
+
+
+def test_successful_named_force_moves_all_identities_to_pending_review(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from talkthrough_mcp.core import jobs, pipeline
+
+    media, stored = _stored_force_identity_job(tmp_path, monkeypatch)
+    _stub_successful_force(media, monkeypatch)
+    result = pipeline.process_media(
+        str(media), force=True, diarize_speakers=True, num_speakers=2
+    )
+    rebuilt = result.manifest.transcript.diarization
+    assert rebuilt is not None and rebuilt.available
+    assert rebuilt.speaker_names is None
+    assert rebuilt.speaker_name_evidence is None
+    assert rebuilt.speaker_names_pending_review == {
+        "S1": "Alice",
+        "S3": "Carol",
+    }
+    assert rebuilt.speaker_name_evidence_pending_review == {
+        "S1": "old introduction",
+        "S3": "older roster",
+    }
+    assert rebuilt.speaker_names_pending_review_context is not None
+    assert set(rebuilt.speaker_names_pending_review_context) == {"S1", "S3"}
+    summary = pipeline.summarize(result)["diarization"]
+    assert "rebuilt the transcript and speaker labels" in summary[
+        "force_identity_review_note"
+    ]
+    assert "not as an active identity" in summary["force_identity_review_note"]
+    assert not list(jobs.job_dir(stored.job_id).glob(f"{jobs.REPROCESS_PREFIX}*"))
+
+
+def test_named_force_same_label_collision_is_reported_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from talkthrough_mcp.core import jobs, pipeline
+    from talkthrough_mcp.core.manifest import save_manifest
+
+    media, stored = _stored_force_identity_job(tmp_path, monkeypatch)
+    diarization = stored.transcript.diarization
+    assert diarization is not None
+    diarization.speaker_names_pending_review = {"S1": "Older Alice"}
+    diarization.speaker_name_evidence_pending_review = {"S1": "old proof"}
+    diarization.speaker_names_pending_review_context = None
+    save_manifest(stored, jobs.job_dir(stored.job_id))
+    _stub_successful_force(media, monkeypatch)
+
+    result = pipeline.process_media(
+        str(media), force=True, diarize_speakers=True, num_speakers=2
+    )
+    summary = pipeline.summarize(result)["diarization"]
+    assert summary["speaker_names_pending_review"] == {"S1": "Alice"}
+    assert summary["speaker_names_pending_review_dropped"] == {
+        "S1": "Older Alice"
+    }
+    later = pipeline.summarize(
+        pipeline.ProcessResult(
+            manifest=jobs.load_job(stored.job_id), reused=True, elapsed_s=0
+        )
+    )["diarization"]
+    assert "speaker_names_pending_review_dropped" not in later
+
+
+@pytest.mark.parametrize("failure_stage", ["stt", "diarization", "ocr"])
+def test_failed_named_force_keeps_old_manifest_and_frames(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_stage: str,
+) -> None:
+    from talkthrough_mcp.core import jobs, ocr, pipeline, stt
+
+    video = failure_stage == "ocr"
+    media, stored = _stored_force_identity_job(
+        tmp_path, monkeypatch, video=video
+    )
+    _stub_successful_force(media, monkeypatch, video=video)
+    directory = jobs.job_dir(stored.job_id)
+    before_manifest = (directory / "manifest.json").read_bytes()
+    before_frames = (
+        {
+            path.name: path.read_bytes()
+            for path in (directory / "frames").iterdir()
+        }
+        if video
+        else {}
+    )
+    if failure_stage == "stt":
+        monkeypatch.setattr(
+            stt,
+            "transcribe",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                ToolFailureError("controlled STT failure")
+            ),
+        )
+    elif failure_stage == "diarization":
+        monkeypatch.setattr(
+            diarize,
+            "create_diarizer",
+            lambda: (_ for _ in ()).throw(
+                ToolFailureError("controlled diarizer failure")
+            ),
+        )
+    else:
+        monkeypatch.setattr(
+            ocr,
+            "ocr_image",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                ToolFailureError("controlled OCR failure")
+            ),
+        )
+
+    with pytest.raises(ToolFailureError):
+        pipeline.process_media(
+            str(media), force=True, diarize_speakers=True, num_speakers=2
+        )
+    assert (directory / "manifest.json").read_bytes() == before_manifest
+    if video:
+        assert {
+            path.name: path.read_bytes()
+            for path in (directory / "frames").iterdir()
+        } == before_frames
+    assert jobs.load_job(stored.job_id).transcript.diarization is not None
+    assert not list(directory.glob(f"{jobs.REPROCESS_PREFIX}*"))
+
+
+def test_two_named_force_calls_serialize_under_the_job_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import threading
+    import time
+
+    from talkthrough_mcp.core import pipeline, stt
+
+    media, _stored = _stored_force_identity_job(tmp_path, monkeypatch)
+    _stub_successful_force(media, monkeypatch)
+    real_transcribe = stt.transcribe
+    guard = threading.Lock()
+    active = 0
+    max_active = 0
+
+    def observed_transcribe(*args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal active, max_active
+        with guard:
+            active += 1
+            max_active = max(max_active, active)
+        try:
+            time.sleep(0.05)
+            return real_transcribe(*args, **kwargs)
+        finally:
+            with guard:
+                active -= 1
+
+    monkeypatch.setattr(stt, "transcribe", observed_transcribe)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        calls = [
+            pool.submit(
+                pipeline.process_media,
+                str(media),
+                force=True,
+                diarize_speakers=True,
+                num_speakers=2,
+            )
+            for _ in range(2)
+        ]
+        assert all(call.result(timeout=10).reused is False for call in calls)
+    assert max_active == 1
 
 
 def test_concurrent_label_and_relabel_amend_never_lose_verified_names(

--- a/tests/unit/test_pipeline_config.py
+++ b/tests/unit/test_pipeline_config.py
@@ -9,7 +9,7 @@ import pytest
 from tests.conftest import make_manifest
 
 from talkthrough_mcp.core import diarize
-from talkthrough_mcp.core.diarize import Diarization
+from talkthrough_mcp.core.diarize import Diarization, PendingSpeakerReviewContext
 from talkthrough_mcp.core.errors import ToolFailureError, ValidationError
 from talkthrough_mcp.core.pipeline import (
     ALLOWED_WHISPER_MODELS,
@@ -767,6 +767,11 @@ def test_noop_amend_reports_labels_unchanged_and_keeps_provenance(
     assert before_diarization is not None
     before_diarization.speaker_names = {"S1": "Vera"}
     before_diarization.speaker_name_evidence = {"S1": "intro"}
+    before_diarization.speaker_names_pending_review = {"S2": "Tom"}
+    before_diarization.speaker_name_evidence_pending_review = {"S2": "old plate"}
+    before_diarization.speaker_names_pending_review_context = {
+        "S2": PendingSpeakerReviewContext(longest_turn_at_ms=5000)
+    }
     save_manifest(before_amend, jobs.job_dir(before_amend.job_id))
     result = _amend_through_fake_engine(media, monkeypatch, turns=turns, k=3)
     assert result.amended is True  # the amend RAN and landed labels…
@@ -776,6 +781,11 @@ def test_noop_amend_reports_labels_unchanged_and_keeps_provenance(
     assert diarization.amend_reason == "num_speakers"
     assert diarization.speaker_names == {"S1": "Vera"}
     assert diarization.speaker_name_evidence == {"S1": "intro"}
+    assert diarization.speaker_names_pending_review == {"S2": "Tom"}
+    assert diarization.speaker_name_evidence_pending_review == {"S2": "old plate"}
+    assert diarization.speaker_names_pending_review_context == {
+        "S2": PendingSpeakerReviewContext(longest_turn_at_ms=5000)
+    }
     summary = pipeline.summarize(result)["diarization"]
     assert summary["labels_changed"] is False
     assert "nothing was relabelled" in summary["amend_note"]
@@ -878,6 +888,133 @@ def test_relabelling_amend_moves_verified_names_to_persistent_pending_review(
     assert latest_diarization.speaker_name_evidence_pending_review == {
         "S1": "reviewed against current roster"
     }
+
+
+def test_multiple_relabel_generations_merge_disjoint_pending_and_keep_old_anchors(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from talkthrough_mcp.core import jobs, pipeline
+    from talkthrough_mcp.core.diarize import Turn
+    from talkthrough_mcp.core.manifest import save_manifest
+    from talkthrough_mcp.server import label_speakers
+
+    media, original = _stored_attributed_job(tmp_path, monkeypatch)
+    stored = jobs.load_job(jobs.compute_job_id(media))
+    first_diarization = stored.transcript.diarization
+    assert first_diarization is not None
+    first_diarization.speaker_names = {"S1": "Samantha", "S2": "Daniel"}
+    first_diarization.speaker_name_evidence = {
+        "S1": "first voice",
+        "S2": "second voice",
+    }
+    save_manifest(stored, jobs.job_dir(stored.job_id))
+
+    three_speakers = [
+        Turn(0, 2500, "S1"),
+        Turn(2500, 5000, "S2"),
+        Turn(5000, 8000, "S3"),
+    ]
+    first_amend = _amend_through_fake_engine(
+        media, monkeypatch, turns=three_speakers, k=3
+    )
+    first_pending = first_amend.manifest.transcript.diarization
+    assert first_pending is not None
+    assert first_pending.speaker_names_pending_review == {
+        "S1": "Samantha",
+        "S2": "Daniel",
+    }
+    assert first_pending.speaker_names_pending_review_context is not None
+    assert first_pending.speaker_names_pending_review_context["S1"].talk_time_ms == 5000
+    assert first_pending.speaker_names_pending_review_context[
+        "S2"
+    ].longest_turn_at_ms == 5000
+
+    label_speakers(stored.job_id, {"S3": "Ghost"}, {"S3": "third voice"})
+    second_amend = _amend_through_fake_engine(
+        media, monkeypatch, turns=original, k=2
+    )
+    final = second_amend.manifest.transcript.diarization
+    assert final is not None
+    assert final.speaker_names is None
+    assert final.speaker_names_pending_review == {
+        "S1": "Samantha",
+        "S2": "Daniel",
+        "S3": "Ghost",
+    }
+    assert final.speaker_names_pending_review_context is not None
+    assert set(final.speaker_names_pending_review_context) == {"S1", "S2", "S3"}
+    assert final.speaker_names_pending_review_context[
+        "S3"
+    ].source_detected_num_speakers == 3
+    assert final.speaker_names_pending_review_context["S3"].longest_turn_at_ms == 5000
+    summary = pipeline.summarize(second_amend)["diarization"]
+    assert summary["speaker_names_pending_review_stale_labels"] == ["S3"]
+
+    label_speakers(stored.job_id, {"S3": None})
+    cleaned = jobs.load_job(stored.job_id).transcript.diarization
+    assert cleaned is not None
+    assert cleaned.speaker_names_pending_review == {
+        "S1": "Samantha",
+        "S2": "Daniel",
+    }
+    assert cleaned.speaker_names_pending_review_context is not None
+    assert set(cleaned.speaker_names_pending_review_context) == {"S1", "S2"}
+
+
+def test_same_label_collision_is_reported_once_and_active_value_wins(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from talkthrough_mcp.core import jobs, pipeline
+    from talkthrough_mcp.core.diarize import Turn
+    from talkthrough_mcp.core.manifest import save_manifest
+
+    media, _original = _stored_attributed_job(tmp_path, monkeypatch)
+    stored = jobs.load_job(jobs.compute_job_id(media))
+    diarization = stored.transcript.diarization
+    assert diarization is not None
+    diarization.speaker_names = {"S1": "New Alice"}
+    diarization.speaker_name_evidence = {"S1": "fresh intro"}
+    diarization.speaker_names_pending_review = {"S1": "Old Alice"}
+    diarization.speaker_name_evidence_pending_review = {"S1": "old intro"}
+    save_manifest(stored, jobs.job_dir(stored.job_id))
+
+    changed = [Turn(0, 3000, "S1"), Turn(3000, 8000, "S2")]
+    result = _amend_through_fake_engine(media, monkeypatch, turns=changed, k=3)
+    updated = result.manifest.transcript.diarization
+    assert updated is not None
+    assert updated.speaker_names_pending_review == {"S1": "New Alice"}
+    summary = pipeline.summarize(result)["diarization"]
+    assert summary["speaker_names_pending_review_dropped"] == {"S1": "Old Alice"}
+    assert summary["speaker_names_pending_review_dropped_total"] == 1
+    assert "superseded" in summary["speaker_names_pending_review_dropped_note"]
+
+    reloaded = jobs.load_job(stored.job_id)
+    later = pipeline.summarize(
+        pipeline.ProcessResult(manifest=reloaded, reused=True, elapsed_s=0)
+    )["diarization"]
+    assert "speaker_names_pending_review_dropped" not in later
+
+
+def test_same_label_and_name_does_not_report_a_drop(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from talkthrough_mcp.core import jobs, pipeline
+    from talkthrough_mcp.core.diarize import Turn
+    from talkthrough_mcp.core.manifest import save_manifest
+
+    media, _original = _stored_attributed_job(tmp_path, monkeypatch)
+    stored = jobs.load_job(jobs.compute_job_id(media))
+    diarization = stored.transcript.diarization
+    assert diarization is not None
+    diarization.speaker_names = {"S1": "Alice"}
+    diarization.speaker_names_pending_review = {"S1": "Alice"}
+    save_manifest(stored, jobs.job_dir(stored.job_id))
+
+    changed = [Turn(0, 3000, "S1"), Turn(3000, 8000, "S2")]
+    result = _amend_through_fake_engine(media, monkeypatch, turns=changed, k=3)
+    summary = pipeline.summarize(result)["diarization"]
+    assert summary["speaker_names_pending_review"] == {"S1": "Alice"}
+    assert "speaker_names_pending_review_dropped" not in summary
 
 
 def test_concurrent_label_and_relabel_amend_never_lose_verified_names(

--- a/tests/unit/test_release_notes.py
+++ b/tests/unit/test_release_notes.py
@@ -83,3 +83,14 @@ def test_cli_writes_output_file(tmp_path: Path) -> None:
     assert output.read_text(encoding="utf-8") == extract_release_notes(
         CHANGELOG, "0.3.2", tag="v0.3.2"
     )
+
+
+def test_release_workflow_checks_project_version_before_publish() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(
+        encoding="utf-8"
+    )
+    assert 'PROJECT_VERSION="$(uv version --short)"' in workflow
+    assert '--version "$PROJECT_VERSION"' in workflow
+    assert '--tag "$GITHUB_REF_NAME"' in workflow
+    assert "--notes-file release-notes.md" in workflow
+    assert "--generate-notes" not in workflow

--- a/tests/unit/test_release_notes.py
+++ b/tests/unit/test_release_notes.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from scripts.extract_release_notes import ReleaseNotesError, extract_release_notes
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "extract_release_notes.py"
+
+CHANGELOG = """\
+# Changelog
+
+## [0.3.2] — 2026-09-03
+
+### Fixed
+
+- Kept the stored job safe.
+
+## [0.3.1] — 2026-09-02
+
+- Previous release.
+"""
+
+
+def test_extracts_exact_nonempty_section_without_next_release() -> None:
+    notes = extract_release_notes(CHANGELOG, "0.3.2", tag="v0.3.2")
+    assert notes.startswith("## [0.3.2] — 2026-09-03\n")
+    assert "Kept the stored job safe" in notes
+    assert "0.3.1" not in notes
+    assert notes.endswith("\n")
+
+
+@pytest.mark.parametrize(
+    ("changelog", "error"),
+    [
+        ("# Changelog\n", "missing"),
+        (CHANGELOG + "\n## [0.3.2]\n\n- Again.\n", "duplicate"),
+        ("## [0.3.2] — soon\n\n## [0.3.1]\n\n- Old.\n", "empty"),
+    ],
+)
+def test_rejects_missing_duplicate_or_empty_section(changelog: str, error: str) -> None:
+    with pytest.raises(ReleaseNotesError, match=error):
+        extract_release_notes(changelog, "0.3.2")
+
+
+@pytest.mark.parametrize(
+    ("version", "tag", "error"),
+    [
+        ("0.3.2", "v0.3.1", "mismatch"),
+        ("0.3.2", "0.3.2", "must start"),
+        ("release", "vrelease", "invalid version"),
+    ],
+)
+def test_rejects_invalid_or_mismatched_version_tag(
+    version: str, tag: str, error: str
+) -> None:
+    with pytest.raises(ReleaseNotesError, match=error):
+        extract_release_notes(CHANGELOG, version, tag=tag)
+
+
+def test_cli_writes_output_file(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    output = tmp_path / "release-notes.md"
+    changelog.write_text(CHANGELOG, encoding="utf-8")
+    subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--version",
+            "0.3.2",
+            "--tag",
+            "v0.3.2",
+            "--changelog",
+            str(changelog),
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+    assert output.read_text(encoding="utf-8") == extract_release_notes(
+        CHANGELOG, "0.3.2", tag="v0.3.2"
+    )

--- a/tests/unit/test_server_tools.py
+++ b/tests/unit/test_server_tools.py
@@ -15,7 +15,13 @@ from pathlib import Path
 import pytest
 from tests.conftest import make_manifest
 
-from talkthrough_mcp.core.diarize import Diarization, Turn, attribute_segments, speaker_roster
+from talkthrough_mcp.core.diarize import (
+    Diarization,
+    PendingSpeakerReviewContext,
+    Turn,
+    attribute_segments,
+    speaker_roster,
+)
 from talkthrough_mcp.core.jobs import job_dir
 from talkthrough_mcp.core.manifest import Manifest, Transcript, save_manifest
 from talkthrough_mcp.core.stt import SttWord
@@ -548,6 +554,7 @@ def test_unknown_saved_name_returns_bounded_honesty_note(isolated_home: Path) ->
 
 
 def test_pending_review_name_is_not_an_active_search_identity(isolated_home: Path) -> None:
+    from talkthrough_mcp.core import pipeline
     from talkthrough_mcp.server import search
 
     manifest = _diarize(make_manifest())
@@ -558,6 +565,29 @@ def test_pending_review_name_is_not_an_active_search_identity(isolated_home: Pat
     assert payload["hits"] == []
     assert "saved in pending review" in payload["note"]
     assert "not an active identity" in payload["note"]
+    assert pipeline.pending_review_note(diarization) in payload["note"]
+
+
+def test_pending_review_payload_marks_stale_labels_and_bounds_context() -> None:
+    from talkthrough_mcp.core import pipeline
+
+    manifest = _diarize(make_manifest())
+    diarization = manifest.transcript.diarization
+    assert diarization is not None
+    diarization.speaker_names_pending_review = {"S1": "Vera", "S3": "Ghost"}
+    diarization.speaker_names_pending_review_context = {
+        "S1": PendingSpeakerReviewContext(longest_turn_at_ms=0),
+        "S3": PendingSpeakerReviewContext(longest_turn_at_ms=9000),
+        "S9": PendingSpeakerReviewContext(longest_turn_at_ms=9999),
+    }
+    payload = pipeline.pending_review_payload(diarization)
+    assert payload["speaker_names_pending_review_stale_labels"] == ["S3"]
+    assert payload["speaker_names_pending_review_stale_total"] == 1
+    assert payload["speaker_names_pending_review_context"] == {
+        "S1": {"longest_turn_at_ms": 0},
+        "S3": {"longest_turn_at_ms": 9000},
+    }
+    assert "S9" not in payload["speaker_names_pending_review_context"]
 
 
 def test_pending_review_payload_is_roster_capped(isolated_home: Path) -> None:
@@ -569,10 +599,21 @@ def test_pending_review_payload_is_roster_capped(isolated_home: Path) -> None:
     diarization.speaker_names_pending_review = {
         f"S{index}": f"Name {index}" for index in range(1, pipeline.SUMMARY_ROSTER_CAP + 4)
     }
+    diarization.speaker_names_pending_review["S99"] = "Stale name"
+    diarization.speaker_names_pending_review_context = {
+        label: PendingSpeakerReviewContext(longest_turn_at_ms=index)
+        for index, label in enumerate(diarization.speaker_names_pending_review)
+    }
     payload = pipeline.pending_review_payload(diarization)
     assert len(payload["speaker_names_pending_review"]) == pipeline.SUMMARY_ROSTER_CAP
-    assert payload["speaker_names_pending_review_total"] == pipeline.SUMMARY_ROSTER_CAP + 3
-    assert payload["speaker_names_pending_review_truncated"] == 3
+    assert payload["speaker_names_pending_review_total"] == pipeline.SUMMARY_ROSTER_CAP + 4
+    assert payload["speaker_names_pending_review_truncated"] == 4
+    assert set(payload["speaker_names_pending_review_context"]) == set(
+        payload["speaker_names_pending_review"]
+    )
+    assert payload["speaker_names_pending_review_stale_total"] == 1
+    assert payload["speaker_names_pending_review_stale_truncated"] == 1
+    assert "speaker_names_pending_review_stale_labels" not in payload
 
 
 def test_name_candidates_are_bounded_deduplicated_name_like_ocr_hints(

--- a/tests/unit/test_server_tools.py
+++ b/tests/unit/test_server_tools.py
@@ -654,7 +654,21 @@ def test_name_candidates_are_bounded_deduplicated_name_like_ocr_hints(
 
 @pytest.mark.parametrize(
     "line",
-    ["Vera Smith", "MARTIN DUBOIS", "Ирина Петрова", "Élodie Martin", "张伟", "محمد علي"],
+    [
+        "Vera Smith",
+        "MARTIN DUBOIS",
+        "Ирина Петрова",
+        "Élodie Martin",
+        "张伟",
+        "محمد علي",
+        "Vera Smith (she/her)",
+        "Ludwig van der Beek",
+        "Jean d'Arc",
+        "Иван Петров (организатор)",
+        "Prof. Dr. Hans-Peter von der Linden",
+        "Ana María López de la Torre",
+        "vera smith",
+    ],
 )
 def test_name_candidate_filter_accepts_names_across_scripts(line: str) -> None:
     from talkthrough_mcp.core.pipeline import _name_candidates
@@ -676,6 +690,18 @@ def test_name_candidate_filter_accepts_names_across_scripts(line: str) -> None:
         r"C:\\Users\\alex\\project.py",
         "this is a long slide sentence explaining the quarterly product roadmap",
         "A" * 81,
+        "PROPHET",
+        "Terminal",
+        "Loading",
+        "Meeting Chat",
+        "Zoom Meeting",
+        "Waiting Room",
+        "Everyone",
+        "Unknown Caller",
+        "Copy Paste Delete",
+        "Stop Recording",
+        "参会者",
+        "Продажи Отчет",
     ],
 )
 def test_name_candidate_filter_rejects_ui_chrome_paths_and_long_text(line: str) -> None:
@@ -688,6 +714,41 @@ def test_name_candidate_filter_rejects_ui_chrome_paths_and_long_text(line: str) 
     assert _name_candidates(manifest, 0) == []
 
 
+@pytest.mark.parametrize(
+    ("line", "reason"),
+    [
+        ("Vera Smith (she/her)", None),
+        ("vera smith", None),
+        ("Meeting Chat", "ui_phrase"),
+        ("https://example.com/Vera", "url_or_path"),
+        ("Vera 123", "digit"),
+        ("ordinary lowercase sentence", None),
+        ("ordinary lowercase sentence with five", "casing"),
+    ],
+)
+def test_name_candidate_filter_exposes_explainable_reasons(
+    line: str, reason: str | None
+) -> None:
+    from talkthrough_mcp.core.pipeline import _name_candidate_rejection_reason
+
+    assert _name_candidate_rejection_reason(line) == reason
+
+
+def test_name_candidate_dedupe_uses_nfkc_casefold_and_punctuation() -> None:
+    from talkthrough_mcp.core.pipeline import _name_candidates
+
+    manifest = make_manifest()
+    fullwidth = "\uff36\uff45\uff52\uff41\u3000\uff33\uff4d\uff49\uff54\uff48"
+    manifest.frames.items[0].ocr_text = (
+        f"{fullwidth}\nVERA-SMITH\nVera Smith (she/her)"
+    )
+    manifest.frames.items[2].ocr_text = None
+    manifest.frames.items[3].ocr_text = None
+    assert _name_candidates(manifest, 0) == [
+        {"text": fullwidth.replace("\u3000", " "), "frame_ms": 0}
+    ]
+
+
 def test_old_flat_ocr_payload_does_not_become_a_long_name_candidate() -> None:
     from talkthrough_mcp.core.pipeline import _name_candidates
 
@@ -698,6 +759,52 @@ def test_old_flat_ocr_payload_does_not_become_a_long_name_candidate() -> None:
     manifest.frames.items[2].ocr_text = None
     manifest.frames.items[3].ocr_text = None
     assert _name_candidates(manifest, 0) == []
+
+
+def test_legacy_ocr_note_is_metadata_based_bounded_and_read_only(
+    isolated_home: Path,
+) -> None:
+    from talkthrough_mcp.core import jobs, pipeline
+    from talkthrough_mcp.server import get_transcript, label_speakers
+
+    manifest = _diarize(make_manifest())
+    manifest.tool_versions["talkthrough-mcp"] = "0.3.0"
+    manifest.frames.items[0].ocr_text = (
+        "Vera Smith File Edit View Navigate Code Refactor Run Tools Window Help"
+    )
+    job_id = _store(manifest)
+    path = jobs.job_dir(job_id) / "manifest.json"
+    before = path.read_bytes()
+
+    transcript = get_transcript(job_id)
+    summary = pipeline.summarize(
+        pipeline.ProcessResult(manifest=manifest, reused=True, elapsed_s=0)
+    )["diarization"]
+    labelled = label_speakers(job_id, {})
+    note = transcript["name_candidates_note"]
+    assert note == summary["name_candidates_note"] == labelled["name_candidates_note"]
+    assert "legacy single-line OCR" in note
+    assert "may be absent" in note
+    assert all("name_candidates" not in speaker for speaker in transcript["speakers"])
+    assert path.read_bytes() == before
+
+
+def test_legacy_ocr_note_uses_producer_not_newline_shape() -> None:
+    from talkthrough_mcp.core.pipeline import legacy_name_candidates_note
+
+    current = make_manifest()
+    current.tool_versions["talkthrough-mcp"] = "0.3.2"
+    current.frames.items[0].ocr_text = "Vera Smith"
+    assert legacy_name_candidates_note(current) is None
+
+    audio = make_manifest(kind="audio")
+    audio.tool_versions["talkthrough-mcp"] = "0.3.0"
+    assert legacy_name_candidates_note(audio) is None
+
+    no_ocr = make_manifest()
+    no_ocr.tool_versions["talkthrough-mcp"] = "0.3.0"
+    no_ocr.caps = replace(no_ocr.caps, ocr=False)
+    assert legacy_name_candidates_note(no_ocr) is None
 
 
 def test_search_whitespace_semantics_survive_ocr_line_boundaries() -> None:

--- a/tests/unit/test_speaker_labels.py
+++ b/tests/unit/test_speaker_labels.py
@@ -6,7 +6,11 @@ from typing import Any, cast
 
 import pytest
 
-from talkthrough_mcp.core.diarize import Diarization, SpeakerStat
+from talkthrough_mcp.core.diarize import (
+    Diarization,
+    PendingSpeakerReviewContext,
+    SpeakerStat,
+)
 from talkthrough_mcp.core.errors import ValidationError
 from talkthrough_mcp.core.speaker_labels import apply_speaker_label_patch
 
@@ -105,6 +109,10 @@ def test_explicit_label_patch_reviews_only_the_touched_pending_entries() -> None
         "S1": "old intro",
         "S2": "old name plate",
     }
+    diarization.speaker_names_pending_review_context = {
+        "S1": PendingSpeakerReviewContext(longest_turn_at_ms=1000),
+        "S2": PendingSpeakerReviewContext(longest_turn_at_ms=5000),
+    }
     apply_speaker_label_patch(
         diarization,
         {"S1": "Vera"},
@@ -116,10 +124,14 @@ def test_explicit_label_patch_reviews_only_the_touched_pending_entries() -> None
     }
     assert diarization.speaker_names_pending_review == {"S2": "Tom"}
     assert diarization.speaker_name_evidence_pending_review == {"S2": "old name plate"}
+    assert diarization.speaker_names_pending_review_context == {
+        "S2": PendingSpeakerReviewContext(longest_turn_at_ms=5000)
+    }
 
     apply_speaker_label_patch(diarization, {"S2": None})
     assert diarization.speaker_names_pending_review is None
     assert diarization.speaker_name_evidence_pending_review is None
+    assert diarization.speaker_names_pending_review_context is None
 
 
 def test_evidence_only_patch_does_not_claim_pending_identity_was_reviewed() -> None:
@@ -128,3 +140,53 @@ def test_evidence_only_patch_does_not_claim_pending_identity_was_reviewed() -> N
     diarization.speaker_names_pending_review = {"S2": "Tom"}
     apply_speaker_label_patch(diarization, {}, {"S1": "new proof"})
     assert diarization.speaker_names_pending_review == {"S2": "Tom"}
+
+
+def test_stale_pending_label_can_only_be_removed_with_explicit_null() -> None:
+    diarization = _diarization()
+    diarization.speaker_names_pending_review = {"S3": "Ghost"}
+    diarization.speaker_name_evidence_pending_review = {"S3": "old title card"}
+    diarization.speaker_names_pending_review_context = {
+        "S3": PendingSpeakerReviewContext(longest_turn_at_ms=9000)
+    }
+
+    before = diarization.to_dict()
+    with pytest.raises(ValidationError, match=r"inactive.*cannot be confirmed"):
+        apply_speaker_label_patch(diarization, {"S3": "Ghost"})
+    assert diarization.to_dict() == before
+
+    with pytest.raises(ValidationError, match=r"inactive.*cannot be confirmed"):
+        apply_speaker_label_patch(diarization, {"S3": "   "})
+    assert diarization.to_dict() == before
+
+    with pytest.raises(ValidationError, match=r"evidence.*inactive"):
+        apply_speaker_label_patch(diarization, {}, {"S3": "new proof"})
+    assert diarization.to_dict() == before
+
+    apply_speaker_label_patch(diarization, {" s3 ": None})
+    assert diarization.speaker_names_pending_review is None
+    assert diarization.speaker_name_evidence_pending_review is None
+    assert diarization.speaker_names_pending_review_context is None
+
+
+def test_unknown_label_error_names_current_and_pending_sets() -> None:
+    diarization = _diarization()
+    diarization.speaker_names_pending_review = {"S3": "Ghost"}
+    with pytest.raises(
+        ValidationError,
+        match=r"current roster labels: S1, S2; pending-review labels: S3",
+    ):
+        apply_speaker_label_patch(diarization, {"S4": None})
+
+
+def test_mixed_current_and_invalid_stale_patch_is_atomic() -> None:
+    diarization = _diarization()
+    diarization.speaker_names = {"S1": "Vera"}
+    diarization.speaker_names_pending_review = {"S3": "Ghost"}
+    before = diarization.to_dict()
+    with pytest.raises(ValidationError, match=r"inactive.*cannot be confirmed"):
+        apply_speaker_label_patch(
+            diarization,
+            {"S1": "Updated Vera", "S3": "Ghost"},
+        )
+    assert diarization.to_dict() == before

--- a/uv.lock
+++ b/uv.lock
@@ -1666,7 +1666,7 @@ wheels = [
 
 [[package]]
 name = "talkthrough-mcp"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "faster-whisper" },


### PR DESCRIPTION
## Scope

This branch now assembles the complete v0.3.2 release candidate in one PR, per owner direction.

- F1/F3/F4: lossless pending speaker review, old-roster anchors, stale-label removal, deterministic merge/superseded reporting.
- F2: same-filesystem staged full reprocessing, manifest-last commit/rollback, unsafe-force refusal, active+pending identity preservation.
- F5/F7: response-only legacy flat-OCR note and a broader but conservative, capped/deduplicated name-candidate filter.
- F6/F8: one Python-selector argv contract with portable shell quoting and raw JSON/TOML/deeplink args.
- F9/F10/F11: Python 3.11–3.13 CI, MCP inventory smoke, native shell coverage, and factual cold-start/TLS/cache recovery docs.
- F12: deterministic CHANGELOG release-note extraction; missing/duplicate/empty/tag-mismatched notes fail before publish.
- F13: honest compatibility notes, corrected failed-mutation comment, and no doubled crop ellipsis in straddle quotes.
- F14: semantic operational-doc tests that survive harmless copy edits.

No tools, prompts, runtime dependencies, telemetry, runtime network behavior, or manifest schema versions were added. Generated files come only from the canonical generator.

## Safety contract

- Repeated diarization changes never silently discard an active or already-pending identity.
- A full rebuild of a named job requires diarization; refusal happens before probe/staging and leaves the job unchanged.
- Successful full rebuilds deactivate old claims and retain every representable identity as bounded pending-review evidence against the fresh roster.
- STT, diarization, OCR, validation, and injected commit failures retain the old manifest and frames; abandoned nested staging is hidden from listing and covered by GC.
- Legacy manifests are served without migration or writeback.

## Verification on exact RC `b8c6367`

- Full local gate: 419 passed (373 unit, 44 integration, 2 MCP stdio E2E); ruff and strict mypy clean.
- Python compatibility: 3.11, 3.12, and 3.13 import/CLI/MCP inventory passed; unit suite passed on each tested interpreter, and a real fixture processed on 3.13.
- Real-engine acceptance covers k=2→3→2 pending lifecycle, active+pending safe force, controlled failed force retention, word attribution after force, and fresh-session persistence.
- Generated launcher cold-started with an empty managed-Python directory, then passed warm zsh/bash/sh runs without a redirection artifact. PowerShell/cmd forms are gated in CI.
- Generator is idempotent; actionlint, release-note extraction, version/tag mismatch tests, and `twine check` pass.
- Base wheel, `[diarization]` wheel, sdist build/install, and the exact generated plugin command all report 0.3.2 with 8 tools / 6 prompts.
- Artifact hashes:
  - wheel: `17602779ea71722f5f9e1cccdf67686828b2807db1161cc1212c80fc6f97400d`
  - sdist: `8143c19a3ed88b1d5b2cb130e3cd4761e66c8e3591cd243d1cfbbd5c9eb069e5`
- Read-only cloned real-store scan served 10 jobs across producer versions 0.1.0, 0.2.0, 0.2.4, and 0.3.0. Original store digest remains `e2042fa1089b7890fab3be1cdfd0416a5a7d8c5cfb083acdeb713f7aa2dc5331` (7009 files); all 8 tracked fixtures are unchanged.

## Residual risk / owner gate

- Raw S<n> labels remain generation-local; a pending anchor is evidence to re-check, not proof that a same-numbered new label is the same person.
- The copied private store has no 0.3.1-produced specimen; 0.3.1 compatibility is covered by current-schema/unit and old command-pack checks.
- Cross-platform launcher behavior still needs the newly triggered GitHub Linux/macOS/Windows/Python matrix to finish green.
- The paid model/agent parity grid has not been run; the implementation plan requires a separate owner checkpoint with runners, call count, time, and spend cap before any paid run.

This PR must not be merged, tagged, or published until the owner reviews the final green report and gives explicit approval.
