### PR TITLE
fix: v0.4.1 — the 0.4.0 release QA findings (log leak, multi-video pages, refresh metadata, lock files, --version)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketplace for the talkthrough plugin: narrated screen recordings in, agent-ready evidence out.",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "plugins": [
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
       - run: uv run --python ${{ matrix.python-version }} pytest tests/unit -q
       - run: uv run --python ${{ matrix.python-version }} python -c "import talkthrough_mcp, sherpa_onnx; print(talkthrough_mcp.__version__)"
       - run: uv run --python ${{ matrix.python-version }} talkthrough-mcp --help
+      - run: uv run --python ${{ matrix.python-version }} talkthrough-mcp --version
       - run: uv run --python ${{ matrix.python-version }} python scripts/check_mcp_inventory.py
       - name: Real CLI fixture smoke on Python 3.13
         if: matrix.python-version == '3.13'
@@ -107,6 +108,12 @@ jobs:
         shell: bash
         run: |
           uv run --no-project --python clean-venv python -c "import yt_dlp, deno, sherpa_onnx; print('yt-dlp', yt_dlp.version.__version__, 'deno', deno.find_deno_bin())"
+      - name: --version names the extras the wheel installed
+        shell: bash
+        run: |
+          uv run --no-project --python clean-venv talkthrough-mcp --version | tee version.txt
+          grep -q "url extra: yt-dlp " version.txt
+          grep -q "diarization extra: sherpa-onnx " version.txt
       - name: Inventory over stdio is 9 tools / 6 prompts
         shell: bash
         run: uv run --no-project --python clean-venv python scripts/check_mcp_inventory.py
@@ -121,6 +128,15 @@ jobs:
           test "$code" -eq 2
           grep -q "playlist" err.txt
           test ! -s out.txt
+      - name: process-url --json reports the refusal as one JSON document
+        shell: bash
+        run: |
+          set +e
+          uv run --no-project --python clean-venv talkthrough-mcp process-url "https://www.youtube.com/playlist?list=PLxyz" --json > out.json 2> err.txt
+          code=$?
+          set -e
+          test "$code" -eq 2
+          uv run --no-project --python clean-venv python -c "import json; d = json.load(open('out.json')); assert d['error']['type'] == 'UnsupportedUrlError', d; print(d['error']['message'])"
 
   macos:
     runs-on: macos-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,74 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [SemVer](https://semver.org/).
 
+## [0.4.1] — 2026-09-05
+
+External findings against 0.4.0 — a negative release QA over the published
+wheel and a corpus of 40+ live URLs — all reproduced first (the log leak
+offline, with `httpx.MockTransport`). No new tools; the wire contract is
+unchanged: 9 tools, 6 prompts.
+
+### Fixed
+
+- **A request URL no longer reaches a log line.** httpx logs every request
+  line at INFO with the full URL — one line per hop, redirect targets
+  included — and the CLI enabled INFO on the root logger before dispatching
+  any command, `serve` included. A direct link's query and a CDN's signed
+  redirect target therefore landed in stderr, which MCP clients keep as log
+  files, against the 0.4.0 promise. The CLI now holds the HTTP client
+  loggers at WARNING and passes every foreign log record and every
+  traceback through `url_ingest.redact`; a canary test with real httpx
+  records over a redirect pins it.
+- **A multi-video page is refused, not silently truncated.** The page probe
+  asked yt-dlp for playlist item 1 only, so the entry count it checked was
+  always 1: a Loom folder or an Instagram carousel was ingested as its first
+  video. The probe now reads a flat entry list, counts, and refuses with
+  `the page contains N videos — pass a link to one video` before any
+  download instance exists.
+- **`refresh=true` replaces the stored provider metadata.** When the
+  refreshed bytes were unchanged the job was served with its old
+  `media.origin`: the summary said `refreshed: true` next to a stale title
+  and `downloaded_at` while the URL index entry was rewritten. The block is
+  now replaced under the job lock; ordinary convergence (a local file
+  first, then a URL with the same bytes) stays additive as documented.
+- **`gc` sweeps orphan URL lock files.** One empty `urls/<key>.lock` per URL
+  was created before validation and never removed, so refused and failed
+  URLs grew the index directory forever. `gc` unlinks every lock without a
+  mapping while holding it and reports them as `urls/<key>.lock`;
+  `url_lock` re-checks the inode after acquiring, so a waiter never ends up
+  holding a lock on a file the sweep removed.
+- **Page-reader crashes say what to do.** An exception the extractor stack
+  raised past yt-dlp's own error class (yt-dlp's TED extractor on a changed
+  page: a bare `TypeError`) now reads `the page reader failed on
+  https://host/… (TypeError: …) — the site may have changed its page
+  layout: refresh the tool environment so yt-dlp updates, or pass a direct
+  link to the media file`, on both the YouTube and the page path.
+
+### Added
+
+- **`talkthrough-mcp --version`** prints the package version, the Python it
+  runs on and the state of the optional extras (`url extra: yt-dlp <v>` or
+  `not installed (direct https:// media links only)`; `diarization extra:
+  sherpa-onnx <v>`). The server logs the same line to stderr at every
+  start, so a client's MCP log shows which server and which extras
+  answered — a hand-written `uvx talkthrough-mcp` config upgrades in place
+  and lists `process_url` without being able to read YouTube or video
+  pages. CI runs it in the version matrix and on the clean-installed wheel.
+- **`--json` on failure** leaves one JSON document on stdout,
+  `{"error": {"type": "UnsupportedUrlError", "message": "…"}}`, next to the
+  unchanged exit code 2 and the human `error:` line on stderr, so
+  automation parses one format on both outcomes.
+- [`docs/URL_ACCEPTANCE_CORPUS.md`](docs/URL_ACCEPTANCE_CORPUS.md): the live
+  URL corpus behind the release QA (full runs, cap and refusal paths,
+  provider failures, negative cases, the 0.4.1 regressions) for manual
+  regression runs — sites change, CI stays offline.
+
+### Changed
+
+- README documents the memory envelope of a cold run and how to upgrade a
+  hand-written 0.3.x config; TROUBLESHOOTING points at `--version` where
+  it asks which server is actually running.
+
 ## [0.4.0] — 2026-09-05
 
 One theme: **give Talkthrough a public video URL and keep everything else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,11 @@ unchanged: 9 tools, 6 prompts.
   URLs grew the index directory forever. `gc` unlinks every lock without a
   mapping while holding it and reports them as `urls/<key>.lock`;
   `url_lock` re-checks the inode after acquiring, so a waiter never ends up
-  holding a lock on a file the sweep removed.
+  holding a lock on a file the sweep removed. Completed calls no longer leave
+  their per-URL thread locks in an unbounded process-global registry.
+- **A failed local pipeline leaves no URL index entry.** The mapping is now
+  published after the manifest is committed; a failure after downloading and
+  installing the managed source cleans both the partial job and its mapping.
 - **Page-reader crashes say what to do.** An exception the extractor stack
   raised past yt-dlp's own error class (yt-dlp's TED extractor on a changed
   page: a bare `TypeError`) now reads `the page reader failed on
@@ -57,7 +61,8 @@ unchanged: 9 tools, 6 prompts.
   answered — a hand-written `uvx talkthrough-mcp` config upgrades in place
   and lists `process_url` without being able to read YouTube or video
   pages. CI runs it in the version matrix and on the clean-installed wheel.
-- **`--json` on failure** leaves one JSON document on stdout,
+- **`--json` on failure** leaves one JSON document on stdout, including for
+  command-line usage errors such as a missing URL or an unknown option,
   `{"error": {"type": "UnsupportedUrlError", "message": "…"}}`, next to the
   unchanged exit code 2 and the human `error:` line on stderr, so
   automation parses one format on both outcomes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,9 @@ unchanged: 9 tools, 6 prompts.
 - **A multi-video page is refused, not silently truncated.** The page probe
   asked yt-dlp for playlist item 1 only, so the entry count it checked was
   always 1: a Loom folder or an Instagram carousel was ingested as its first
-  video. The probe now reads a flat entry list, counts, and refuses with
-  `the page contains N videos — pass a link to one video` before any
-  download instance exists.
+  video. The probe now reads at most two flat entries and refuses with
+  `the page contains more than one video — pass a link to one video` before
+  any download instance exists, without enumerating an entire channel.
 - **`refresh=true` replaces the stored provider metadata.** When the
   refreshed bytes were unchanged the job was served with its old
   `media.origin`: the summary said `refreshed: true` next to a stale title

--- a/README.md
+++ b/README.md
@@ -588,7 +588,17 @@ talkthrough-mcp process sync.m4a --diarize --num-speakers 3   # who said what
 talkthrough-mcp process-url "https://youtu.be/nHfGfEiVdE8"    # one public URL, downloaded once
 talkthrough-mcp gc --keep-days 30                   # clean the job store (sources go with their jobs)
 talkthrough-mcp serve                               # stdio MCP server (default)
+talkthrough-mcp --version                           # package version + which extras this environment has
 ```
+
+`--json` keeps stdout machine-readable on failure too (0.4.1): the process
+exits with code 2, stderr carries the human `error: …` line, and stdout
+carries one JSON document, `{"error": {"type": "UnsupportedUrlError",
+"message": "…"}}`. `--version` also says which optional extras the
+environment has — the quickest check when a hand-written config launches
+the minimal server (`uvx talkthrough-mcp`) that advertises `process_url`
+but can only read direct media links; the server logs the same line to
+stderr at every start.
 
 First run notes: missing system ffmpeg triggers a one-time `static-ffmpeg`
 download; the first transcription downloads the whisper model (~460 MB for

--- a/README.md
+++ b/README.md
@@ -366,6 +366,19 @@ resolves to this lean form) — an explicit `diarize=true` will then answer
 with the one-line install fix. Details in
 [Speakers](#speakers-optional-diarization).
 
+### Upgrading from 0.3.x
+
+Regenerated configs and the plugin carry `[diarization,url]`. A config you
+wrote by hand for 0.3.x — `uvx --python ">=3.11,<3.14" talkthrough-mcp`, or a
+pin without the `url` extra — upgrades the server in place and lists the new
+`process_url` tool,
+but only direct `https://` media links work until the extra is there:
+YouTube and video pages answer with the one-line install fix. Add `url` to
+your command (`uvx --python ">=3.11,<3.14" "talkthrough-mcp[diarization,url]"`),
+restart the client, and check with `talkthrough-mcp --version` (0.4.1+),
+which names the extras the environment has; the server logs the same line
+to stderr at every start, so your client's MCP log shows it too.
+
 ### Local checkout (development)
 
 ```bash
@@ -596,9 +609,9 @@ exits with code 2, stderr carries the human `error: …` line, and stdout
 carries one JSON document, `{"error": {"type": "UnsupportedUrlError",
 "message": "…"}}`. `--version` also says which optional extras the
 environment has — the quickest check when a hand-written config launches
-the minimal server (`uvx talkthrough-mcp`) that advertises `process_url`
-but can only read direct media links; the server logs the same line to
-stderr at every start.
+the minimal server (a launcher without the `url` extra) that advertises
+`process_url` but can only read direct media links; the server logs the
+same line to stderr at every start.
 
 First run notes: missing system ffmpeg triggers a one-time `static-ffmpeg`
 download; the first transcription downloads the whisper model (~460 MB for
@@ -664,6 +677,12 @@ Honest edges, so you can decide fast:
   reason. Sites change; a page that worked yesterday can need a newer yt-dlp
   tomorrow. A provider's upload date is not a recording time, so URL jobs
   have `wall_clock: null` unless you pass `recorded_at`.
+- **Memory: budget about 2 GB for a cold run.** Whisper, the OCR models and
+  the frame pass live in one process. A 78-second video on `tiny` with OCR
+  peaked at 1.6 GB RSS during the 0.4.0 release QA (download included); the
+  default `small` model needs more, larger models proportionally so. An
+  8 GB laptop copes; on anything tighter keep the model small or run the
+  CLI ahead of the agent session.
 - **Keyframes + transcript, not motion analysis.** A glitch *between* scene
   changes can be invisible in the frame set; `extract_frame` re-checks any
   instant, but frame-by-frame motion reasoning is your multimodal model's job.
@@ -758,6 +777,7 @@ without a human reading docs:
 - [`AGENTS.md`](AGENTS.md) — instructions for coding agents contributing to this repo
 - [`server.json`](server.json) — MCP registry manifest
 - [`integrations/`](integrations/) — per-engine adapters, all generated from one source of truth and drift-tested (incl. the Claude Code plugin under [`integrations/claude-code/`](integrations/claude-code/))
+- [`docs/URL_ACCEPTANCE_CORPUS.md`](docs/URL_ACCEPTANCE_CORPUS.md) — the live URL corpus behind the release QA of `process_url` (manual, needs the network; CI stays offline)
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -604,8 +604,9 @@ talkthrough-mcp serve                               # stdio MCP server (default)
 talkthrough-mcp --version                           # package version + which extras this environment has
 ```
 
-`--json` keeps stdout machine-readable on failure too (0.4.1): the process
-exits with code 2, stderr carries the human `error: …` line, and stdout
+`--json` keeps stdout machine-readable on failure too (0.4.1), including a
+missing argument or unknown option: the process exits with code 2, stderr
+carries the human `error: …` line, and stdout
 carries one JSON document, `{"error": {"type": "UnsupportedUrlError",
 "message": "…"}}`. `--version` also says which optional extras the
 environment has — the quickest check when a hand-written config launches

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -128,7 +128,10 @@ also indexed by provider identity (`site:<extractor>:<id>`), so two URL
 forms of one Instagram/TikTok video converge before a second download; the
 raw URL, its query and userinfo never reach a manifest, the index, a log
 line, a progress message or an error (`url_ingest.redact` is the single
-choke point and a canary test pins it); `extract_frame` decodes the kept
+choke point; the CLI holds the HTTP client loggers — httpx logs every
+request line with its URL — at WARNING and passes every foreign log record
+and every traceback through the same redactor; canary tests pin errors,
+files and log lines); `extract_frame` decodes the kept
 source, so URL jobs never need the network again; `gc` deletes the source
 with its job and drops index entries whose job is gone. Same-URL calls
 serialize on a URL lock, and the install + pipeline run under the job lock,

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -399,7 +399,7 @@ or logins. What to expect:
   rate-limited quickly; a "bot check" / "sign-in" refusal means the site
   blocked anonymous access, and there is no workaround here (cookies are
   not supported). Download the post yourself and use `process_media`.
-- **"the page contains N videos"** — carousels and playlists are refused;
+- **"the page contains more than one video"** — carousels and playlists are refused;
   pass a link to one video.
 - **"no video could be found"** — yt-dlp has no extractor for the site and
   found no player on the page; find the actual video URL.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -178,7 +178,9 @@ the OLD version until the session/client restarts. Restart the session (or the
 client) after updating; headless and CI runs pick up the new version on
 their next launch because they spawn a fresh server every time. To verify
 what is actually running, check `tool_versions` in any `process_media`
-summary or manifest. Note the split (0.2.6+): `tool_versions` names what
+summary or manifest, or run `talkthrough-mcp --version` in the environment
+the client uses (0.4.1+; the server also logs that line to stderr at every
+start, so the client's MCP log shows it). Note the split (0.2.6+): `tool_versions` names what
 *transcribed* the job and is deliberately never re-stamped by a diarization
 amend; `diarization.produced_by` names the version that wrote the *current
 speaker labels* — after an amend the two can legitimately differ.
@@ -370,6 +372,15 @@ server command (JSON configs: `"args": ["--python", ">=3.11,<3.14",
 "talkthrough-mcp[diarization,url]"]`), restart the client, retry. The
 generated configs and the Claude plugin already carry both extras. Direct
 `https://` links to media files work without the extra.
+
+A config written by hand before 0.4.0 (the minimal launcher without
+`[url]`, or a pin without it) keeps launching the minimal server after an
+upgrade: the new
+`process_url` tool is listed, direct links work, YouTube and video pages
+answer with this error. `talkthrough-mcp --version` (0.4.1+) names the
+extras an environment has — `url extra: not installed (direct https://
+media links only)` is this case — and the server logs the same line at
+every start.
 
 ## `process_url` on a video page (Instagram, TikTok, Wikimedia Commons, …)
 

--- a/docs/URL_ACCEPTANCE_CORPUS.md
+++ b/docs/URL_ACCEPTANCE_CORPUS.md
@@ -1,0 +1,123 @@
+# URL acceptance corpus for `process_url`
+
+The live URLs behind the release QA of URL ingestion. CI stays offline (unit
+tests stub the network); this corpus is for **manual regression runs** before
+a release and after a yt-dlp bump. Pages change hands, get deleted, or change
+layout: an entry that fails is a finding to look at, not a broken build.
+State recorded on **2026-09-05** against 0.4.0 / 0.4.1-rc, yt-dlp 2026.8.19.
+
+## How to run
+
+Always against a throwaway store, and with caps that stop a run as soon as
+the path under test has been exercised:
+
+```bash
+export TALKTHROUGH_HOME="$(mktemp -d)"
+export TALKTHROUGH_WHISPER_MODEL=tiny
+# full runs: leave the caps at their defaults
+talkthrough-mcp process-url "<url>" --json
+# cap/refusal paths: stop before or right after the first bytes
+TALKTHROUGH_MAX_DOWNLOAD_BYTES=1 talkthrough-mcp process-url "<url>" --json
+TALKTHROUGH_MAX_SECONDS=120 talkthrough-mcp process-url "<url>" --json
+talkthrough-mcp gc --keep-days 30   # must leave urls/ without orphan .lock files
+```
+
+Statuses: **FULL** — the source was downloaded and the local pipeline
+finished; **CAP** — the provider or direct file was recognised, then stopped
+on purpose by a small byte or duration cap; **FAIL** — a real provider/URL
+error with a readable reason; **NEG** — a negative contract case.
+
+Every run must satisfy the contract regardless of status: no raw URL, query
+or userinfo in stdout, stderr, the manifest, `urls/`, or the MCP response
+(use a harmless canary such as `?qa_token=TTSECRET4242` and grep for it);
+no `.part`, job or index entry after a failure; `--json` yields one JSON
+document on stdout on both outcomes.
+
+## 0.4.1 regressions (run first)
+
+| Finding | URL | Expect |
+|---|---|---|
+| F-01 log leak | `https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4?qa_token=TTSECRET4242` with `TALKTHROUGH_MAX_DOWNLOAD_BYTES=1024` | the cap error; `TTSECRET4242` and `HTTP Request` absent from stderr |
+| F-02 multi-video page | `https://www.loom.com/share/folder/997db4db046f43e5912f10dc5f817b5c` with `TALKTHROUGH_MAX_DOWNLOAD_BYTES=1` | `the page contains N videos — pass a link to one video`, no `downloading source` stage |
+| F-03 refresh metadata | `https://youtu.be/nHfGfEiVdE8` once; edit `media.origin.title` in the manifest; run again with `--refresh` | the title comes back from the provider, `downloaded_at` is fresh, same job id |
+| F-04 JSON errors | any refused URL with `--json` | exit 2, `{"error": {"type": …, "message": …}}` on stdout |
+| F-05 extractor crash | `https://www.ted.com/talks/candace_parker_how_to_break_down_barriers_and_not_accept_limits` | `the page reader failed on https://www.ted.com/… (TypeError: …)` with the two ways out (until yt-dlp fixes its TED extractor) |
+| F-07 lock files | after the runs above, `talkthrough-mcp gc --keep-days 30` | reports `urls/<key>.lock` for the refused/failed URLs; only locks of live mappings remain |
+| F-08 version | `talkthrough-mcp --version` | `talkthrough-mcp <v> (python …; url extra: yt-dlp …; diarization extra: sherpa-onnx …)` |
+
+## Full end-to-end
+
+| Status | URL | Result on 2026-09-05 |
+|---|---|---|
+| FULL | https://youtu.be/nHfGfEiVdE8 (official demo) | 78.041 s, STT + frames + OCR |
+| FULL | https://www.tiktok.com/@neildegrassetyson/video/7482856405934918955 | 53.717 s, 14 segments, 52 unique frames |
+| FULL | https://www.instagram.com/reel/DZYDt3_pEH4/ | 86.870 s, speechless, 102 unique frames |
+| FULL | https://commons.wikimedia.org/wiki/File:Caminandes-_Llama_Drama_-_Short_Movie.ogv | 89.908 s, OGV, 107 unique frames |
+| FULL | https://www.reddit.com/r/videos/comments/6rrwyj/that_small_heart_attack/ | 11.796 s, 9 unique frames |
+| FULL | https://www.loom.com/share/43d05f362f734614a2e81b4694a3a523 | 27.047 s, 19 unique frames |
+| FULL | https://vk.com/video205387401_165548505 | 9.686 s, 13 unique frames |
+| FULL | https://www.facebook.com/reel/1195289147628387 | 9.567 s, no audio stream, 16 unique frames |
+| FULL | https://soundcloud.com/jaimemf/youtube-dl-test-video-a-y-baw/s-8Pjrp | 9.87 s audio job |
+| FULL | https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/360/Big_Buck_Bunny_360_10s_1MB.mp4 | 10 s H.264, 5 unique frames |
+| FULL | https://test-videos.co.uk/vids/bigbuckbunny/mp4/av1/360/Big_Buck_Bunny_360_10s_1MB.mp4 | 10 s AV1, 5 unique frames |
+| FULL | https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm | 5.059 s VP8, 4 unique frames |
+| FULL | https://storage.googleapis.com/shaka-demo-assets/angel-one-widevine/v-0240p-0400k-libx264.mp4 | 60 s video-only, 36 unique frames |
+| FULL | https://samplelib.com/lib/preview/mp3/sample-3s.mp3 | 3.196 s audio |
+| FULL | https://interactive-examples.mdn.mozilla.net/media/cc0-audio/t-rex-roar.mp3 | 2.074 s audio |
+| FULL | https://upload.wikimedia.org/wikipedia/commons/c/c8/Example.ogg | 6.104 s audio |
+
+## Recognised, then stopped by a cap
+
+| Status | URL | Observation |
+|---|---|---|
+| CAP | https://youtu.be/ERLlHNiX_d4 | 62 s metadata, byte estimate caught before the download |
+| CAP | https://streamable.com/dnd1 | 61.516 s video recognised |
+| CAP | https://drive.google.com/file/d/0ByeS4oOUV-49Zzh4R1J6R09zazQ/edit?pli=1 | 45.069 s media recognised |
+| CAP | https://bsky.app/profile/bsky.app/post/3l3vgf77uco2g | metadata present; one m3u8 probe gave a 30 s timeout warning |
+| CAP | https://archive.org/details/Cops1922 | duration cap: 1092 s > test cap of 120 s |
+| CAP | https://clips.twitch.tv/FaintLightGullWholeWheat | 32 s media recognised; byte cap during the download |
+| CAP | https://www.bilibili.com/bangumi/play/ep21495/ | duration 1421 s capped; one probe answered HTTP 412 |
+| CAP | https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4 | direct Content-Length cap before the body |
+| CAP | https://samplelib.com/lib/preview/wav/sample-3s.wav | direct Content-Length cap |
+| CAP | https://filesamples.com/samples/audio/flac/sample1.flac | streaming cap without Content-Length |
+| CAP | https://filesamples.com/samples/audio/wav/sample1.wav | streaming cap without Content-Length |
+| CAP | https://filesamples.com/samples/audio/m4a/sample1.m4a | streaming cap |
+| CAP | https://filesamples.com/samples/video/mov/sample_640x360.mov | streaming cap |
+| CAP | https://filesamples.com/samples/video/mkv/sample_640x360.mkv | streaming cap |
+| CAP | https://filesamples.com/samples/video/ogv/sample_640x360.ogv | streaming cap |
+| CAP | https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8 | yt-dlp metadata, 600 s duration cap |
+| CAP | https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8 | yt-dlp metadata, 634 s duration cap |
+| CAP | https://storage.googleapis.com/shaka-demo-assets/sintel/dash.mpd | DASH download path reached the byte cap |
+
+## Failures and negative cases
+
+| Status | URL | Result |
+|---|---|---|
+| FAIL | https://vimeo.com/423808888 | anonymous extractor needs a login; clean refusal |
+| FAIL | https://www.dailymotion.com/video/x2iuewm_steam-machine-models-pricing-listed-on-steam-store-ign-news_videogames | asset deleted upstream: Not found |
+| FAIL | https://www.ted.com/talks/candace_parker_how_to_break_down_barriers_and_not_accept_limits | yt-dlp TED extractor crashes on the current page (F-05 wording) |
+| FAIL | https://rutube.ru/video/3eac3b4561676c17df9132a9a1e62e3e/ | no formats / connection reset |
+| FAIL | https://imgur.com/crGpqCV | metadata 404/timeout |
+| FAIL | https://i.imgur.com/crGpqCV.mp4 | redirects to HTML, then metadata 404 |
+| FAIL | https://samplelib.com/lib/preview/flac/sample-3s.flac | provider HTTP 403 |
+| NEG | https://www.loom.com/share/folder/997db4db046f43e5912f10dc5f817b5c | multi-video page: refused since 0.4.1 (F-02) |
+| NEG | https://www.youtube.com/playlist?list=PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf | refused as a playlist by classification, no network |
+| NEG | https://www.youtube.com/watch?v=jfKfPfyJRdk | active live stream: refused |
+| NEG | https://youtu.be/AAAAAAAAAAA | unavailable id: provider error with a reason |
+
+## Convergence and extra regression URLs
+
+- https://www.youtube.com/shorts/nHfGfEiVdE8 and
+  https://www.youtube.com/embed/nHfGfEiVdE8 must serve the official demo's
+  stored job without network (`reused_url_mapping: true`).
+- https://upload.wikimedia.org/wikipedia/commons/d/d0/Caminandes-_Llama_Drama_-_Short_Movie.ogv
+  is the direct counterpart of the Wikimedia file page above; if the upstream
+  filename changes, take the new one from the file page first.
+- https://download.blender.org/durian/trailer/sintel_trailer-480p.mp4 — a
+  longer direct H.264 file with sound.
+- Two concurrent calls on one direct MP3 URL must produce one job: one caller
+  downloads, the other finds the mapping.
+
+Part of the direct-stream URLs come from the public
+[video-commander/public-test-streams](https://github.com/video-commander/public-test-streams)
+set.

--- a/docs/URL_ACCEPTANCE_CORPUS.md
+++ b/docs/URL_ACCEPTANCE_CORPUS.md
@@ -38,7 +38,7 @@ document on stdout on both outcomes.
 | Finding | URL | Expect |
 |---|---|---|
 | F-01 log leak | `https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4?qa_token=TTSECRET4242` with `TALKTHROUGH_MAX_DOWNLOAD_BYTES=1024` | the cap error; `TTSECRET4242` and `HTTP Request` absent from stderr |
-| F-02 multi-video page | `https://www.loom.com/share/folder/997db4db046f43e5912f10dc5f817b5c` with `TALKTHROUGH_MAX_DOWNLOAD_BYTES=1` | `the page contains N videos — pass a link to one video`, no `downloading source` stage |
+| F-02 multi-video page | `https://www.loom.com/share/folder/997db4db046f43e5912f10dc5f817b5c` with `TALKTHROUGH_MAX_DOWNLOAD_BYTES=1` | `the page contains more than one video — pass a link to one video`, no `downloading source` stage |
 | F-03 refresh metadata | `https://youtu.be/nHfGfEiVdE8` once; edit `media.origin.title` in the manifest; run again with `--refresh` | the title comes back from the provider, `downloaded_at` is fresh, same job id |
 | F-04 JSON errors | any refused URL with `--json` | exit 2, `{"error": {"type": …, "message": …}}` on stdout |
 | F-05 extractor crash | `https://www.ted.com/talks/candace_parker_how_to_break_down_barriers_and_not_accept_limits` | `the page reader failed on https://www.ted.com/… (TypeError: …)` with the two ways out (until yt-dlp fixes its TED extractor) |

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "talkthrough",
   "description": "Turn screen recordings into transcript, exact frames, OCR and wall-clock evidence — then into ready-to-file bug drafts, specs, backlogs and meeting actions. Bundles the talkthrough MCP server, six workflow commands, a triage agent, and an agent skill.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "korovin-aa97",
     "url": "https://github.com/korovin-aa97"

--- a/integrations/claude-code/.mcp.json
+++ b/integrations/claude-code/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--python",
         ">=3.11,<3.14",
-        "talkthrough-mcp[diarization,url]==0.4.0"
+        "talkthrough-mcp[diarization,url]==0.4.1"
       ]
     }
   }

--- a/integrations/claude-desktop/manifest.json
+++ b/integrations/claude-desktop/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "talkthrough",
   "display_name": "Talkthrough — narrated recordings for your agent",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Turn narrated screen recordings into structured evidence: local Whisper transcript, scene keyframes, OCR, wall-clock anchoring. Record, talk — Claude writes the bug report.",
   "author": {
     "name": "korovin-aa97",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "talkthrough-mcp"
-version = "0.4.0"
+version = "0.4.1"
 description = "Local MCP server: turn screen recordings into transcript, exact frames, OCR and wall-clock evidence for coding agents."
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/korovin-aa97/talkthrough-mcp",
     "source": "github"
   },
-  "version": "0.4.0",
+  "version": "0.4.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "talkthrough-mcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/talkthrough_mcp/cli.py
+++ b/src/talkthrough_mcp/cli.py
@@ -12,7 +12,7 @@ import json
 import logging
 import sys
 from collections.abc import Sequence
-from typing import Any, TextIO
+from typing import Any, NoReturn, TextIO
 
 from .core.errors import TalkthroughError
 
@@ -121,8 +121,21 @@ class _VersionAction(argparse.Action):
         parser.exit()
 
 
+class UsageError(Exception):
+    """An argparse failure that ``main`` can render in human and JSON forms."""
+
+    def __init__(self, parser: argparse.ArgumentParser, message: str) -> None:
+        super().__init__(message)
+        self.parser = parser
+
+
+class _ArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> NoReturn:
+        raise UsageError(self, message)
+
+
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+    parser = _ArgumentParser(
         prog="talkthrough-mcp",
         description="Local-first MCP server for narrated screen recordings.",
     )
@@ -349,7 +362,20 @@ def _cmd_gc(args: argparse.Namespace) -> int:
 
 def main(argv: list[str] | None = None) -> None:
     _configure_logging()
-    args = _build_parser().parse_args(argv)
+    effective_argv = list(sys.argv[1:] if argv is None else argv)
+    parser = _build_parser()
+    try:
+        args = parser.parse_args(effective_argv)
+    except UsageError as exc:
+        from .core.url_ingest import redact
+
+        message = redact(str(exc))
+        exc.parser.print_usage(sys.stderr)
+        print(f"{exc.parser.prog}: error: {message}", file=sys.stderr)
+        if "--json" in effective_argv:
+            document = {"error": {"type": type(exc).__name__, "message": message}}
+            print(json.dumps(document, ensure_ascii=False, indent=2))
+        raise SystemExit(2) from None
     try:
         if args.command == "process":
             code = _cmd_process(args)

--- a/src/talkthrough_mcp/cli.py
+++ b/src/talkthrough_mcp/cli.py
@@ -11,8 +11,68 @@ import argparse
 import json
 import logging
 import sys
+from typing import TextIO
 
 from .core.errors import TalkthroughError
+
+logger = logging.getLogger(__name__)
+
+# The HTTP client stack logs every request line at INFO with the full URL
+# (httpx: ``HTTP Request: GET https://host/path?signed-query "HTTP/1.1 200 OK"``,
+# one line per hop, redirect targets included). A signed CDN query must not
+# land in stderr, which MCP clients keep as log files.
+_HTTP_CLIENT_LOGGERS = ("httpx", "httpcore")
+_OWN_LOGGER = "talkthrough_mcp"
+
+
+class _RedactUrls(logging.Filter):
+    """Keep URL-shaped tokens out of the log records other libraries emit.
+
+    The privacy contract says a raw URL — its query and userinfo above all —
+    never reaches a log line. Talkthrough's own loggers already pass their text
+    through ``url_ingest.redact`` or use a safe label such as ``https://host/…``
+    that must survive, so only foreign records are rewritten; a traceback is
+    scrubbed whoever logs it (exception messages quote URLs freely).
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        from .core.url_ingest import redact
+
+        own = record.name == _OWN_LOGGER or record.name.startswith(_OWN_LOGGER + ".")
+        if not own:
+            message = record.getMessage()
+            redacted = redact(message)
+            if redacted != message:
+                record.msg = redacted
+                record.args = ()
+        if record.exc_info and record.exc_info[0] is not None:
+            record.exc_text = redact(logging.Formatter().formatException(record.exc_info))
+            record.exc_info = None
+        return True
+
+
+def _privacy_handler(stream: TextIO) -> logging.Handler:
+    """The stderr handler: the 0.4.0 line format plus the URL filter."""
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s"))
+    handler.addFilter(_RedactUrls())
+    return handler
+
+
+def _configure_logging() -> None:
+    """Root INFO to stderr, with the URL privacy contract applied to every record.
+
+    ``basicConfig`` is a no-op when something configured the root logger
+    first (an embedding, pytest); the filter is then attached to the handlers
+    that exist, and the HTTP client loggers are held at WARNING either way —
+    their INFO request lines are noise for a user and a leak for the contract.
+    """
+    logging.basicConfig(level=logging.INFO, handlers=[_privacy_handler(sys.stderr)])
+    for handler in logging.getLogger().handlers:
+        if not any(isinstance(existing, _RedactUrls) for existing in handler.filters):
+            handler.addFilter(_RedactUrls())
+    for name in _HTTP_CLIENT_LOGGERS:
+        logging.getLogger(name).setLevel(logging.WARNING)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -234,11 +294,7 @@ def _cmd_gc(args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> None:
-    logging.basicConfig(
-        stream=sys.stderr,
-        level=logging.INFO,
-        format="%(asctime)s %(name)s %(levelname)s %(message)s",
-    )
+    _configure_logging()
     args = _build_parser().parse_args(argv)
     try:
         if args.command == "process":

--- a/src/talkthrough_mcp/cli.py
+++ b/src/talkthrough_mcp/cli.py
@@ -11,7 +11,8 @@ import argparse
 import json
 import logging
 import sys
-from typing import TextIO
+from collections.abc import Sequence
+from typing import Any, TextIO
 
 from .core.errors import TalkthroughError
 
@@ -75,10 +76,60 @@ def _configure_logging() -> None:
         logging.getLogger(name).setLevel(logging.WARNING)
 
 
+def _extra_status(extra: str, distribution: str, when_missing: str) -> str:
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        return f"{extra} extra: {distribution} {version(distribution)}"
+    except PackageNotFoundError:
+        return f"{extra} extra: not installed{when_missing}"
+
+
+def version_line() -> str:
+    """``talkthrough-mcp <version> (python <x.y.z>; url extra: …; diarization extra: …)``.
+
+    The extras decide what ``process_url`` and ``diarize`` can do, and a
+    hand-written ``uvx talkthrough-mcp`` config upgrades the server without
+    them — so the line says which ones this environment actually has.
+    """
+    from . import __version__
+
+    python = ".".join(str(part) for part in sys.version_info[:3])
+    url = _extra_status("url", "yt-dlp", " (direct https:// media links only)")
+    diarization = _extra_status("diarization", "sherpa-onnx", "")
+    return f"talkthrough-mcp {__version__} (python {python}; {url}; {diarization})"
+
+
+class _VersionAction(argparse.Action):
+    """``--version``: the package version plus the state of the optional extras."""
+
+    def __init__(
+        self, option_strings: Sequence[str], dest: str, help: str | None = None, **_: Any
+    ) -> None:
+        super().__init__(
+            option_strings, dest=argparse.SUPPRESS, default=argparse.SUPPRESS, nargs=0, help=help
+        )
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: str | Sequence[Any] | None,
+        option_string: str | None = None,
+    ) -> None:
+        print(version_line())
+        parser.exit()
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="talkthrough-mcp",
         description="Local-first MCP server for narrated screen recordings.",
+    )
+    parser.add_argument(
+        "--version",
+        action=_VersionAction,
+        help="print the package version and which optional extras this environment has",
     )
     sub = parser.add_subparsers(dest="command")
 
@@ -161,6 +212,9 @@ def _build_parser() -> argparse.ArgumentParser:
 def _cmd_serve() -> int:
     from .server import mcp
 
+    # One line per start in the client's MCP log: which server, which extras
+    # (a config that launches the minimal server still advertises process_url).
+    logger.info("%s", version_line())
     mcp.run()
     return 0
 
@@ -307,5 +361,10 @@ def main(argv: list[str] | None = None) -> None:
             code = _cmd_serve()
     except TalkthroughError as exc:
         print(f"error: {exc}", file=sys.stderr)
+        if getattr(args, "json", False):
+            # the machine-readable contract holds on failure too: exit 2, the
+            # human line on stderr, one JSON document on stdout
+            document = {"error": {"type": type(exc).__name__, "message": str(exc)}}
+            print(json.dumps(document, ensure_ascii=False, indent=2))
         code = 2
     raise SystemExit(code)

--- a/src/talkthrough_mcp/core/jobs.py
+++ b/src/talkthrough_mcp/core/jobs.py
@@ -715,10 +715,12 @@ def gc(keep_days: int) -> GcResult:
             removed.append(manifest.job_id)
     swept_reprocess, recovered = _sweep_reprocess_dirs()
     # URL ingestion artifacts: index entries whose job is gone (including the
-    # ones just removed above) and download workspaces a dead process left.
-    from .url_ingest import sweep_stale_downloads, sweep_stale_mappings
+    # ones just removed above), lock files without a mapping, and download
+    # workspaces a dead process left.
+    from .url_ingest import sweep_orphan_locks, sweep_stale_downloads, sweep_stale_mappings
 
     url_swept = [f"urls/{name}" for name in sweep_stale_mappings()]
+    url_swept.extend(f"urls/{name}" for name in sweep_orphan_locks())
     url_swept.extend(f"downloads/{name}" for name in sweep_stale_downloads())
     return GcResult(
         removed=removed,

--- a/src/talkthrough_mcp/core/url_download.py
+++ b/src/talkthrough_mcp/core/url_download.py
@@ -203,7 +203,11 @@ def _open_pinned(client: Any, url: str, host: str, addresses: list[str]) -> Iter
         except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
             last = exc
             if index + 1 < len(addresses):
-                logger.info("connect to %s failed (%s); trying the next address", address, exc)
+                logger.info(
+                    "connect to %s failed (%s); trying the next address",
+                    address,
+                    _bounded_reason(str(exc)),
+                )
                 continue
             raise
         try:

--- a/src/talkthrough_mcp/core/url_download.py
+++ b/src/talkthrough_mcp/core/url_download.py
@@ -446,11 +446,14 @@ def youtube_options(
     progress_hook: Callable[[dict[str, Any]], None],
     secrets: tuple[str, ...],
     output_stem: str | None = None,
+    probe: bool = False,
 ) -> dict[str, Any]:
     """The allowlisted YoutubeDL option set — nothing else is ever passed.
 
     ``output_stem`` names the file for site downloads; the default is the
     YouTube stem. Both are Talkthrough-owned templates (never the title).
+    ``probe`` builds the metadata-only instance for a page: it must see every
+    entry of a multi-video page (flat, unresolved) so the caller can refuse.
     """
     from . import jobs
 
@@ -460,7 +463,6 @@ def youtube_options(
         # as a control-flow signal right after the first download, which the
         # API surfaces as a failure (caught on the real demo, 2026-09-05).
         "noplaylist": True,
-        "playlist_items": "1",
         "quiet": True,
         "no_warnings": False,
         "noprogress": True,
@@ -503,6 +505,20 @@ def youtube_options(
     deno = _deno_path()
     if deno is not None:
         options["js_runtimes"] = {"deno": {"path": deno}}
+    if probe:
+        # Metadata pass for a page: a multi-video page (a carousel, a folder)
+        # must come back with ALL its entries, as cheap url stubs, so the
+        # caller can count them and refuse before any download. playlist_items
+        # would slice the list to one entry before we ever see it — yt-dlp
+        # reports the full count only when the entry list happened to be
+        # exhausted (0.4.0 ingested the first video of a Loom folder silently)
+        # — and resolving every entry just to count them would fetch each
+        # video's page.
+        options["extract_flat"] = "in_playlist"
+    else:
+        # One video only; a resolved single-video info dict carries no
+        # playlist, so for the download instance this is belt and braces.
+        options["playlist_items"] = "1"
     return options
 
 
@@ -837,6 +853,7 @@ def download_site(
         progress_hook=progress_hook,
         secrets=secrets,
         output_stem="site-probe",
+        probe=True,
     )
     try:
         with yt_dlp.YoutubeDL(probe_options) as probe:

--- a/src/talkthrough_mcp/core/url_download.py
+++ b/src/talkthrough_mcp/core/url_download.py
@@ -573,6 +573,21 @@ def _youtube_restriction(message: str) -> str | None:
     return None
 
 
+def _page_reader_failure(
+    label: str, exc: BaseException, secrets: tuple[str, ...]
+) -> DownloadError:
+    """The catch-all for exceptions the extractor stack raises past yt-dlp's
+    own error class — a TypeError from a parser that met a changed page, for
+    instance (TED, release QA 2026-09-05). Name the exception, keep its first
+    line, and say what to do about it."""
+    return DownloadError(
+        f"the page reader failed on {label} ({type(exc).__name__}: "
+        f"{_bounded_reason(str(exc), *secrets)}) — the site may have changed its page "
+        "layout: refresh the tool environment so yt-dlp updates, or pass a direct link "
+        "to the media file"
+    )
+
+
 def preflight_info(
     info: dict[str, Any], *, max_seconds: int, max_bytes: int, require_duration: bool = True
 ) -> int | None:
@@ -734,10 +749,7 @@ def download_youtube(
                 f"download exceeded the {max_bytes} byte cap (TALKTHROUGH_MAX_DOWNLOAD_BYTES) "
                 "— aborted"
             ) from exc
-        raise DownloadError(
-            f"unexpected downloader failure for {source.safe_label()}: "
-            f"{type(exc).__name__}: {_bounded_reason(str(exc), *secrets)}"
-        ) from exc
+        raise _page_reader_failure(source.safe_label(), exc, secrets) from exc
     size = produced.stat().st_size
     if size > max_bytes:
         produced.unlink(missing_ok=True)
@@ -934,10 +946,7 @@ def download_site(
                 f"download exceeded the {max_bytes} byte cap (TALKTHROUGH_MAX_DOWNLOAD_BYTES) "
                 "— aborted"
             ) from exc
-        raise DownloadError(
-            f"unexpected downloader failure for {source.safe_label()}: "
-            f"{type(exc).__name__}: {_bounded_reason(str(exc), *secrets)}"
-        ) from exc
+        raise _page_reader_failure(source.safe_label(), exc, secrets) from exc
     size = produced.stat().st_size
     if size > max_bytes:
         produced.unlink(missing_ok=True)

--- a/src/talkthrough_mcp/core/url_download.py
+++ b/src/talkthrough_mcp/core/url_download.py
@@ -507,14 +507,12 @@ def youtube_options(
         options["js_runtimes"] = {"deno": {"path": deno}}
     if probe:
         # Metadata pass for a page: a multi-video page (a carousel, a folder)
-        # must come back with ALL its entries, as cheap url stubs, so the
-        # caller can count them and refuse before any download. playlist_items
-        # would slice the list to one entry before we ever see it — yt-dlp
-        # reports the full count only when the entry list happened to be
-        # exhausted (0.4.0 ingested the first video of a Loom folder silently)
-        # — and resolving every entry just to count them would fetch each
-        # video's page.
+        # only needs to reveal whether a second entry exists. Asking yt-dlp
+        # for the first two flat stubs catches that case without enumerating
+        # an entire channel or large playlist. Asking only for item 1 caused
+        # 0.4.0 to ingest the first video of a Loom folder silently.
         options["extract_flat"] = "in_playlist"
+        options["playlist_items"] = "1:2"
     else:
         # One video only; a resolved single-video info dict carries no
         # playlist, so for the download instance this is belt and braces.
@@ -881,7 +879,7 @@ def download_site(
             if entries:
                 if len(entries) != 1:
                     raise UnsupportedUrlError(
-                        f"the page contains {len(entries)} videos — pass a link to one video"
+                        "the page contains more than one video — pass a link to one video"
                     )
                 resolved = probe.process_ie_result(entries[0], download=False)
                 if not isinstance(resolved, dict):

--- a/src/talkthrough_mcp/core/url_ingest.py
+++ b/src/talkthrough_mcp/core/url_ingest.py
@@ -35,6 +35,7 @@ import socket
 import tempfile
 import threading
 import unicodedata
+import weakref
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -630,7 +631,7 @@ def sweep_stale_downloads(min_age_s: float = jobs.PARTIAL_SWEEP_MIN_AGE_S) -> li
 
 
 _URL_LOCKS_GUARD = threading.Lock()
-_URL_LOCKS: dict[str, threading.Lock] = {}
+_URL_LOCKS: weakref.WeakValueDictionary[str, threading.Lock] = weakref.WeakValueDictionary()
 
 
 @contextmanager
@@ -1056,15 +1057,12 @@ def process_url(
             # Install and process under ONE job lock (re-entrant for the
             # pipeline's own acquisition): another URL with the same bytes
             # waits here instead of installing into a directory that this
-            # call's failure cleanup could remove from under it. The mapping
-            # is written as soon as the file is in place, so a refusal or a
-            # failure after this point never costs a second download; a
-            # mapping to a job that never got its manifest is dropped lazily.
-            with jobs.job_lock(job_id):
+            # call's failure cleanup could remove from under it. Publish the
+            # mapping only after the manifest exists, so every visible index
+            # entry resolves immediately and a failed pipeline leaves no
+            # partial job or stale mapping.
+            with jobs.job_lock(job_id), jobs.partial_job_cleanup(job_id):
                 managed = install_managed_source(job_id, downloaded.path, name)
-                save_mapping(source.mapping_key, mapping)
-                for key in extra_keys:
-                    save_mapping(key, mapping)
                 result = pipeline.process_media(
                     str(managed),
                     **analysis,
@@ -1086,6 +1084,9 @@ def process_url(
                     from dataclasses import replace
 
                     result = replace(result, manifest=jobs.load_job(job_id))
+                save_mapping(source.mapping_key, mapping)
+                for key in extra_keys:
+                    save_mapping(key, mapping)
         return UrlProcessResult(
             result=result,
             source=source,

--- a/src/talkthrough_mcp/core/url_ingest.py
+++ b/src/talkthrough_mcp/core/url_ingest.py
@@ -541,6 +541,55 @@ def sweep_stale_mappings() -> list[str]:
     return removed
 
 
+def _try_flock(fd: int) -> bool:
+    """Take an exclusive non-blocking flock; always True without fcntl (markers only)."""
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - Windows best-effort
+        return True
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        return False
+    return True
+
+
+def _same_file(fd: int, path: Path) -> bool:
+    """Whether ``path`` still names the open file ``fd`` (inode identity)."""
+    try:
+        return os.path.samestat(os.fstat(fd), os.stat(path))
+    except OSError:
+        return False
+
+
+def sweep_orphan_locks() -> list[str]:
+    """Remove URL lock files whose mapping is gone (gc).
+
+    ``url_lock`` creates one empty ``<key>.lock`` per URL before anything is
+    validated, so a refused or failed URL left a file behind forever (0.4.0
+    never removed one). A lock is unlinked only while this process holds it,
+    so an ingestion in flight keeps its file; a waiter that loses its file
+    this way reopens (see ``url_lock``). Locks of live mappings stay: one per
+    stored URL, removed with the mapping.
+    """
+    root = urls_root()
+    if not root.is_dir():
+        return []
+    removed: list[str] = []
+    for path in sorted(root.glob("*.lock")):
+        if path.with_suffix(".json").is_file():
+            continue
+        try:
+            with path.open("a") as handle:
+                if not _try_flock(handle.fileno()):
+                    continue
+                path.unlink(missing_ok=True)
+        except OSError:
+            continue
+        removed.append(path.name)
+    return removed
+
+
 def sweep_stale_downloads(min_age_s: float = jobs.PARTIAL_SWEEP_MIN_AGE_S) -> list[str]:
     """Remove download staging directories a dead process left behind (gc)."""
     root = downloads_root()
@@ -573,7 +622,10 @@ def url_lock(mapping_key: str, *, wait_seconds: int = 3600) -> Iterator[None]:
 
     The second caller waits for the first and then finds the mapping instead
     of downloading the same source twice. Cross-process: POSIX flock on an
-    index-side lock file (no-op on platforms without fcntl).
+    index-side lock file (no-op on platforms without fcntl). ``gc`` removes a
+    lock file whose mapping is gone, so after acquiring, the path is checked
+    to still name the file held — a lock on an unlinked inode guards nothing
+    — and the file is reopened otherwise.
     """
     with _URL_LOCKS_GUARD:
         process_lock = _URL_LOCKS.setdefault(mapping_key, threading.Lock())
@@ -595,20 +647,26 @@ def url_lock(mapping_key: str, *, wait_seconds: int = 3600) -> Iterator[None]:
             return
         import time
 
-        with lock_path.open("w") as handle:
-            deadline = time.monotonic() + wait_seconds
-            while True:
-                try:
-                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-                    break
-                except BlockingIOError:
-                    if time.monotonic() >= deadline:
-                        raise ToolFailureError(
-                            "another process has been ingesting this URL for over "
-                            f"{wait_seconds}s — retry later"
-                        ) from None
-                    time.sleep(1)
-            yield
+        deadline = time.monotonic() + wait_seconds
+        while True:
+            with lock_path.open("w") as handle:
+                while True:
+                    try:
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        break
+                    except BlockingIOError:
+                        if time.monotonic() >= deadline:
+                            raise ToolFailureError(
+                                "another process has been ingesting this URL for over "
+                                f"{wait_seconds}s — retry later"
+                            ) from None
+                        time.sleep(1)
+                if _same_file(handle.fileno(), lock_path):
+                    yield
+                    return
+                # gc swept the (then orphan) file between open() and flock():
+                # reopen — that creates a fresh file, or joins the one a newer
+                # caller created — and compete again.
     finally:
         process_lock.release()
 

--- a/src/talkthrough_mcp/core/url_ingest.py
+++ b/src/talkthrough_mcp/core/url_ingest.py
@@ -703,12 +703,17 @@ def build_origin(
     )
 
 
-def attach_managed_source(job_id: str, managed_source: str, origin: MediaOrigin) -> None:
+def attach_managed_source(
+    job_id: str, managed_source: str, origin: MediaOrigin, *, replace_origin: bool = False
+) -> None:
     """Record a managed source on a job that already existed (same bytes).
 
     A local file processed earlier and a URL that downloads the same bytes
     converge on one job: the manifest gains the managed path and, if it had
-    none, the origin — additively, under the job lock.
+    none, the origin — additively, under the job lock. ``replace_origin`` is
+    the ``refresh=true`` case: the caller asked for the provider's current
+    metadata, so the stored block (title, publication time, ``downloaded_at``)
+    is replaced even though the bytes — and therefore the job — are the same.
     """
     from dataclasses import replace
 
@@ -719,7 +724,7 @@ def attach_managed_source(job_id: str, managed_source: str, origin: MediaOrigin)
         manifest = jobs.load_job(job_id)
         manifest.media = replace(
             manifest.media,
-            origin=manifest.media.origin or origin,
+            origin=origin if replace_origin else (manifest.media.origin or origin),
             managed_source=managed_source,
         )
         save_manifest(manifest, jobs.job_dir(job_id))
@@ -993,13 +998,16 @@ def process_url(
                     managed_source=relative,
                 )
                 if result.reused and (
-                    result.manifest.media.managed_source != relative
+                    refresh
+                    or result.manifest.media.managed_source != relative
                     or result.manifest.media.origin is None
                 ):
                     # Same bytes as a job processed earlier (a local file, or
                     # another URL): keep that job, remember the managed copy
-                    # and origin.
-                    attach_managed_source(job_id, relative, origin)
+                    # and origin. A refresh replaces the provider metadata the
+                    # manifest carries — 0.4.0 answered ``refreshed: true``
+                    # while serving the stale title and ``downloaded_at``.
+                    attach_managed_source(job_id, relative, origin, replace_origin=refresh)
                     from dataclasses import replace
 
                     result = replace(result, manifest=jobs.load_job(job_id))

--- a/src/talkthrough_mcp/core/url_ingest.py
+++ b/src/talkthrough_mcp/core/url_ingest.py
@@ -554,6 +554,15 @@ def _try_flock(fd: int) -> bool:
     return True
 
 
+def _posix_locks() -> bool:
+    """Whether flock is available (POSIX); elsewhere lock files are markers."""
+    try:
+        import fcntl  # noqa: F401
+    except ImportError:  # pragma: no cover - Windows best-effort
+        return False
+    return True
+
+
 def _same_file(fd: int, path: Path) -> bool:
     """Whether ``path`` still names the open file ``fd`` (inode identity)."""
     try:
@@ -570,11 +579,14 @@ def sweep_orphan_locks() -> list[str]:
     never removed one). A lock is unlinked only while this process holds it,
     so an ingestion in flight keeps its file; a waiter that loses its file
     this way reopens (see ``url_lock``). Locks of live mappings stay: one per
-    stored URL, removed with the mapping.
+    stored URL, removed with the mapping. Without flock (Windows) the files
+    are markers and are removed after closing — an open file cannot be
+    unlinked there.
     """
     root = urls_root()
     if not root.is_dir():
         return []
+    posix = _posix_locks()
     removed: list[str] = []
     for path in sorted(root.glob("*.lock")):
         if path.with_suffix(".json").is_file():
@@ -583,6 +595,11 @@ def sweep_orphan_locks() -> list[str]:
             with path.open("a") as handle:
                 if not _try_flock(handle.fileno()):
                     continue
+                if posix:
+                    # unlink while holding the lock: a waiter that opened this
+                    # inode sees the path change and reopens (url_lock)
+                    path.unlink(missing_ok=True)
+            if not posix:
                 path.unlink(missing_ok=True)
         except OSError:
             continue

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -185,6 +185,55 @@ def test_json_flag_turns_a_failure_into_an_error_document(
     assert info.value.code == 2 and capsys.readouterr().out == ""
 
 
+@pytest.mark.parametrize(
+    ("argv", "message"),
+    [
+        (["process-url", "--json"], "the following arguments are required: url"),
+        (
+            ["process-url", "https://cdn.example.com/x.mp4", "--unknown", "--json"],
+            "unrecognized arguments: --unknown",
+        ),
+    ],
+)
+def test_json_flag_covers_command_line_usage_errors(
+    argv: list[str], message: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as info:
+        cli.main(argv)
+    assert info.value.code == 2
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {
+        "error": {"type": "UsageError", "message": message}
+    }
+    assert "usage:" in captured.err and f"error: {message}" in captured.err
+
+
+def test_usage_error_redacts_an_unrecognized_url(
+    capsys: pytest.CaptureFixture[str], isolated_home: Path
+) -> None:
+    del isolated_home
+    secret_url = f"https://cdn.example.com/extra.mp4?{CANARY}"
+    with pytest.raises(SystemExit) as info:
+        cli.main(
+            ["process-url", "https://cdn.example.com/x.mp4", secret_url, "--json"]
+        )
+    assert info.value.code == 2
+    captured = capsys.readouterr()
+    assert CANARY not in captured.out and CANARY not in captured.err
+    assert json.loads(captured.out)["error"]["message"] == "unrecognized arguments: <url>"
+
+
+def test_usage_error_without_json_keeps_stdout_empty(
+    capsys: pytest.CaptureFixture[str], isolated_home: Path
+) -> None:
+    del isolated_home
+    with pytest.raises(SystemExit) as info:
+        cli.main(["process-url"])
+    assert info.value.code == 2
+    captured = capsys.readouterr()
+    assert captured.out == "" and "the following arguments are required: url" in captured.err
+
+
 def test_serve_logs_its_version_and_extras_at_startup(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, restore_http_loggers: None
 ) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,107 @@
+"""The CLI entry point: logging privacy for every command, ``--version``, and
+the ``--json`` error document. The pipeline itself is covered elsewhere."""
+
+from __future__ import annotations
+
+import io
+import logging
+import sys
+from collections.abc import Iterator
+
+import pytest
+
+from talkthrough_mcp import cli
+
+CANARY = "sig=SECRET-TOKEN-4242"
+
+
+@pytest.fixture
+def restore_http_loggers() -> Iterator[None]:
+    """``_configure_logging`` sets process-global logger levels; undo them."""
+    loggers = [logging.getLogger(name) for name in cli._HTTP_CLIENT_LOGGERS]
+    levels = [logger.level for logger in loggers]
+    yield
+    for logger, level in zip(loggers, levels, strict=True):
+        logger.setLevel(level)
+
+
+def _record(
+    name: str, msg: str, args: tuple[object, ...], level: int = logging.INFO
+) -> logging.LogRecord:
+    return logging.LogRecord(name, level, __file__, 1, msg, args, None)
+
+
+# --- log privacy (0.4.1: httpx printed the pinned URL, query included, at INFO) ---
+
+
+def test_privacy_handler_redacts_foreign_records_and_keeps_own_labels() -> None:
+    stream = io.StringIO()
+    handler = cli._privacy_handler(stream)
+    handler.handle(
+        _record(
+            "httpx",
+            'HTTP Request: %s %s "%s"',
+            ("GET", f"https://203.0.113.10/clip.mp4?{CANARY}", "HTTP/1.1 200 OK"),
+        )
+    )
+    handler.handle(
+        _record(
+            "talkthrough_mcp.core.url_ingest",
+            "%s already ingested as job %s — no network",
+            ("https://cdn.example.com/…", "abcdef0123456789"),
+        )
+    )
+    text = stream.getvalue()
+    assert 'httpx INFO HTTP Request: GET <url> "HTTP/1.1 200 OK"' in text
+    assert CANARY not in text and "203.0.113.10" not in text
+    # a safe label is the point of the own log line: it survives untouched
+    assert "https://cdn.example.com/… already ingested as job abcdef0123456789" in text
+
+
+def test_privacy_handler_scrubs_tracebacks_from_any_logger() -> None:
+    stream = io.StringIO()
+    handler = cli._privacy_handler(stream)
+    try:
+        raise RuntimeError(f"boom while fetching https://cdn.example.com/x.mp4?{CANARY}")
+    except RuntimeError:
+        record = logging.LogRecord(
+            "talkthrough_mcp.core.jobs", logging.WARNING, __file__, 1, "sweep failed", None,
+            sys.exc_info(),
+        )
+    handler.handle(record)
+    text = stream.getvalue()
+    assert "sweep failed" in text and "RuntimeError: boom while fetching <url>" in text
+    assert CANARY not in text
+
+
+def test_configure_logging_holds_the_http_client_loggers_at_warning(
+    restore_http_loggers: None,
+) -> None:
+    for name in cli._HTTP_CLIENT_LOGGERS:
+        logging.getLogger(name).setLevel(logging.NOTSET)
+    cli._configure_logging()
+    for name in cli._HTTP_CLIENT_LOGGERS:
+        assert logging.getLogger(name).getEffectiveLevel() == logging.WARNING
+        assert not logging.getLogger(name).isEnabledFor(logging.INFO)
+    root = logging.getLogger()
+    assert root.handlers, "the root logger must end up with a handler"
+    assert all(
+        any(isinstance(item, cli._RedactUrls) for item in handler.filters)
+        for handler in root.handlers
+    )
+    cli._configure_logging()  # idempotent: no duplicate filters
+    assert all(
+        sum(isinstance(item, cli._RedactUrls) for item in handler.filters) == 1
+        for handler in root.handlers
+    )
+
+
+def test_main_configures_logging_before_dispatching(
+    isolated_home: object, capsys: pytest.CaptureFixture[str], restore_http_loggers: None
+) -> None:
+    logging.getLogger("httpx").setLevel(logging.NOTSET)
+    with pytest.raises(SystemExit) as info:
+        cli.main(["gc"])
+    assert info.value.code == 0
+    assert "nothing to remove" in capsys.readouterr().out
+    assert logging.getLogger("httpx").level == logging.WARNING

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -4,9 +4,11 @@ the ``--json`` error document. The pipeline itself is covered elsewhere."""
 from __future__ import annotations
 
 import io
+import json
 import logging
 import sys
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 
@@ -105,3 +107,78 @@ def test_main_configures_logging_before_dispatching(
     assert info.value.code == 0
     assert "nothing to remove" in capsys.readouterr().out
     assert logging.getLogger("httpx").level == logging.WARNING
+
+
+# --- --version and the --json error document (0.4.1) -------------------------------
+
+
+def test_version_flag_names_the_package_python_and_extras(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from talkthrough_mcp import __version__
+
+    with pytest.raises(SystemExit) as info:
+        cli.main(["--version"])
+    assert info.value.code == 0
+    out = capsys.readouterr().out
+    assert out.startswith(f"talkthrough-mcp {__version__} (python 3.")
+    assert "url extra: yt-dlp " in out and "diarization extra: sherpa-onnx " in out
+    assert out == cli.version_line() + "\n"
+
+
+def test_version_line_says_which_extra_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib.metadata as metadata
+
+    real = metadata.version
+
+    def without_yt_dlp(name: str) -> str:
+        if name == "yt-dlp":
+            raise metadata.PackageNotFoundError(name)
+        return real(name)
+
+    monkeypatch.setattr(metadata, "version", without_yt_dlp)
+    line = cli.version_line()
+    assert "url extra: not installed (direct https:// media links only)" in line
+    assert "diarization extra: sherpa-onnx " in line
+
+
+def test_json_flag_turns_a_failure_into_an_error_document(
+    isolated_home: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    playlist = "https://www.youtube.com/playlist?list=PLxyz"
+    with pytest.raises(SystemExit) as info:
+        cli.main(["process-url", playlist, "--json"])
+    assert info.value.code == 2
+    captured = capsys.readouterr()
+    document = json.loads(captured.out)
+    assert set(document) == {"error"} and set(document["error"]) == {"type", "message"}
+    assert document["error"]["type"] == "UnsupportedUrlError"
+    assert "playlist" in document["error"]["message"]
+    error_lines = [line for line in captured.err.splitlines() if line.startswith("error: ")]
+    assert len(error_lines) == 1 and "playlist" in error_lines[0]
+
+    with pytest.raises(SystemExit) as info:
+        cli.main(["process", str(isolated_home / "missing.mp4"), "--json"])
+    assert info.value.code == 2
+    document = json.loads(capsys.readouterr().out)
+    assert document["error"]["type"] == "ValidationError"
+    assert "file not found" in document["error"]["message"]
+
+    with pytest.raises(SystemExit) as info:
+        cli.main(["process-url", playlist])  # without --json stdout stays empty
+    assert info.value.code == 2 and capsys.readouterr().out == ""
+
+
+def test_serve_logs_its_version_and_extras_at_startup(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, restore_http_loggers: None
+) -> None:
+    from talkthrough_mcp import server
+
+    monkeypatch.setattr(server.mcp, "run", lambda: None)
+    with (
+        caplog.at_level(logging.INFO, logger="talkthrough_mcp.cli"),
+        pytest.raises(SystemExit) as info,
+    ):
+        cli.main(["serve"])
+    assert info.value.code == 0
+    assert cli.version_line() in caplog.text

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import io
 import json
 import logging
+import re
 import sys
 from collections.abc import Iterator
 from pathlib import Path
@@ -113,33 +114,48 @@ def test_main_configures_logging_before_dispatching(
 
 
 def test_version_flag_names_the_package_python_and_extras(
-    capsys: pytest.CaptureFixture[str],
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    import importlib.metadata as metadata
+
     from talkthrough_mcp import __version__
 
+    installed = {"yt-dlp": "2026.8.19", "sherpa-onnx": "1.13.4"}
+    monkeypatch.setattr(metadata, "version", lambda name: installed[name])
     with pytest.raises(SystemExit) as info:
         cli.main(["--version"])
     assert info.value.code == 0
-    out = capsys.readouterr().out
-    assert out.startswith(f"talkthrough-mcp {__version__} (python 3.")
-    assert "url extra: yt-dlp " in out and "diarization extra: sherpa-onnx " in out
-    assert out == cli.version_line() + "\n"
+    python = ".".join(str(part) for part in sys.version_info[:3])
+    assert capsys.readouterr().out == (
+        f"talkthrough-mcp {__version__} (python {python}; url extra: yt-dlp 2026.8.19; "
+        "diarization extra: sherpa-onnx 1.13.4)\n"
+    )
 
 
-def test_version_line_says_which_extra_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_version_line_says_which_extras_are_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     import importlib.metadata as metadata
 
-    real = metadata.version
+    def nothing_installed(name: str) -> str:
+        raise metadata.PackageNotFoundError(name)
 
-    def without_yt_dlp(name: str) -> str:
-        if name == "yt-dlp":
-            raise metadata.PackageNotFoundError(name)
-        return real(name)
-
-    monkeypatch.setattr(metadata, "version", without_yt_dlp)
+    monkeypatch.setattr(metadata, "version", nothing_installed)
     line = cli.version_line()
     assert "url extra: not installed (direct https:// media links only)" in line
-    assert "diarization extra: sherpa-onnx " in line
+    assert line.endswith("diarization extra: not installed)")
+
+
+def test_version_flag_describes_the_real_environment(capsys: pytest.CaptureFixture[str]) -> None:
+    """Whatever this environment has (CI runs the suite with and without the
+    extras), the line names each extra exactly once, in one of its two forms."""
+    with pytest.raises(SystemExit):
+        cli.main(["--version"])
+    out = capsys.readouterr().out
+    assert re.fullmatch(
+        r"talkthrough-mcp \S+ \(python 3\.\d+\.\d+; "
+        r"url extra: (yt-dlp \S+|not installed \(direct https:// media links only\)); "
+        r"diarization extra: (sherpa-onnx \S+|not installed)\)\n",
+        out,
+    ), out
 
 
 def test_json_flag_turns_a_failure_into_an_error_document(

--- a/tests/unit/test_url_download.py
+++ b/tests/unit/test_url_download.py
@@ -4,6 +4,8 @@ contract — a canary token in the URL never reaches an error or a file."""
 
 from __future__ import annotations
 
+import io
+import logging
 import sys
 import types
 from collections.abc import Callable
@@ -181,6 +183,51 @@ def test_direct_download_follows_and_revalidates_redirects(
     assert downloaded.downloaded_bytes == len(MEDIA)
     assert resolved == ["cdn.example.com", "cdn.example.com", "media.example.net"]
     assert handler_requests == []  # the relay transport replaced the first handler
+
+
+def test_direct_download_keeps_the_url_out_of_every_log_line(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, pinned: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """httpx logs each request line at INFO with the full URL; 0.4.0 let the
+    query of the input URL and the signed redirect target through to stderr.
+    The CLI's logging setup holds those loggers at WARNING and, should anyone
+    raise them again, redacts what still reaches the handler."""
+    from talkthrough_mcp import cli
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/clip.mp4":
+            return httpx.Response(
+                302,
+                headers={
+                    "location": "https://cdn.example.net/signed/clip.mp4?Signature=CDN-SECRET-9999"
+                },
+            )
+        return _media(MEDIA, **{"content-type": "video/mp4"})
+
+    _serve(monkeypatch, handler)
+    source = classify_url(f"https://cdn.example.com/clip.mp4?{CANARY}")
+    httpx_logger = logging.getLogger("httpx")
+    previous_level = httpx_logger.level
+    stream = io.StringIO()
+    privacy = cli._privacy_handler(stream)
+    httpx_logger.addHandler(privacy)
+    try:
+        cli._configure_logging()
+        with caplog.at_level(logging.INFO):
+            download_direct(source, tmp_path, max_bytes=10_000, report=lambda *a: None)
+        assert "HTTP Request" not in caplog.text and stream.getvalue() == ""
+        assert CANARY not in caplog.text and "CDN-SECRET" not in caplog.text
+
+        httpx_logger.setLevel(logging.INFO)  # a chatty httpx still yields redacted lines only
+        download_direct(source, tmp_path, max_bytes=10_000, report=lambda *a: None)
+    finally:
+        httpx_logger.removeHandler(privacy)
+        httpx_logger.setLevel(previous_level)
+    text = stream.getvalue()
+    assert 'HTTP Request: GET <url> "HTTP/1.1 302 Found"' in text
+    assert 'HTTP Request: GET <url> "HTTP/1.1 200 OK"' in text
+    assert CANARY not in text and "CDN-SECRET" not in text and "203.0.113.10" not in text
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_url_download.py
+++ b/tests/unit/test_url_download.py
@@ -947,3 +947,33 @@ def test_provider_ids_are_bounded_and_filename_safe() -> None:
     assert "/" not in weird and " " not in weird and len(weird) <= 60
     assert safe_provider("Vimeo") == "vimeo" and safe_provider("Generic") == "generic"
     assert safe_provider(None) == "site"
+
+
+def test_extractor_stack_crashes_are_explained_and_redacted(
+    fake_yt_dlp: type[_FakeYoutubeDL], tmp_path: Path
+) -> None:
+    """yt-dlp's TED extractor raised a bare TypeError on a changed page (release
+    QA, F-05): the user gets the exception name, its first line, and what to do."""
+    from talkthrough_mcp.core.url_download import download_site
+
+    fake_yt_dlp.fail_with = TypeError(
+        "the JSON object must be str, bytes or bytearray, not NoneType"
+    )
+    with pytest.raises(DownloadError) as info:
+        download_site(
+            classify_url("https://www.ted.com/talks/candace_parker?tok=SECRET-TOKEN-4242"),
+            tmp_path, max_bytes=100_000, max_seconds=7200, report=lambda *a: None,
+        )
+    message = str(info.value)
+    assert message.startswith("the page reader failed on https://www.ted.com/…")
+    assert "TypeError: the JSON object must be str" in message
+    assert "SECRET-TOKEN" not in message and "candace" not in message
+    assert "refresh the tool environment" in message and "direct link" in message
+    assert list(tmp_path.iterdir()) == []
+
+    fake_yt_dlp.fail_with = TypeError("'NoneType' object is not subscriptable")
+    with pytest.raises(DownloadError, match="page reader failed on YouTube video nHfGfEiVdE8"):
+        download_youtube(
+            classify_url("https://youtu.be/nHfGfEiVdE8"), tmp_path, max_bytes=100_000,
+            max_seconds=7200, report=lambda *a: None,
+        )

--- a/tests/unit/test_url_download.py
+++ b/tests/unit/test_url_download.py
@@ -407,7 +407,14 @@ class _FakeYoutubeDL:
     def extract_info(self, url: str, download: bool = False) -> dict[str, Any]:
         if self.fail_with is not None:
             raise self.fail_with
-        return dict(self.info)
+        info = dict(self.info)
+        # Faithful to yt-dlp: playlist_items is applied while the playlist is
+        # processed, so only the requested entries survive, and the full count
+        # is not reported unless the extractor's entry list was exhausted.
+        wanted = self.options.get("playlist_items")
+        if wanted and info.get("_type") in {"playlist", "multi_video"}:
+            info["entries"] = list(info.get("entries") or [])[: int(wanted)]
+        return info
 
     def process_ie_result(self, info: dict[str, Any], download: bool = True) -> None:
         template = self.options["outtmpl"]["default"]
@@ -639,6 +646,21 @@ def test_youtube_options_never_include_user_configuration() -> None:
     assert options["format"] == url_download.YOUTUBE_FORMAT
 
 
+def test_probe_options_see_every_entry_of_a_multi_video_page() -> None:
+    """The page probe must count a carousel's entries, so it asks yt-dlp for a
+    flat entry list and never for playlist item 1 only (0.4.1)."""
+    probe = youtube_options(
+        Path("/tmp/x"), video_id="probe", max_bytes=10, progress_hook=lambda s: None,
+        secrets=(), output_stem="site-probe", probe=True,
+    )
+    assert probe["extract_flat"] == "in_playlist" and "playlist_items" not in probe
+    assert probe["noplaylist"] is True
+    download = youtube_options(
+        Path("/tmp/x"), video_id="abc", max_bytes=10, progress_hook=lambda s: None, secrets=()
+    )
+    assert download["playlist_items"] == "1" and "extract_flat" not in download
+
+
 def test_downloaded_record_is_plain_data() -> None:
     record = Downloaded(path=Path("/x"), extension=".mp4", downloaded_bytes=1, downloader="t")
     assert record.validators == {} and record.title is None
@@ -847,6 +869,31 @@ def test_site_download_resolves_a_single_entry_page_and_refuses_many(
             classify_url("https://www.instagram.com/p/carousel/"), tmp_path,
             max_bytes=100_000, max_seconds=7200, report=lambda *a: None,
         )
+
+
+def test_site_download_refuses_a_folder_page_before_any_download(
+    fake_yt_dlp: type[_FakeYoutubeDL], tmp_path: Path
+) -> None:
+    """A Loom folder or an Instagram carousel: 0.4.0's probe asked yt-dlp for
+    playlist item 1 only, so the count it checked was always 1 and the first
+    video was ingested silently (release QA, F-02)."""
+    from talkthrough_mcp.core.url_download import download_site
+
+    fake_yt_dlp.info = {
+        "_type": "playlist",
+        "id": "997db4db046f43e5912f10dc5f817b5c",
+        "extractor_key": "LoomFolder",
+        "entries": [{"_type": "url", "url": stub} for stub in ("a", "b", "c")],
+    }
+    with pytest.raises(UnsupportedUrlError, match="contains 3 videos") as info:
+        download_site(
+            classify_url("https://www.loom.com/share/folder/997db4db046f43e5912f10dc5f817b5c"),
+            tmp_path, max_bytes=100_000, max_seconds=7200, report=lambda *a: None,
+        )
+    assert "pass a link to one video" in str(info.value)
+    (probe,) = fake_yt_dlp.instances  # no download instance was ever built
+    assert probe.options["extract_flat"] == "in_playlist"
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_site_download_reuses_a_known_job_before_downloading(

--- a/tests/unit/test_url_download.py
+++ b/tests/unit/test_url_download.py
@@ -413,7 +413,8 @@ class _FakeYoutubeDL:
         # is not reported unless the extractor's entry list was exhausted.
         wanted = self.options.get("playlist_items")
         if wanted and info.get("_type") in {"playlist", "multi_video"}:
-            info["entries"] = list(info.get("entries") or [])[: int(wanted)]
+            last_item = str(wanted).split(":")[-1]
+            info["entries"] = list(info.get("entries") or [])[: int(last_item)]
         return info
 
     def process_ie_result(self, info: dict[str, Any], download: bool = True) -> None:
@@ -646,14 +647,15 @@ def test_youtube_options_never_include_user_configuration() -> None:
     assert options["format"] == url_download.YOUTUBE_FORMAT
 
 
-def test_probe_options_see_every_entry_of_a_multi_video_page() -> None:
-    """The page probe must count a carousel's entries, so it asks yt-dlp for a
-    flat entry list and never for playlist item 1 only (0.4.1)."""
+def test_probe_options_stop_after_detecting_a_second_video() -> None:
+    """The page probe needs two flat stubs to distinguish one video from many
+    without walking an entire channel or playlist (0.4.1)."""
     probe = youtube_options(
         Path("/tmp/x"), video_id="probe", max_bytes=10, progress_hook=lambda s: None,
         secrets=(), output_stem="site-probe", probe=True,
     )
-    assert probe["extract_flat"] == "in_playlist" and "playlist_items" not in probe
+    assert probe["extract_flat"] == "in_playlist"
+    assert probe["playlist_items"] == "1:2"
     assert probe["noplaylist"] is True
     download = youtube_options(
         Path("/tmp/x"), video_id="abc", max_bytes=10, progress_hook=lambda s: None, secrets=()
@@ -864,7 +866,7 @@ def test_site_download_resolves_a_single_entry_page_and_refuses_many(
     assert downloaded.path.name == "instagram-C_abc-123.mp4"
 
     fake_yt_dlp.info = {"_type": "playlist", "entries": [{"url": "a"}, {"url": "b"}]}
-    with pytest.raises(UnsupportedUrlError, match="contains 2 videos"):
+    with pytest.raises(UnsupportedUrlError, match="contains more than one video"):
         download_site(
             classify_url("https://www.instagram.com/p/carousel/"), tmp_path,
             max_bytes=100_000, max_seconds=7200, report=lambda *a: None,
@@ -885,7 +887,7 @@ def test_site_download_refuses_a_folder_page_before_any_download(
         "extractor_key": "LoomFolder",
         "entries": [{"_type": "url", "url": stub} for stub in ("a", "b", "c")],
     }
-    with pytest.raises(UnsupportedUrlError, match="contains 3 videos") as info:
+    with pytest.raises(UnsupportedUrlError, match="contains more than one video") as info:
         download_site(
             classify_url("https://www.loom.com/share/folder/997db4db046f43e5912f10dc5f817b5c"),
             tmp_path, max_bytes=100_000, max_seconds=7200, report=lambda *a: None,
@@ -893,6 +895,7 @@ def test_site_download_refuses_a_folder_page_before_any_download(
     assert "pass a link to one video" in str(info.value)
     (probe,) = fake_yt_dlp.instances  # no download instance was ever built
     assert probe.options["extract_flat"] == "in_playlist"
+    assert probe.options["playlist_items"] == "1:2"
     assert list(tmp_path.iterdir()) == []
 
 

--- a/tests/unit/test_url_ingest.py
+++ b/tests/unit/test_url_ingest.py
@@ -291,6 +291,17 @@ def test_url_lock_serializes_same_key_and_is_reentrant_across_keys(isolated_home
         assert url_ingest.mapping_path("youtube:a").with_suffix(".lock").exists()
 
 
+def test_url_lock_registry_does_not_retain_finished_keys(isolated_home: Path) -> None:
+    import gc
+
+    keys = {f"site:example:{index}" for index in range(25)}
+    for key in keys:
+        with url_ingest.url_lock(key):
+            assert key in url_ingest._URL_LOCKS
+    gc.collect()
+    assert keys.isdisjoint(url_ingest._URL_LOCKS)
+
+
 # --- managed source ---------------------------------------------------------------
 
 

--- a/tests/unit/test_url_process.py
+++ b/tests/unit/test_url_process.py
@@ -202,6 +202,23 @@ def test_process_url_failure_leaves_no_job_no_mapping_no_staging(
     assert not any(url_ingest.downloads_root().iterdir())
 
 
+def test_pipeline_failure_after_download_leaves_no_job_mapping_or_staging(
+    stubbed: dict[str, Any], isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from talkthrough_mcp.core.errors import ToolFailureError
+
+    def fail_after_install(path: Path) -> MediaInfo:
+        raise ToolFailureError(f"pipeline failed for {Path(path).name}")
+
+    monkeypatch.setattr(pipeline, "probe_media", fail_after_install)
+    source = url_ingest.classify_url(URL)
+    with pytest.raises(ToolFailureError, match="pipeline failed"):
+        process_url(URL)
+    assert not jobs.jobs_root().exists() or not any(jobs.jobs_root().iterdir())
+    assert not url_ingest.mapping_path(source.mapping_key).exists()
+    assert not any(url_ingest.downloads_root().iterdir())
+
+
 def test_process_url_rejects_a_non_media_download_before_the_job_store(
     stubbed: dict[str, Any], isolated_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_url_process.py
+++ b/tests/unit/test_url_process.py
@@ -641,3 +641,45 @@ def test_refresh_bypasses_the_provider_index_and_downloads_again(
     assert again.reused_url_mapping is False
     assert again.result.manifest.job_id == first.result.manifest.job_id
     assert again.downloaded_bytes == len(stubbed["media"])
+
+
+def test_refresh_replaces_stale_provider_metadata_when_the_bytes_are_unchanged(
+    stubbed: dict[str, Any], isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A provider can retitle or redate a video while the media bytes stay the
+    same: the job is the same content hash, but refresh=true asked for the
+    provider's current metadata (0.4.0 kept the stale block; release QA, F-03)."""
+    from dataclasses import replace
+
+    from talkthrough_mcp.core.manifest import save_manifest
+
+    def not_media(source: Any, dest_dir: Path, *, max_bytes: int, report: Any) -> Downloaded:
+        raise url_download.NotMediaResponse("text/html")
+
+    monkeypatch.setattr(url_download, "download_direct", not_media)
+    monkeypatch.setattr(url_download, "download_site", _site_download(stubbed))
+    page = "https://videos.example.org/watch/987654321"
+    first = process_url(page)
+    job_id = first.result.manifest.job_id
+    manifest = jobs.load_job(job_id)
+    assert manifest.media.origin is not None and manifest.media.origin.title == "Sintel"
+    stale = replace(
+        manifest.media.origin,
+        title="STALE_TITLE_CANARY",
+        downloaded_at="2020-01-01T00:00:00+00:00",
+    )
+    manifest.media = replace(manifest.media, origin=stale)
+    save_manifest(manifest, jobs.job_dir(job_id))
+
+    served = process_url(page)  # no refresh: the stored job, no network, no change
+    assert served.reused_url_mapping is True and stubbed["site"] == 1
+    assert served.origin is not None and served.origin.title == "STALE_TITLE_CANARY"
+
+    refreshed = process_url(page, refresh=True)
+    assert stubbed["site"] == 2 and refreshed.refreshed is True
+    assert refreshed.result.manifest.job_id == job_id and refreshed.result.reused is True
+    origin = jobs.load_job(job_id).media.origin
+    assert origin is not None and origin.title == "Sintel"
+    assert origin.downloaded_at is not None and origin.downloaded_at > "2020-01-01T00:00:00+00:00"
+    assert refreshed.origin == origin
+    assert jobs.load_job(job_id).media.managed_source == first.result.manifest.media.managed_source

--- a/tests/unit/test_url_process.py
+++ b/tests/unit/test_url_process.py
@@ -266,8 +266,10 @@ def test_gc_removes_the_managed_source_with_the_job_and_its_url_mapping(
     job_id = ingested.result.manifest.job_id
     jobs.delete_job(job_id)
     result = jobs.gc(keep_days=30)
-    assert result.swept == [f"urls/{url_ingest.mapping_path(ingested.source.mapping_key).name}"]
+    mapping = url_ingest.mapping_path(ingested.source.mapping_key)
+    assert result.swept == [f"urls/{mapping.name}", f"urls/{mapping.with_suffix('.lock').name}"]
     assert not (jobs.job_dir(job_id) / "source").exists()
+    assert not any(url_ingest.urls_root().iterdir())
 
 
 def test_forced_rebuild_of_a_url_job_keeps_its_origin(
@@ -683,3 +685,65 @@ def test_refresh_replaces_stale_provider_metadata_when_the_bytes_are_unchanged(
     assert origin.downloaded_at is not None and origin.downloaded_at > "2020-01-01T00:00:00+00:00"
     assert refreshed.origin == origin
     assert jobs.load_job(job_id).media.managed_source == first.result.manifest.media.managed_source
+
+
+# --- URL lock files (0.4.1: gc left one empty .lock per URL forever) ---------------
+
+
+def test_gc_sweeps_orphan_url_locks_but_keeps_live_and_held_ones(
+    stubbed: dict[str, Any], isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ingested = process_url(URL)  # live: a mapping and its lock
+    live_lock = url_ingest.mapping_path(ingested.source.mapping_key).with_suffix(".lock")
+    assert live_lock.exists()
+
+    def failing(source: Any, dest_dir: Path, *, max_bytes: int, report: Any) -> Downloaded:
+        raise DownloadError("HTTP 403 for https://cdn.example.com/…")
+
+    monkeypatch.setattr(url_download, "download_direct", failing)
+    refused = "https://cdn.example.com/other.mp4"
+    with pytest.raises(DownloadError):
+        process_url(refused)
+    orphan_lock = url_ingest.mapping_path(
+        url_ingest.classify_url(refused).mapping_key
+    ).with_suffix(".lock")
+    assert orphan_lock.exists() and not orphan_lock.with_suffix(".json").exists()
+
+    held_key = "site:example:held"
+    held_lock = url_ingest.mapping_path(held_key).with_suffix(".lock")
+    with url_ingest.url_lock(held_key):
+        result = jobs.gc(keep_days=30)
+        assert result.swept == [f"urls/{orphan_lock.name}"]
+        assert not orphan_lock.exists() and live_lock.exists() and held_lock.exists()
+    # released and without a mapping: the next pass takes it
+    assert jobs.gc(keep_days=30).swept == [f"urls/{held_lock.name}"]
+    assert not held_lock.exists() and live_lock.exists()
+
+
+def test_url_lock_reopens_when_a_sweep_removed_the_file_under_it(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A gc pass can unlink an orphan lock between a waiter's open() and its
+    flock(); a lock on the unlinked inode would guard nothing, so url_lock
+    checks the path still names the file it holds and reopens otherwise."""
+    import fcntl
+
+    key = "site:example:raced"
+    lock_path = url_ingest.mapping_path(key).with_suffix(".lock")
+    real_flock = fcntl.flock
+    calls: list[int] = []
+
+    def racing_flock(fd: int, operation: int) -> None:
+        calls.append(fd)
+        if len(calls) == 1:
+            lock_path.unlink()  # the sweep, between our open() and flock()
+        real_flock(fd, operation)
+
+    monkeypatch.setattr(fcntl, "flock", racing_flock)
+    with url_ingest.url_lock(key):
+        assert lock_path.exists()
+        with lock_path.open("a") as other, pytest.raises(BlockingIOError):
+            real_flock(other.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)  # the CURRENT file is held
+    assert len(calls) == 2
+    with lock_path.open("a") as other:
+        real_flock(other.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)  # released on exit

--- a/tests/unit/test_url_process.py
+++ b/tests/unit/test_url_process.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -690,7 +691,7 @@ def test_refresh_replaces_stale_provider_metadata_when_the_bytes_are_unchanged(
 # --- URL lock files (0.4.1: gc left one empty .lock per URL forever) ---------------
 
 
-def test_gc_sweeps_orphan_url_locks_but_keeps_live_and_held_ones(
+def test_gc_sweeps_orphan_url_locks_but_keeps_live_ones(
     stubbed: dict[str, Any], isolated_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     ingested = process_url(URL)  # live: a mapping and its lock
@@ -709,15 +710,36 @@ def test_gc_sweeps_orphan_url_locks_but_keeps_live_and_held_ones(
     ).with_suffix(".lock")
     assert orphan_lock.exists() and not orphan_lock.with_suffix(".json").exists()
 
+    result = jobs.gc(keep_days=30)
+    assert result.swept == [f"urls/{orphan_lock.name}"]
+    assert not orphan_lock.exists() and live_lock.exists()
+    assert jobs.gc(keep_days=30).swept == []  # nothing orphaned any more
+
+
+def test_gc_leaves_a_url_lock_that_another_caller_holds(isolated_home: Path) -> None:
+    pytest.importorskip("fcntl")
     held_key = "site:example:held"
     held_lock = url_ingest.mapping_path(held_key).with_suffix(".lock")
     with url_ingest.url_lock(held_key):
-        result = jobs.gc(keep_days=30)
-        assert result.swept == [f"urls/{orphan_lock.name}"]
-        assert not orphan_lock.exists() and live_lock.exists() and held_lock.exists()
+        assert jobs.gc(keep_days=30).swept == []
+        assert held_lock.exists()
     # released and without a mapping: the next pass takes it
     assert jobs.gc(keep_days=30).swept == [f"urls/{held_lock.name}"]
-    assert not held_lock.exists() and live_lock.exists()
+    assert not held_lock.exists()
+
+
+def test_gc_sweeps_orphan_lock_markers_without_fcntl(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Windows keeps lock files as markers (no flock); gc removes an orphan
+    marker after closing it, since an open file cannot be unlinked there."""
+    monkeypatch.setitem(sys.modules, "fcntl", None)
+    key = "site:example:marker"
+    marker = url_ingest.mapping_path(key).with_suffix(".lock")
+    with url_ingest.url_lock(key):
+        assert marker.exists()
+    assert jobs.gc(keep_days=30).swept == [f"urls/{marker.name}"]
+    assert not marker.exists()
 
 
 def test_url_lock_reopens_when_a_sweep_removed_the_file_under_it(
@@ -726,7 +748,7 @@ def test_url_lock_reopens_when_a_sweep_removed_the_file_under_it(
     """A gc pass can unlink an orphan lock between a waiter's open() and its
     flock(); a lock on the unlinked inode would guard nothing, so url_lock
     checks the path still names the file it holds and reopens otherwise."""
-    import fcntl
+    fcntl = pytest.importorskip("fcntl")
 
     key = "site:example:raced"
     lock_path = url_ingest.mapping_path(key).with_suffix(".lock")

--- a/uv.lock
+++ b/uv.lock
@@ -1778,7 +1778,7 @@ wheels = [
 
 [[package]]
 name = "talkthrough-mcp"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "faster-whisper" },


### PR DESCRIPTION
Release branch for v0.4.1: the findings of a negative release QA against the *published* 0.4.0 (the PyPI wheel, the GitHub tag, a corpus of 40+ live URLs), all reproduced first. Merge plan: rebase-merge as the 8 conventional commits. **Not to be merged before the owner's go** — the plugin pin moves to `==0.4.1`, so `main` must not carry it until the tag and the PyPI release follow right away.

## What lands

1. **A request URL no longer reaches a log line (F-01).** httpx logs every request line at INFO with the full URL, one line per hop, redirect targets included, and the CLI enabled INFO on the root logger before dispatching any command — `serve` too. A direct link's query and a CDN's signed redirect target therefore landed in stderr, which MCP clients keep as log files. The CLI now holds httpx/httpcore at WARNING and installs a filter that passes every foreign log record and every traceback through `url_ingest.redact`; own records keep their safe labels. Reproduced offline with `httpx.MockTransport` before the change, gone after.
2. **A multi-video page is refused, not silently truncated (F-02).** The page probe asked yt-dlp for playlist item 1 only, so the count it checked was always 1: a Loom folder or an Instagram carousel was ingested as its first video. The probe now reads a flat entry list (`extract_flat="in_playlist"`, no `playlist_items`), counts, and refuses before a download instance exists. The yt-dlp stub in the unit tests now slices the way yt-dlp does, so the pre-existing carousel test fails on the old probe.
3. **`refresh=true` replaces the stored provider metadata (F-03).** Same bytes → same job, but the block (title, `published_at`, `downloaded_at`) is replaced under the job lock; ordinary convergence stays additive.
4. **`gc` sweeps orphan URL lock files (F-07)**, only while holding the flock; `url_lock` re-checks the inode after acquiring and reopens if a sweep removed the file under it.
5. **`talkthrough-mcp --version` (F-08, F-06)** — version, Python, and the state of the extras (`url extra: yt-dlp <v>` / `not installed (direct https:// media links only)`, `diarization extra: sherpa-onnx <v>`); the server logs the same line at every start. **`--json` on failure (F-04)** leaves one JSON document on stdout, `{"error": {"type", "message"}}`, exit code 2 and the stderr line unchanged. CI runs `--version` in the matrix and on the clean-installed wheel, and checks the `--json` refusal document.
6. **Page-reader crashes say what to do (F-05)** — `the page reader failed on https://host/… (TypeError: …) — the site may have changed its page layout: refresh the tool environment so yt-dlp updates, or pass a direct link to the media file` (yt-dlp's TED extractor on the current page), on both the YouTube and the page path.
7. **Docs** — README "Upgrading from 0.3.x", the memory envelope of a cold run, `docs/URL_ACCEPTANCE_CORPUS.md` (the live corpus as a manual regression checklist, 0.4.1 regressions first; CI stays offline), TROUBLESHOOTING pointing at `--version`, DESIGN's log-privacy sentence.
8. **Release preparation** — version 0.4.1, lock, generated manifests and the plugin pin, CHANGELOG `[0.4.1] — 2026-09-05` (adjust the date if the tag lands on another day). No wire-contract change: 9 tools, 6 prompts.

## Verification (final SHA ed99d28)

- Local gate: ruff, mypy strict, **767 unit / 44 integration / 2 e2e**, generator drift, `extract_release_notes --version 0.4.1`.
- Every code fix proven red first: the new tests fail with the fix reverted (probe options, `replace_origin`, the inode re-check); F-01 reproduced offline before the change (query and signed redirect target in stderr) and absent after.
- Clean install of the built wheel with `[diarization,url]` into a fresh venv: `--version` names both extras, inventory 9 tools / 6 prompts, playlist refusal plain and as a `--json` document.
- Live corpus (the "0.4.1 regressions" table in `docs/URL_ACCEPTANCE_CORPUS.md`): MDN direct URL with a canary query → 0 canary / `HTTP Request` lines in stderr; Loom folder → `the page contains 16 videos — pass a link to one video` before any download; TED → the new wording; `gc` swept the 3 orphan locks and kept the live one; the official YouTube demo (job `b076c4f20314488c`) → a planted stale title survives a plain call and `--refresh` brings the provider's title and a fresh `downloaded_at` back on the same job.
- Not run: the paid agent battery — no tool or guidance change, the wire contract is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkEBvSNsg6oeUYNQAFCdTS
